### PR TITLE
use constants for database config params

### DIFF
--- a/adm_plugins/calendar/calendar.php
+++ b/adm_plugins/calendar/calendar.php
@@ -281,7 +281,7 @@ if($plg_ter_aktiv)
 // query of all birthdays
 if($plg_geb_aktiv)
 {
-    if($gDbType === Database::PDO_ENGINE_PGSQL || $gDbType === 'postgresql') // for backwards compatibility "postgresql"
+    if(DB_ENGINE === Database::PDO_ENGINE_PGSQL || DB_ENGINE === 'postgresql') // for backwards compatibility "postgresql"
     {
         $sqlMonthOfBirthday = ' date_part(\'month\', timestamp birthday.usd_value) ';
         $sqlDayOfBirthday   = ' date_part(\'day\', timestamp birthday.usd_value) ';

--- a/adm_program/installation/db_scripts/upd_2_4_0_conv.php
+++ b/adm_program/installation/db_scripts/upd_2_4_0_conv.php
@@ -11,7 +11,7 @@
 require_once(ADMIDIO_PATH . FOLDER_CLASSES . '/tableusers.php');
 
 // drop foreign keys to delete index
-if($gDbType === Database::PDO_ENGINE_MYSQL)
+if(DB_ENGINE === Database::PDO_ENGINE_MYSQL)
 {
     $sql = 'ALTER TABLE '.TBL_USERS.' DROP FOREIGN KEY '.TABLE_PREFIX.'_FK_USR_ORG_REG';
     $gDb->query($sql, false);

--- a/adm_program/installation/db_scripts/upd_2_4_2_conv.php
+++ b/adm_program/installation/db_scripts/upd_2_4_2_conv.php
@@ -10,7 +10,7 @@
  */
 
 // alter ip columns for IPv6
-if($gDbType === Database::PDO_ENGINE_MYSQL)
+if(DB_ENGINE === Database::PDO_ENGINE_MYSQL)
 {
     $sql = 'ALTER TABLE '.TBL_AUTO_LOGIN.' MODIFY COLUMN atl_ip_address varchar(39) NOT NULL';
     $gDb->query($sql, false);

--- a/adm_program/installation/install_functions.php
+++ b/adm_program/installation/install_functions.php
@@ -136,9 +136,7 @@ function querySqlFile(Database $db, $sqlFileName)
  */
 function disableSoundexSearchIfPgSql(Database $db)
 {
-    global $gDbType;
-
-    if ($gDbType === Database::PDO_ENGINE_PGSQL || $gDbType === 'postgresql') // for backwards compatibility "postgresql"
+    if (DB_ENGINE === Database::PDO_ENGINE_PGSQL || DB_ENGINE === 'postgresql') // for backwards compatibility "postgresql"
     {
         // soundex is not a default function in PostgreSQL
         $sql = 'UPDATE ' . TBL_PREFERENCES . '

--- a/adm_program/installation/install_steps/start_installation.php
+++ b/adm_program/installation/install_steps/start_installation.php
@@ -33,12 +33,12 @@ if (!is_file($pathConfigFile))
 // if previous dialogs were filled then check if the settings are equal to config file
 if (isset($_SESSION['prefix'])
 &&    (TABLE_PREFIX    !== $_SESSION['prefix']
-    || $gDbType        !== $_SESSION['db_type']
-    || $g_adm_srv      !== $_SESSION['db_host']
-    || $g_adm_port     !== $_SESSION['db_port']
-    || $g_adm_db       !== $_SESSION['db_database']
-    || $g_adm_usr      !== $_SESSION['db_user']
-    || $g_adm_pw       !== $_SESSION['db_password']
+    || DB_ENGINE       !== $_SESSION['db_type']
+    || DB_HOST         !== $_SESSION['db_host']
+    || DB_PORT         !== $_SESSION['db_port']
+    || DB_NAME         !== $_SESSION['db_database']
+    || DB_USERNAME     !== $_SESSION['db_user']
+    || DB_PASSWORD     !== $_SESSION['db_password']
     || $g_organization !== $_SESSION['orga_shortname']))
 {
     showNotice(

--- a/adm_program/installation/installation.php
+++ b/adm_program/installation/installation.php
@@ -148,12 +148,12 @@ if (is_file($pathConfigFile))
     if ($step === 'welcome')
     {
         // save database parameters of config.php in session variables
-        $_SESSION['db_type']     = $gDbType;
-        $_SESSION['db_host']     = $g_adm_srv;
-        $_SESSION['db_port']     = $g_adm_port;
-        $_SESSION['db_database'] = $g_adm_db;
-        $_SESSION['db_user']     = $g_adm_usr;
-        $_SESSION['db_password'] = $g_adm_pw;
+        $_SESSION['db_type']     = DB_ENGINE;
+        $_SESSION['db_host']     = DB_HOST;
+        $_SESSION['db_port']     = DB_PORT;
+        $_SESSION['db_database'] = DB_NAME;
+        $_SESSION['db_user']     = DB_USERNAME;
+        $_SESSION['db_password'] = DB_PASSWORD;
         $_SESSION['prefix']      = TABLE_PREFIX;
 
         admRedirect(safeUrl(ADMIDIO_URL . '/adm_program/installation/installation.php', array('step' => 'create_organization')));

--- a/adm_program/installation/update_functions.php
+++ b/adm_program/installation/update_functions.php
@@ -97,9 +97,9 @@ function updateOrgPreferences()
  */
 function toggleForeignKeyChecks($enable)
 {
-    global $gDbType, $gDb;
+    global $gDb;
 
-    if ($gDbType === Database::PDO_ENGINE_MYSQL)
+    if (DB_ENGINE === Database::PDO_ENGINE_MYSQL)
     {
         // disable foreign key checks for mysql, so tables can easily deleted
         $sql = 'SET foreign_key_checks = ' . (int) $enable;
@@ -114,7 +114,7 @@ function toggleForeignKeyChecks($enable)
  */
 function doVersion2Update(&$versionMain, &$versionMinor, &$versionPatch)
 {
-    global $gLogger, $gDb, $gL10n, $gSettingsManager, $gDbType;
+    global $gLogger, $gDb, $gL10n, $gSettingsManager;
 
     // nun in einer Schleife alle Update-Scripte fuer Version 2 einspielen
     while ($versionMain === 2)

--- a/adm_program/modules/backup/backup.php
+++ b/adm_program/modules/backup/backup.php
@@ -35,7 +35,7 @@ if(!$gCurrentUser->isAdministrator())
 }
 
 // module not available for other databases except MySQL
-if($gDbType !== Database::PDO_ENGINE_MYSQL)
+if(DB_ENGINE !== Database::PDO_ENGINE_MYSQL)
 {
     $gMessage->show($gL10n->get('BAC_ONLY_MYSQL'));
     // => EXIT

--- a/adm_program/modules/backup/backup_script.php
+++ b/adm_program/modules/backup/backup_script.php
@@ -27,7 +27,7 @@ if(!$gCurrentUser->isAdministrator())
 }
 
 // module not available for other databases except MySQL
-if($gDbType !== Database::PDO_ENGINE_MYSQL)
+if(DB_ENGINE !== Database::PDO_ENGINE_MYSQL)
 {
     $gMessage->show($gL10n->get('BAC_ONLY_MYSQL'));
     // => EXIT
@@ -83,14 +83,14 @@ $sql = 'SELECT table_name
           FROM information_schema.tables
          WHERE table_schema = ?
            AND table_name LIKE ?';
-$statement = $gDb->queryPrepared($sql, array($g_adm_db, TABLE_PREFIX . '_%'));
+$statement = $gDb->queryPrepared($sql, array(DB_NAME, TABLE_PREFIX . '_%'));
 $tables = array();
 while($tableName = $statement->fetchColumn())
 {
     $tables[] = $tableName;
 }
 
-$SelectedTables[$g_adm_db] = $tables;
+$SelectedTables[DB_NAME] = $tables;
 
 $starttime = getmicrotime();
 
@@ -118,7 +118,7 @@ if ((OUTPUT_COMPRESSION_TYPE === 'gzip'  && ($zp = @gzopen($backupabsolutepath.$
 
     $fileheaderline  = '-- Admidio v'.ADMIDIO_VERSION_TEXT.' (https://www.admidio.org)'.LINE_TERMINATOR;
     $fileheaderline .= '-- '.$gL10n->get('BAC_BACKUP_FROM', array(date('d.m.Y'), date('G:i:s'))).LINE_TERMINATOR.LINE_TERMINATOR;
-    $fileheaderline .= '-- '.$gL10n->get('SYS_DATABASE').': '.$g_adm_db.LINE_TERMINATOR.LINE_TERMINATOR;
+    $fileheaderline .= '-- '.$gL10n->get('SYS_DATABASE').': '.DB_NAME.LINE_TERMINATOR.LINE_TERMINATOR;
     $fileheaderline .= '-- '.$gL10n->get('SYS_USER').': '.$gCurrentUser->getValue('FIRST_NAME', 'database'). ' '. $gCurrentUser->getValue('LAST_NAME', 'database').LINE_TERMINATOR.LINE_TERMINATOR;
     $fileheaderline .= 'SET FOREIGN_KEY_CHECKS=0;'.LINE_TERMINATOR.LINE_TERMINATOR;
     if (OUTPUT_COMPRESSION_TYPE === 'bzip2')

--- a/adm_program/modules/dates/dates_new.php
+++ b/adm_program/modules/dates/dates_new.php
@@ -290,7 +290,7 @@ else
 // if room selection is activated then show a selectbox with all rooms
 if($gSettingsManager->getBool('dates_show_rooms'))
 {
-    if($gDbType === Database::PDO_ENGINE_MYSQL)
+    if(DB_ENGINE === Database::PDO_ENGINE_MYSQL)
     {
         $sql = 'SELECT room_id, CONCAT(room_name, \' (\', room_capacity, \'+\', IFNULL(room_overhang, \'0\'), \')\')
                   FROM '.TBL_ROOMS.'

--- a/adm_program/modules/lists/mylist.php
+++ b/adm_program/modules/lists/mylist.php
@@ -124,7 +124,7 @@ $page->enableModal();
 
 // within MySql it's only possible to join 61 tables therefore show a message if user
 // want's to join more than 57 columns
-if($gDbType === Database::PDO_ENGINE_MYSQL)
+if(DB_ENGINE === Database::PDO_ENGINE_MYSQL)
 {
     $mySqlMaxColumnAlert = '
     if (fieldNumberIntern >= 57) {

--- a/adm_program/modules/members/members_assign.php
+++ b/adm_program/modules/members/members_assign.php
@@ -37,7 +37,7 @@ $getLastname  = admFuncVariableIsValid($_POST, 'lastname',  'string', array('req
 $getFirstname = admFuncVariableIsValid($_POST, 'firstname', 'string', array('requireValue' => true));
 
 // search for users with similar names (SQL function SOUNDEX only available in MySQL)
-if($gSettingsManager->getBool('system_search_similar') && $gDbType === Database::PDO_ENGINE_MYSQL)
+if($gSettingsManager->getBool('system_search_similar') && DB_ENGINE === Database::PDO_ENGINE_MYSQL)
 {
     $sqlSimilarName = '
         (  (   SUBSTRING(SOUNDEX(last_name.usd_value),  1, 4) = SUBSTRING(SOUNDEX(?), 1, 4)     -- $gDb->escapeString($getLastname)

--- a/adm_program/modules/registration/registration_assign.php
+++ b/adm_program/modules/registration/registration_assign.php
@@ -42,7 +42,7 @@ $lastName  = $gDb->escapeString($newUser->getValue('LAST_NAME', 'database'));
 $firstName = $gDb->escapeString($newUser->getValue('FIRST_NAME', 'database'));
 
 // search for users with similar names (SQL function SOUNDEX only available in MySQL)
-if($gDbType === Database::PDO_ENGINE_MYSQL && $gSettingsManager->getBool('system_search_similar'))
+if(DB_ENGINE === Database::PDO_ENGINE_MYSQL && $gSettingsManager->getBool('system_search_similar'))
 {
     $sqlSimilarName =
         '(  (   SUBSTRING(SOUNDEX(last_name.usd_value),  1, 4) = SUBSTRING(SOUNDEX('. $lastName.'), 1, 4)

--- a/adm_program/system/classes/ComponentUpdate.php
+++ b/adm_program/system/classes/ComponentUpdate.php
@@ -144,18 +144,18 @@ class ComponentUpdate extends Component
      * If the step was successfully done the id will be stored in the component recordset
      * so if the whole update crashs later we know that this step was successfully executed.
      * When the node has an attribute @b database than this sql statement will only executed
-     * if the value of the attribute is equal to your current @b $gDbType . If the node has
+     * if the value of the attribute is equal to your current @b DB_ENGINE . If the node has
      * an attribute @b error and this is set to @b ignore than an sql error will not stop
      * the update script.
      * @param \SimpleXMLElement $xmlNode A SimpleXML node of the current update step.
      */
     private function executeStep(\SimpleXMLElement $xmlNode)
     {
-        global $gDbType, $gLogger;
+        global $gLogger;
 
         // for backwards compatibility "postgresql"
-        $dbType = $gDbType;
-        if ($gDbType === 'postgresql')
+        $dbType = DB_ENGINE;
+        if (DB_ENGINE === 'postgresql')
         {
             $dbType = Database::PDO_ENGINE_PGSQL;
         }

--- a/adm_program/system/classes/Database.php
+++ b/adm_program/system/classes/Database.php
@@ -23,7 +23,7 @@
  * // create object and open connection to database
  * try
  * {
- *     $gDb = new Database($gDbType, $g_adm_srv, $g_adm_port, $g_adm_db, $g_adm_usr, $g_adm_pw);
+ *     $gDb = new Database(DB_ENGINE, DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD);
  * }
  * catch (AdmException $e)
  * {
@@ -126,20 +126,20 @@ class Database
      */
     public static function createDatabaseInstance()
     {
-        global $gLogger, $gDbType, $g_adm_srv, $g_adm_port, $g_adm_db, $g_adm_usr, $g_adm_pw;
+        global $gLogger;
 
         if ($gLogger instanceof \Psr\Log\LoggerInterface) // fix for non-object error in PHP 5.3
         {
             $gLogger->debug(
                 'DATABASE: Create DB-Instance with default params!',
                 array(
-                    'engine' => $gDbType, 'host' => $g_adm_srv, 'port' => $g_adm_port,
-                    'name' => $g_adm_db, 'username' => $g_adm_usr, 'password' => $g_adm_pw
+                    'engine' => DB_ENGINE, 'host' => DB_HOST, 'port' => DB_PORT,
+                    'name' => DB_NAME, 'username' => DB_USERNAME, 'password' => DB_PASSWORD
                 )
             );
         }
 
-        return new Database($gDbType, $g_adm_srv, $g_adm_port, $g_adm_db, $g_adm_usr, $g_adm_pw);
+        return new Database(DB_ENGINE, DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD);
     }
 
     /**

--- a/adm_program/system/classes/ListConfiguration.php
+++ b/adm_program/system/classes/ListConfiguration.php
@@ -186,7 +186,7 @@ class ListConfiguration extends TableLists
      */
     public function getSQL(array $roleIds, $showFormerMembers = false, $startDate = null, $endDate = null, array $relationtypeIds = array())
     {
-        global $gL10n, $gProfileFields, $gCurrentOrganization, $gDbType;
+        global $gL10n, $gProfileFields, $gCurrentOrganization;
 
         $sqlColumnNames = array();
         $sqlOrderBys    = array();
@@ -229,7 +229,7 @@ class ListConfiguration extends TableLists
                 {
                     // if a field has numeric values then there must be a cast because database
                     // column is varchar. A varchar sort of 1,10,2 will be with cast 1,2,10
-                    if($gDbType === Database::PDO_ENGINE_PGSQL || $gDbType === 'postgresql') // for backwards compatibility "postgresql"
+                    if(DB_ENGINE === Database::PDO_ENGINE_PGSQL || DB_ENGINE === 'postgresql') // for backwards compatibility "postgresql"
                     {
                         $columnType = 'numeric';
                     }

--- a/adm_program/system/constants.php
+++ b/adm_program/system/constants.php
@@ -97,6 +97,17 @@ define('DATETIME_NOW', date('Y-m-d H:i:s'));
 define('DATE_MAX', '9999-12-31');
 
 // ###################
+// ###  DB-CONFIG  ###
+// ###################
+
+define('DB_ENGINE', $gDbType);
+define('DB_HOST', $g_adm_srv);
+define('DB_PORT', $g_adm_port);
+define('DB_NAME', $g_adm_db);
+define('DB_USERNAME', $g_adm_usr);
+define('DB_PASSWORD', $g_adm_pw);
+
+// ###################
 // ###  DB-TABLES  ###
 // ###################
 
@@ -144,7 +155,7 @@ define('TBL_USER_RELATION_TYPES', TABLE_PREFIX . '_user_relation_types');
 // create an installation unique cookie prefix and remove special characters
 if(isset($g_adm_db))
 {
-    $cookiePrefix = 'ADMIDIO_' . $g_organization . '_' . $g_adm_db . '_' . TABLE_PREFIX;
+    $cookiePrefix = 'ADMIDIO_' . $g_organization . '_' . DB_NAME . '_' . TABLE_PREFIX;
 }
 else
 {

--- a/demo_data/build.php
+++ b/demo_data/build.php
@@ -120,9 +120,9 @@ function prepareAdmidioDataFolder()
  */
 function toggleForeignKeyChecks($enable)
 {
-    global $gDbType, $gDb;
+    global $gDb;
 
-    if ($gDbType === Database::PDO_ENGINE_MYSQL)
+    if (DB_ENGINE === Database::PDO_ENGINE_MYSQL)
     {
         // disable foreign key checks for mysql, so tables can easily deleted
         $sql = 'SET foreign_key_checks = ' . (int) $enable;
@@ -258,9 +258,9 @@ function readAndExecuteSQLFromFile($filename)
 
 function resetPostgresSequences()
 {
-    global $gDb, $gDbType;
+    global $gDb;
 
-    if ($gDbType === Database::PDO_ENGINE_PGSQL || $gDbType === 'postgresql') // for backwards compatibility "postgresql"
+    if (DB_ENGINE === Database::PDO_ENGINE_PGSQL || DB_ENGINE === 'postgresql') // for backwards compatibility "postgresql"
     {
         $sql = 'SELECT relname
                   FROM pg_class


### PR DESCRIPTION
Add new Constants for DB config like the `TABLE_PREFIX` (https://github.com/Admidio/admidio/pull/716)
- `$gDbType` => `DB_ENGINE` or `DB_TYPE`
- `$g_adm_srv` => `DB_HOST` or `DB_DOMAIN`
- `$g_adm_port` => `DB_PORT`
- `$g_adm_db` => `DB_NAME` or `DB_DATABASE`
- `$g_adm_usr` => `DB_USERNAME` or `DB_USER`
- `$g_adm_pw` => `DB_PASSWORD`
The first one is my preferred option
Like here: https://codex.wordpress.org/Editing_wp-config.php