### PR TITLE
fix for unidirectional relations

### DIFF
--- a/adm_program/system/classes/tableuserrelationtype.php
+++ b/adm_program/system/classes/tableuserrelationtype.php
@@ -33,7 +33,7 @@ class TableUserRelationType extends TableAccess
     {
         if (!$this->isNewRecord())
         {
-            if ($this->getValue('urt_id_inverse') === null)
+            if (empty($this->getValue('urt_id_inverse')))
             {
                 return 'unidirectional';
             }


### PR DESCRIPTION
This commit was a bit too restrictive: dfe5d55592d9210c5fa06e7d6bd89d5812803b49
BTW: There doesn't seem to be a way in the `tableaccess` class to get null values.