### PR TITLE
Detect ipv6 status in startup.sh for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN yum update -y --setopt=tsflags=nodocs && \
     yum -y clean all --enablerepo='*'
 
 COPY . .
+RUN mkdir provisioning && cp -a adm_plugins adm_themes adm_my_files provisioning/ && rm -rf adm_plugins adm_themes adm_my_files
 
 RUN chown -R default:root .
 

--- a/dockerscripts/startup.sh
+++ b/dockerscripts/startup.sh
@@ -13,6 +13,16 @@ set -o pipefail  # causes a pipeline (for example, curl -s https://sipb.mit.edu/
 #     check for db connection and existing tables instead
 
 
+
+
+# check for existing admidio directories in docker volumes
+for dir in "adm_plugins" "adm_themes" "adm_my_files" ; do
+    if [ ! -d "${dir}" -o "$(find "${dir}" -maxdepth 0 -type d -empty 2>/dev/null)" != "" ]; then
+        echo "[INFO ] provisioning missing directory ${dir}"
+        cp -a "provisioning/${dir}" .
+    fi
+done
+
 # configure apache
 echo "[INFO ] configure ServerName in /etc/httpd/conf/httpd.conf"
 sed -i "s/#ServerName.*/ServerName \$\{HOSTNAME\}/g" /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
Detect ipv6 status and set inet_protocols to ipv4 if disabled to prevent "no local interface found" error on container startup; Add some logging output for better debugging (#1003)