### PR TITLE
Issue 1067: Implement admin notification mails for all user/profile/membership changes and user creations/deletions

### DIFF
--- a/adm_program/installation/db_scripts/preferences.php
+++ b/adm_program/installation/db_scripts/preferences.php
@@ -62,6 +62,7 @@ $defaultOrgPreferences = array(
     'enable_system_mails'         => '1',
     'email_administrator'         => 'administrator@'. DOMAIN,
     'enable_email_notification'   => '0',
+    'enable_email_changenotification'   => '0',
 
     // Captcha
     'captcha_type'                => 'pic',

--- a/adm_program/installation/update.php
+++ b/adm_program/installation/update.php
@@ -101,6 +101,7 @@ if (!$gSettingsManager->has('system_language'))
 }
 $gLanguageData = new LanguageData($gSettingsManager->getString('system_language'));
 $gL10n = new Language($gLanguageData);
+$gChangeNotification = new ChangeNotification();
 
 if (FileSystemUtils::isUnixWithPosix() && (!is_executable(ADMIDIO_PATH . FOLDER_DATA) || !is_writable(ADMIDIO_PATH . FOLDER_DATA)))
 {

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -343,6 +343,8 @@
   <string name="ORG_SYSTEM_INFORMATION">Systeminformationen</string>
   <string name="ORG_SYSTEM_MAIL_ADDRESS">E-Mail-Adresse</string>
   <string name="ORG_SYSTEM_MAIL_ADDRESS_DESC">Hier sollte die E-Mail-Adresse eines Administrators eingetragen werden. Diese wird als Absenderadresse für Systembenachrichtigungen benutzt, z.B. bei der Registrierungsbestätigung.</string>
+  <string name="ORG_SYSTEM_MAIL_CHANGES">Benachrichtigung bei Profiländerungen</string>
+  <string name="ORG_SYSTEM_MAIL_CHANGES_DESC">Hier kann die Systembenachrichtigung für geänderte Profildaten aktiviert werden. Werden von einem Benutzer oder Administrator Profildaten geändert oder Benutzer gelöscht oder erstellt, erfolgt eine Benachrichtigung an die angegebene E-Mail #VAR1# (Voreinstellung: nein).</string>
   <string name="ORG_SYSTEM_MAIL_NEW_ENTRIES">Benachrichtigung bei neuen Einträgen</string>
   <string name="ORG_SYSTEM_MAIL_NEW_ENTRIES_DESC">Hier kann die Systembenachrichtigung für neue Einträge in den Modulen aktiviert werden. Sie dient als Überwachungsfunktion innerhalb von Admidio. Der Administrator hat so die Möglichkeit sich über neue Einträge in den Modulen per E-Mail benachrichtigen zu lassen (es werden nur neue Einträge berücksichtigt). Die Systembenachrichtigungen wird an die E-Mail-Adresse #VAR1# versendet. (Voreinstellung: nein)</string>
   <string name="ORG_SYSTEM_MAIL_TEXTS_DESC">Hier können die Texte aller Systembenachrichtigungen angepasst und ergänzt werden. Die Texte sind in 2 Bereiche (Betreff &amp; Inhalt) unterteilt und werden durch die Zeichenfolge #subject# und #content# identifiziert. Danach folgt dann der jeweilige Inhalt für diesen Bereich.\n\nIn jeder Mail können folgende Platzhalter benutzt werden, welche dann zur Laufzeit durch die entsprechenden Inhalt ersetzt werden</string>
@@ -776,6 +778,10 @@
   <string name="SYS_EMAIL">E-Mail</string>
   <string name="SYS_EMAIL_ANNOUNCEMENT_NOTIFICATION_TITLE">Eine neue Ankündigung wurde angelegt</string>
   <string name="SYS_EMAIL_ANNOUNCEMENT_NOTIFICATION_MESSAGE">Es wurde eine neue Ankündigung bei #VAR1# angelegt.\n\nTitel: #VAR2#\nAngelegt von: #VAR3#\nAngelegt am: #VAR4#</string>
+  <string name="SYS_EMAIL_CHANGE_NOTIFICATION_TITLE">Benutzer #VAR1# #VAR2# (Login: #VAR3#) wurde geändert</string>
+  <string name="SYS_EMAIL_CHANGE_NOTIFICATION_MESSAGE">Benutzerdaten von #VAR1# #VAR2# (Login: #VAR3#) wurden geändert durch #VAR4#:</string>
+  <string name="SYS_EMAIL_DELETE_NOTIFICATION_TITLE">Benutzer #VAR1# #VAR2# (Login: #VAR3#) wurde gelöscht</string>
+  <string name="SYS_EMAIL_DELETE_NOTIFICATION_MESSAGE">Der Benutzer #VAR1# #VAR2# (Login: #VAR3#) wurde gelöscht von #VAR4#:</string>
   <string name="SYS_EMAIL_DESC">E-Mails können an unterschiedliche Rollen, dies können Gruppen, Kurse oder Abteilungen sein, geschrieben werden.</string>
   <string name="SYS_EMAIL_FILE_NOTIFICATION_TITLE">Eine neue Datei wurde hochgeladen</string>
   <string name="SYS_EMAIL_FILE_NOTIFICATION_MESSAGE">Es wurde eine neue Datei bei #VAR1# hochgeladen.\n\nDatei: #VAR2#\nAngelegt von: #VAR3#\nAngelegt am: #VAR4#</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -343,6 +343,8 @@
   <string name="ORG_SYSTEM_INFORMATION">System informations</string>
   <string name="ORG_SYSTEM_MAIL_ADDRESS">Mail address</string>
   <string name="ORG_SYSTEM_MAIL_ADDRESS_DESC">This field should contain the email address of an administrator as it will be used as sender address of system notifications, e.g. for registration confirmation.</string>
+  <string name="ORG_SYSTEM_MAIL_CHANGES">Notification for changed profile fields</string>
+  <string name="ORG_SYSTEM_MAIL_CHANGES_DESC">Enable this setting to send notifications for any changes to a user's profile fields. This way an administrator has the possibility to ensure a proper re data quality. Change notifications will be send to the following mail address #VAR1# (default: no).</string>
   <string name="ORG_SYSTEM_MAIL_NEW_ENTRIES">Notification for new entries</string>
   <string name="ORG_SYSTEM_MAIL_NEW_ENTRIES_DESC">Here you can activate system notifications for new module entries. These notifications will be used for internal monitoring of Admidio. This way an administrator has the possibility to get informed about new module entries (only new entries will be considered). System notifications will be send to the following mail address #VAR1# (default: no).</string>
   <string name="ORG_SYSTEM_MAIL_TEXTS_DESC">Here you can justify the text of each system notification. The texts are divided into two parts (subject and content) and are identified by #subject# and #content#. The content for each section follows it.\n\nIn each mail the following wildcards can be used. They will be replaced with the corresponding content at runtime</string>
@@ -776,6 +778,12 @@
   <string name="SYS_EMAIL">E-mail</string>
   <string name="SYS_EMAIL_ANNOUNCEMENT_NOTIFICATION_TITLE">A new announcement was created</string>
   <string name="SYS_EMAIL_ANNOUNCEMENT_NOTIFICATION_MESSAGE">A new announcement at #VAR1# was created\n\nTitle: #VAR2#\nCreated by: #VAR3#\nCreated at: #VAR4#</string>
+  <string name="SYS_EMAIL_CHANGE_NOTIFICATION_TITLE">User #VAR1# #VAR2# (login: #VAR3#) was changed</string>
+  <string name="SYS_EMAIL_CHANGE_NOTIFICATION_MESSAGE">The profile data of the user #VAR1# #VAR2# (login: #VAR3#) was changed by #VAR4#:</string>
+  <string name="SYS_EMAIL_CREATE_NOTIFICATION_TITLE">User #VAR1# #VAR2# (login: #VAR3#) was created</string>
+  <string name="SYS_EMAIL_CREATE_NOTIFICATION_MESSAGE">The user #VAR1# #VAR2# (login: #VAR3#) was created by #VAR4#:</string>
+  <string name="SYS_EMAIL_DELETE_NOTIFICATION_TITLE">User #VAR1# #VAR2# (login: #VAR3#) was deleted</string>
+  <string name="SYS_EMAIL_DELETE_NOTIFICATION_MESSAGE">The profile of the user #VAR1# #VAR2# (login: #VAR3#) was deleted by #VAR4#:</string>
   <string name="SYS_EMAIL_DESC">E-mails can be sent to different roles like groups, courses or departments.</string>
   <string name="SYS_EMAIL_FILE_NOTIFICATION_TITLE">A new file was uploaded</string>
   <string name="SYS_EMAIL_FILE_NOTIFICATION_MESSAGE">A new file was uploaded at #VAR1#\n\nFile: #VAR2#\nUploaded by: #VAR3#\nUploaded at: #VAR4#</string>

--- a/adm_program/libs/server/composer/autoload_classmap.php
+++ b/adm_program/libs/server/composer/autoload_classmap.php
@@ -8,6 +8,7 @@ $baseDir = dirname(dirname(dirname($vendorDir)));
 return array(
     'AdmException' => $baseDir . '/adm_program/system/classes/AdmException.php',
     'AutoLogin' => $baseDir . '/adm_program/system/classes/AutoLogin.php',
+    'ChangeNotification' => $baseDir . '/adm_program/system/classes/ChangeNotification.php',
     'Component' => $baseDir . '/adm_program/system/classes/Component.php',
     'ComponentUpdate' => $baseDir . '/adm_program/system/classes/ComponentUpdate.php',
     'ComponentUpdateSteps' => $baseDir . '/adm_program/system/classes/ComponentUpdateSteps.php',

--- a/adm_program/libs/server/composer/autoload_static.php
+++ b/adm_program/libs/server/composer/autoload_static.php
@@ -201,6 +201,7 @@ class ComposerStaticInitc301026038c71b1da7db13211002b5b3
     public static $classMap = array (
         'AdmException' => __DIR__ . '/../../../..' . '/adm_program/system/classes/AdmException.php',
         'AutoLogin' => __DIR__ . '/../../../..' . '/adm_program/system/classes/AutoLogin.php',
+        'ChangeNotification' => __DIR__ . '/../../../..' . '/adm_program/system/classes/ChangeNotification.php',
         'Component' => __DIR__ . '/../../../..' . '/adm_program/system/classes/Component.php',
         'ComponentUpdate' => __DIR__ . '/../../../..' . '/adm_program/system/classes/ComponentUpdate.php',
         'ComponentUpdateSteps' => __DIR__ . '/../../../..' . '/adm_program/system/classes/ComponentUpdateSteps.php',

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -512,6 +512,10 @@ $formSystemNotification->addCheckbox(
     'enable_email_notification', $gL10n->get('ORG_SYSTEM_MAIL_NEW_ENTRIES'), (bool) $formValues['enable_email_notification'],
     array('helpTextIdInline' => array('ORG_SYSTEM_MAIL_NEW_ENTRIES_DESC', array('<em>'.$gSettingsManager->getString('email_administrator').'</em>')))
 );
+$formSystemNotification->addCheckbox(
+    'enable_email_changenotification', $gL10n->get('ORG_SYSTEM_MAIL_CHANGES'), (bool) $formValues['enable_email_changenotification'],
+    array('helpTextIdInline' => array('ORG_SYSTEM_MAIL_CHANGES_DESC', array('<em>'.$gSettingsManager->getString('email_administrator').'</em>')))
+);
 $formSystemNotification->addCustomContent($gL10n->get('SYS_SYSTEM_MAILS'),
     '<p>'.$gL10n->get('ORG_SYSTEM_MAIL_TEXTS_DESC').':</p>
     <p><strong>#user_first_name#</strong> - '.$gL10n->get('ORG_VARIABLE_FIRST_NAME').'<br />

--- a/adm_program/modules/profile/profile_new.php
+++ b/adm_program/modules/profile/profile_new.php
@@ -418,7 +418,7 @@ foreach($gProfileFields->getProfileFields() as $field)
             }
             else
             {
-                $maxlength = '50';
+                $maxlength = '100';
             }
 
             $form->addInput(

--- a/adm_program/modules/profile/profile_new.php
+++ b/adm_program/modules/profile/profile_new.php
@@ -191,7 +191,7 @@ foreach($gProfileFields->getProfileFields() as $field)
 
         if($field->getValue('cat_name_intern') === 'BASIC_DATA')
         {
-            if($userId > 0 || $getNewUser === 2)
+            if($userId > 0 || $getNewUser === 2 || $getNewUser === 1)
             {
                 // add username to form
                 $fieldProperty = HtmlForm::FIELD_DEFAULT;
@@ -202,7 +202,7 @@ foreach($gProfileFields->getProfileFields() as $field)
                     $fieldProperty = HtmlForm::FIELD_DISABLED;
                     $fieldHelpId   = '';
                 }
-                elseif($getNewUser > 0)
+                elseif($getNewUser >= 2)
                 {
                     $fieldProperty = HtmlForm::FIELD_REQUIRED;
                 }

--- a/adm_program/system/classes/ChangeNotification.php
+++ b/adm_program/system/classes/ChangeNotification.php
@@ -363,7 +363,7 @@ class ChangeNotification
             if ($row['mem_end'] ) {
                 $this->logRoleChange($userId, $row['rol_name'], $gL10n->get('SYS_MEMBERSHIP_END'), $row['mem_end'], null, $user, /*deleting=*/true);
             }
-            if ($row['mem_leaser'] ) {
+            if ($row['mem_leader'] ) {
                 $this->logRoleChange($userId, $row['rol_name'], $gL10n->get('SYS_LEADER'), $row['mem_leader'], null, $user, /*deleting=*/true);
             }
         }

--- a/adm_program/system/classes/ChangeNotification.php
+++ b/adm_program/system/classes/ChangeNotification.php
@@ -1,0 +1,475 @@
+<?php
+/**
+ ***********************************************************************************************
+ * @copyright 2004-2021 The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ ***********************************************************************************************
+ */
+
+/**
+ * Object to collect change notifications and optionally send a message to the administrator
+ *
+ * This class can be used to log changes to profile fields and role
+ * memberships. It stores all changes and at the end of the request,
+ * sends one notification mail per modified user to the administrator, if
+ * system notifications for profile field changes are enabled in Admidio's
+ * configuration.
+ *
+ * On startup, a global (singleton) object $gChangeNotifications is created
+ * that is automatically used the User and TableMembers classes to log
+ * changes.
+ *
+ *
+ * **Code example**
+ * ```
+ * // log a change to a profile field (done automatically by the User classe)
+ * $gChangeNotifications->logProfileChange($usr_id, 123, 'first_name', 'Old Name', 'New Name');
+ *
+ * // Force sending the change notifications (if configured at all)
+ * $gChangeNotifications->sendNotification();
+ * ```
+ */
+class ChangeNotification
+{
+    /** @var $changes Queued array of changes (user ID as key) made during this
+     *  php process. This data structure is meant to cache all changes and then
+     *  send out only one notification mail per user when PHP is finished.
+     *  The structure of each entry of this entry is:
+     *      uid => array(
+     *          'uid'=>123,
+     *          'usr_login_name'=>'',
+     *          'first_name'=>'',
+     *          'last_name'=>'',
+     *          'created' => false,
+     *          'deleted' => false,
+     *          'profile_changes' => array(
+     *              field_id => array('Field Name', 'old_value', 'new_value'),
+     *          ),
+     *          'role_changes' => array(
+     *              role_id => array('Role Name', 'fieldname', 'old_value', 'new_value'),
+     *          )
+     *      )
+     */
+     protected $changes = array();
+
+     /** @var $format Whether to send mails as 'html' or 'text' (as configured)
+     */
+     protected $format = 'html';
+
+     /**
+     * Constructor that initialize the class member parameters
+     */
+    public function __construct()
+    {
+        global $gSettingsManager;
+        $this->format = $gSettingsManager->getBool('mail_html_registered_users') ? 'html' : 'text';
+
+        // Register a shutdown function, which will be called when the whole PHP
+        // script is finished, but before all global objects are destroyed
+        // => That's the correct place to send out all pending change notification mails!
+        register_shutdown_function(array($this, 'shutdown'));
+    }
+
+   /**
+     * Clear the queue of all recorded changes. No notifications are sent out by
+     * this method.
+     * @param int $userId The user for whom all recorded changes should be cleared (null for all users)
+     */
+    public function clearChanges($userId = null)
+    {
+        if ($userId) {
+            unset($this->changes[$userId]);
+        } else {
+            $this->changes = array();
+        }
+    }
+
+   /**
+     * Initialize the internal data structure to queue changes to a given user ID.
+     * @param int $userId The user for whom to prepare the internal data structure
+     */
+    public function prepareUserChanges($userId, $user = null)
+    {
+        global $gDb, $gProfileFields;
+        if (!isset($this->changes[$userId])) {
+            if (is_null($user)) {
+                $user = new User($gDb, $gProfileFields, $userId);
+            }
+            $this->changes[$userId] = array(
+                'uid' => $userId,
+                'usr_login_name' => $user->getValue('usr_login_name'),
+                'first_name' => $user->getValue('FIRST_NAME'),
+                'last_name' => $user->getValue('LAST_NAME'),
+                'created' => false,
+                'deleted' => false,
+                'profile_changes' => array(),
+                'role_changes' => array(),
+            );
+        }
+    }
+
+    /**
+     * Records a profile field change for the given user ID and the field ID.
+     * Both the old and the new values are stored in an array and sent via
+     * a system notification mail to the admin if configured.
+     * @param int $userId The user to whom the change applies
+     * @param int $fieldId The ID of the modified profile field.
+     * @param string $fieldname The human-readable name of the modified profile field.
+     * @param string $old_value The previous value of the field before the change
+     * @param string $new_value The new value of the field after the change
+     * @param string $old_value_db The previous value of the field before the change as stored in the database
+     * @param string $new_value_db The new value of the field after the change as stored in the database
+     * @param bool $deleting Whether the profile is changed due to deleting the
+     *                       user. In this case, the change will not be logged
+     *                       in the history database.
+     */
+    public function logProfileChange($userId, $fieldId, $fieldname, $old_value, $new_value, $old_value_db = null, $new_value_db = null, $user = NULL, $deleting = false)
+    {
+        global $gSettingsManager, $gDb;
+        // 1. Create a database log entry if so configured
+        if (!$deleting && $userId > 0 && $gSettingsManager->getBool('profile_log_edit_fields')) {
+            $logEntry = new TableAccess($gDb, TBL_USER_LOG, 'usl');
+            $logEntry->setValue('usl_usr_id', $userId);
+            $logEntry->setValue('usl_usf_id', $fieldId);
+            $logEntry->setValue('usl_value_old', $old_value_db);
+            $logEntry->setValue('usl_value_new', $new_value_db);
+            $logEntry->setValue('usl_comm', '');
+            $logEntry->save();
+        }
+
+        // 2. Store the change to send out one change notification mail (after all modifications are done)
+        $this->prepareUserChanges($userId, $user);
+        $this->changes[$userId]['profile_changes'][] = array($fieldname, $old_value, $new_value);
+    }
+
+    /**
+     * Records a core user field change for the given user ID and the field ID.
+     * Both the old and the new values are stored in an array and sent via
+     * a system notification mail to the admin if configured.
+     * Some user fields are special cased (password, photo), others are ignored
+     * for irrelevance (internal fields).
+     * @param int $userId The user to whom the change applies
+     * @param int $fieldId The ID of the modified profile field.
+     * @param string $fieldname The human-readable name of the modified profile field.
+     * @param string $old_value The previous value of the field before the change
+     * @param string $new_value The new value of the field after the change
+     * @param bool $deleting Whether the profile is changed due to deleting the
+     *                       user. In this case, the change will not be logged
+     *                       in the history database.
+     */
+    public function logUserChange($userId, $fieldId, $old_value, $new_value, $user = NULL, $deleting = false)
+    {
+        global $gSettingsManager, $gL10n;
+
+        // 1. Create a database log entry if so configured
+        if ($gSettingsManager->getBool('profile_log_edit_fields')) {
+            // TODO: User table fields are not yet logged in the database!
+        }
+
+        // 2. Store the change to send out one change notification mail (after all modifications are done)
+        $this->prepareUserChanges($userId, $user);
+
+        $fieldtitle = $fieldId;
+
+        // Ignore all fields (internal logging about who and when a user was
+        // last changed) except explicitly handled (login, pwd, photo)
+        $ignore = false;
+
+        switch ($fieldId) {
+            case 'usr_login_name':
+                $fieldtitle = $gL10n->get('SYS_USERNAME');
+                break;
+            case 'usr_password':
+                $fieldtitle = $gL10n->get('SYS_PASSWORD');
+                $old_value = $new_value = '********';
+                break;
+            case 'usr_photo':
+                $fieldtitle = $gL10n->get('SYS_PHOTO');
+                // Don't show photo data, replace with [...] if set
+                $old_value = $old_value ? '[...]' : $old_value;
+                $new_value = $new_value ? '[...]' : $new_value;
+                break;
+            default:
+                $ignore = true;
+        }
+
+        if (!$ignore) {
+            $this->changes[$userId]['profile_changes'][] = array($fieldtitle, $old_value, $new_value);
+        }
+    }
+
+    /**
+     * Records a role membership change for the given user ID and the given role.
+     * Both the old and the new values are stored in an array and sent via
+     * a system notification mail to the admin if configured.
+     * @param int $userId The user to whom the change applies
+     * @param int $fieldId The ID of the modified profile field.
+     * @param string $fieldname The human-readable name of the modified profile field.
+     * @param string $old_value The previous value of the field before the change
+     * @param string $new_value The new value of the field after the change
+     * @param bool $deleting Whether the profile is changed due to deleting the
+     *                       user. In this case, the change will not be logged
+     *                       in the history database.
+     */
+    public function logRoleChange($userId, $roleId, $role, $fieldname, $old_value, $new_value, $user = NULL, $deleting = false)
+    {
+        global $gSettingsManager, $gL10n;
+        // Don't log anything if no User ID is set yet (e.g. user not yet saved to the database!)
+        if ($userId == 0) {
+            return;
+        }
+        // 1. Create a database log entry if so configured
+        if (!$deleting && $userId > 0 && $gSettingsManager->getBool('profile_log_edit_fields')) {
+            // TODO: Role changes are not yet logged in the database!
+        }
+
+        // 2. Store the change to send out one change notification mail (after all modifications are done)
+        $this->prepareUserChanges($userId, $user);
+        $fieldtitle = $fieldname;
+        $ignore = false;
+        switch($fieldname) {
+            case 'mem_begin':
+                $fieldtitle = $gL10n->get('SYS_MEMBERSHIP_START');
+                break;
+            case 'mem_end':
+                $fieldtitle = $gL10n->get('SYS_MEMBERSHIP_END');
+                break;
+            case 'mem_leader':
+                $fieldtitle = $gL10n->get('SYS_LEADER');
+                break;
+            default:
+                $ignore = true;
+                break;
+        }
+        if (!$ignore) {
+            $this->changes[$userId]['role_changes'][] = array($role, $fieldtitle, $old_value, $new_value);
+        }
+    }
+
+    /**
+     * Records a user creation with the given user ID. The user is assumed to be
+     * stored to the database already.
+     * All non-empty fields are added to the list of changes and queued for notification.
+     *
+     * @param int $userId The user to whom the change applies
+     * @param User $user(optional) The User object of the newly created user
+     */
+    public function logUserCreation($userId, $user = NULL)
+    {
+        global $gProfileFields, $gL10n;
+
+        // If user was never created in the DB, no need to log
+        if ($userId == 0)
+            return;
+        if (is_null($user)) {
+            $user = new User($this->db, $gProfileFields, $userId);
+        }
+
+        // 1. TODO: Create a history log database entry for the creation
+
+
+        // 2. Prepare the admin notifications
+        $this->prepareUserChanges($userId, $user);
+        $this->changes[$userId]['created'] = true;
+
+        // Username and Passwords
+        foreach (array('usr_login_name', 'usr_password', 'usr_photo', 'usr_text') as $fieldname) {
+            $newval = $user->getValue($fieldname, $this->format);
+            if ($newval) {
+                $this->logUserChange($userId, $fieldname, null, $newval, null, $user);
+            }
+        }
+        // Loop through all profile fields and add all non-empty fields to the notification
+        if ($user->getProfileFieldsData() instanceof ProfileFields) {
+            foreach ($user->getProfileFieldsData()->getProfileFields() as $fieldname => $field) {
+                // Always use the text representation in the notification mail,
+                // as the HTML-representation might make use of css classes or
+                // image paths that are not available in a mail!
+                $newval = $user->getValue($fieldname, 'text');
+                $newval_db = $user->getValue($fieldname, 'database');
+                if ($newval) {
+                    $fieldtitle = $field->getValue('usf_name', $this->format);
+                    $fieldid = $field->getValue('usf_id');
+                    $this->logProfileChange($userId, $fieldid, $fieldtitle, null, $newval, null, $newval_db, $user, /*deleting=*/false);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Records a user deletion for the given user ID.
+     * All non-empty fields are added to the list of changes and queued for notification.
+     * This function must be called before removing the user from the database.
+     *
+     * @param int $userId The user to whom the change applies
+     * @param User $user(optional) The User object of the user to be deleted
+     */
+    public function logUserDeletion($userId, $user = NULL)
+    {
+        global $gProfileFields, $gL10n, $gDb;
+
+        // If user wasn't yet created in the DB, no need to log anything
+        if ($userId == 0)
+            return;
+
+        // 1. TODO: Create a history log database entry for the deletion
+
+        // 2. Prepare the admin notifications
+        $this->prepareUserChanges($userId, $user);
+        $this->changes[$userId]['deleted'] = true;
+
+        $olddata = new User($gDb, $gProfileFields, $userId);
+
+        // Username and Passwords
+        foreach (array('usr_login_name', 'usr_password', 'usr_photo', 'usr_text') as $fieldname) {
+            $oldval = $olddata->getValue($fieldname, $this->format);
+            if ($oldval) {
+                $this->logUserChange($userId, $fieldname, $oldval, null, $user);
+            }
+        }
+        // Loop through all profile fields and add all non-empty fields to the notification
+        if ($olddata->getProfileFieldsData() instanceof ProfileFields) {
+            foreach (array_keys($olddata->getProfileFieldsData()->getProfileFields()) as $fieldname) {
+                // Always use the text representation in the notification mail,
+                // as the HTML-representation might make use of css classes or
+                // image paths that are not available in a mail!
+                $oldval = $olddata->getValue($fieldname, 'text');
+                $oldval_db = $olddata->getValue($fieldname, 'database');
+                if ($oldval) {
+                    $fieldtitle = $olddata->getProfileFieldsData()->getProfileFields()[$fieldname]->getValue('usf_name', $this->format);
+                    $this->logProfileChange($userId, $fieldname, $fieldtitle, $oldval, null, $oldval_db, null, $user, /*deleting=*/true);
+                }
+            }
+        }
+
+        // Role memberships => For simplicity read directly from database
+        global $gDb;
+        $sql = 'SELECT *
+                  FROM '.TBL_MEMBERS.'
+            INNER JOIN '.TBL_ROLES.'
+                    ON rol_id = mem_rol_id
+            INNER JOIN '.TBL_CATEGORIES.'
+                    ON cat_id = rol_cat_id
+                 WHERE mem_usr_id  = ? -- $userId
+                   AND rol_valid   = 1
+                   AND cat_name_intern <> \'EVENTS\'
+                 ORDER BY cat_org_id, cat_sequence, rol_name';
+        $query = $gDb->queryPrepared($sql, array($userId));
+
+        while ($row = $query->fetch()) {
+            $this->logRoleChange($userId, $row['rol_name'], $gL10n->get('SYS_MEMBERSHIP_START'), $row['mem_begin'], null, $user, /*deleting=*/true);
+            if ($row['mem_end'] ) {
+                $this->logRoleChange($userId, $row['rol_name'], $gL10n->get('SYS_MEMBERSHIP_END'), $row['mem_end'], null, $user, /*deleting=*/true);
+            }
+            if ($row['mem_leaser'] ) {
+                $this->logRoleChange($userId, $row['rol_name'], $gL10n->get('SYS_LEADER'), $row['mem_leader'], null, $user, /*deleting=*/true);
+            }
+        }
+
+    }
+
+    /**
+     * Send out all queued change notifications, if the configuration has system
+     * change notifications enabled at all.
+     * @param int $userId The user for whom the notification shall be sent (null for all queued notifications)
+     */
+    public function sendNotifications($userId = null)
+    {
+        global $gSettingsManager, $gL10n, $gCurrentUser;
+
+        $currfullname = $gCurrentUser->getValue('FIRST_NAME').' '.$gCurrentUser->getValue('LAST_NAME');
+        $currname =  $currfullname . ' (login: ' . $gCurrentUser->getValue('usr_login_name') . ')';
+        if ($this->format == 'html') {
+            $format_hdr    = "<tr><th> %s </th><th> %s </th><th> %s </th></tr>\n";
+            $format_row    = "<tr><th> %s </th><td> %s </td><td> %s </td></tr>\n";
+            $format_rolhdr = "<tr><th> %s </th><th> %s </th><th> %s </th><th> %s </th></tr>\n";
+            $format_rolrow = "<tr><th> %s </th><td> %s </td><td> %s </td><td> %s </td></tr>\n";
+            $table_begin   = "<br><br><table border=\"1\">";
+            $table_end     = "</table><br>";
+        } else {
+            $format_hdr    = "%25s %25s -> %25s\n";
+            $format_row    = "%25.25s %25.25s -> %25s\n ";
+            $format_rolhdr = "%25s %25s %25s -> %25s\n";
+            $format_rolrow = "%25.25s %25s %25.25s -> %25s\n ";
+            $table_begin   = '\n';
+            $table_end     = '\n\n';
+        }
+
+        if ($gSettingsManager->getBool('enable_email_changenotification')) {
+            $changes = $this->changes;
+            if ($userId) {
+                $changes = array();
+                $changes[$userId] = $this->changes[$userId];
+            }
+            foreach ($changes as $uid => $userdata) {
+                $notification = new Email();
+                $hasContent = false;
+
+                if ($userdata['deleted']) {
+                    $message = 'SYS_EMAIL_DELETE_NOTIFICATION_MESSAGE';
+                    $messageTitle = 'SYS_EMAIL_DELETE_NOTIFICATION_TITLE';
+                } elseif ($userdata['created']) {
+                    $message = 'SYS_EMAIL_CREATE_NOTIFICATION_MESSAGE';
+                    $messageTitle = 'SYS_EMAIL_CREATE_NOTIFICATION_TITLE';
+                } else {
+                    $message = 'SYS_EMAIL_CHANGE_NOTIFICATION_MESSAGE';
+                    $messageTitle = 'SYS_EMAIL_CHANGE_NOTIFICATION_TITLE';
+                }
+
+                $message = $gL10n->get(
+                    $message,
+                    array($userdata['first_name'], $userdata['last_name'], $userdata['usr_login_name'], $currname));
+
+                $changes = $userdata['profile_changes'];
+                if ($changes) {
+                    $hasContent = true;
+                    $message .= $table_begin .
+                        sprintf($format_hdr, $gL10n->get('SYS_FIELD'),
+                                $gL10n->get('SYS_PREVIOUS_VALUE'),
+                                $gL10n->get('SYS_NEW_VALUE'));
+                    foreach ($changes as $c) {
+                        $message .= sprintf($format_row, $c[0], $c[1], $c[2]);
+                    }
+                    $message .= $table_end;
+                }
+
+                $changes = $userdata['role_changes'];
+                if ($changes) {
+                    $hasContent = true;
+                    $message .= $table_begin .
+                        sprintf($format_rolhdr,
+                                $gL10n->get('SYS_ROLE'), $gL10n->get('SYS_FIELD'),
+                                $gL10n->get('SYS_PREVIOUS_VALUE'),
+                                $gL10n->get('SYS_NEW_VALUE'));
+                    foreach ($changes as $c) {
+                        $message .= sprintf($format_rolrow, $c[0], $c[1], $c[2], $c[3]);
+                    }
+                    $message .= $table_end;
+                }
+
+                if ($hasContent) {
+
+                    $notification->adminNotification(
+                        $gL10n->get($messageTitle,
+                            array($userdata['first_name'], $userdata['last_name'], $userdata['usr_login_name'])),
+                        $message,
+                        $currfullname, $gCurrentUser->getValue('EMAIL'), 'enable_email_changenotification');
+                }
+
+            }
+
+        }
+
+        $this->clearChanges($userId);
+    }
+
+
+    /**
+     * Shutdown function for cleanup: Send out all pending notification when the php processing is finished.
+     */
+    public function shutdown() {
+        $this->sendNotifications();
+    }
+}

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -289,11 +289,11 @@ class Email extends PHPMailer
      * @throws AdmException 'SYS_EMAIL_NOT_SEND'
      * @return bool|string
      */
-    public function adminNotification($subject, $message, $editorName = '', $editorEmail = '')
+    public function adminNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'enable_email_notification')
     {
         global $gSettingsManager, $gCurrentOrganization;
 
-        if (!$gSettingsManager->getBool('enable_email_notification'))
+        if (!$gSettingsManager->getBool($enable_flag))
         {
             return false;
         }

--- a/adm_program/system/classes/User.php
+++ b/adm_program/system/classes/User.php
@@ -242,6 +242,9 @@ class User extends TableAccess
         {
             // one record found than update this record
             $row = $membershipStatement->fetch();
+            if (($mode === 'set') && ($row['mem_id'] > 0)) {
+                $member = new TableMembers($this->db, $row['mem_id']);
+            }
             $member->setArray($row);
 
             // save new start date if an earlier date exists
@@ -654,10 +657,13 @@ class User extends TableAccess
      */
     public function delete()
     {
-        global $gCurrentUser;
+        global $gCurrentUser, $gChangeNotification;
 
         $usrId     = (int) $this->getValue('usr_id');
         $currUsrId = (int) $gCurrentUser->getValue('usr_id');
+
+        // Register all non-empty fields for the notification
+        $gChangeNotification->logUserDeletion($usrId, $this);
 
         // first delete send messages from the user
         $sql = 'SELECT msg_id FROM ' . TBL_MESSAGES . ' WHERE msg_usr_id_sender = ? -- $usrId';
@@ -1001,6 +1007,7 @@ class User extends TableAccess
     {
         return $this->getAllRolesWithRight($this->listViewRights);
     }
+
 
     /**
      * Returns the id of the organization this user object has been assigned.
@@ -1789,7 +1796,7 @@ class User extends TableAccess
      */
     public function save($updateFingerPrint = true)
     {
-        global $gCurrentSession, $gCurrentUser;
+        global $gCurrentSession, $gCurrentUser, $gChangeNotification;
 
         $usrId = (int) $this->getValue('usr_id');
 
@@ -1822,6 +1829,8 @@ class User extends TableAccess
             $this->columnsValueChanged = true;
         }
 
+        $newRecord = $this->newRecord;
+
         $returnValue = parent::save($updateFingerPrint);
         $usrId = (int) $this->getValue('usr_id'); // if a new user was created get the new id
 
@@ -1845,6 +1854,13 @@ class User extends TableAccess
             // because he has new data and maybe new rights
             $gCurrentSession->renewUserObject($usrId);
         }
+        // The record is a new record, which was just stored to the database
+        // for the first time => record it as a user creation now
+        if ($newRecord) {
+            // Register all non-empty fields for the notification
+            $gChangeNotification->logUserCreation($usrId, $this);
+        }
+
         $this->db->endTransaction();
 
         return $returnValue;
@@ -1859,6 +1875,7 @@ class User extends TableAccess
     {
         $this->saveChangesWithoutRights = true;
     }
+
 
     /**
      * Set the id of the organization which should be used in this user object.
@@ -1882,10 +1899,15 @@ class User extends TableAccess
      */
     public function setPassword($newPassword, $doHashing = true)
     {
-        global $gSettingsManager, $gPasswordHashAlgorithm;
+        global $gSettingsManager, $gPasswordHashAlgorithm, $gChangeNotification;
 
         if (!$doHashing)
         {
+            $gChangeNotification->logUserChange(
+                (int)$this->getValue('usr_id'),
+                'usr_password',
+                $this->getValue('usr_password'), $newPassword, $this
+            );
             return parent::setValue('usr_password', $newPassword, false);
         }
 
@@ -1903,6 +1925,11 @@ class User extends TableAccess
             return false;
         }
 
+        $gChangeNotification->logUserChange(
+            (int)$this->getValue('usr_id'),
+            'usr_password',
+            $this->getValue('usr_password'), $newPasswordHash, $this
+        );
         return parent::setValue('usr_password', $newPasswordHash, false);
     }
 
@@ -1944,7 +1971,7 @@ class User extends TableAccess
      */
     public function setValue($columnName, $newValue, $checkValue = true)
     {
-        global $gCurrentUser, $gSettingsManager;
+        global $gCurrentUser, $gSettingsManager, $gChangeNotification;
 
         // users data from adm_users table
         if (str_starts_with($columnName, 'usr_'))
@@ -1961,11 +1988,24 @@ class User extends TableAccess
                 return false;
             }
 
+            // For new records, do not immediately queue all changes for notification,
+            // as the record might never be saved to the database (e.g. when
+            // doing a check for an existing user)! => For new records,
+            // log the changes only when $this->save is called!
+            if (!$this->newRecord) {
+                $gChangeNotification->logUserChange(
+                    (int)$this->getValue('usr_id'),
+                    $columnName,
+                    $this->getValue($columnName), $newValue, $this
+                );
+            }
+
             return parent::setValue($columnName, $newValue, $checkValue);
         }
 
-        // user data from adm_user_fields table
-        $oldFieldValue = $this->mProfileFieldsData->getValue($columnName, 'database');
+        // user data from adm_user_fields table (human-readable text representation and raw database value)
+        $oldFieldValue = $this->mProfileFieldsData->getValue($columnName, 'text');
+        $oldFieldValue_db = $this->mProfileFieldsData->getValue($columnName, 'database');
         $newValue = (string) $newValue;
 
         // format of date will be local but database hase stored Y-m-d format must be changed for compare
@@ -1980,7 +2020,7 @@ class User extends TableAccess
         }
 
         // only to a update if value has changed
-        if ($oldFieldValue === $newValue)
+        if ($oldFieldValue_db === $newValue)
         {
             return true;
         }
@@ -2002,18 +2042,20 @@ class User extends TableAccess
         }
 
         // Nicht alle Aenderungen werden geloggt. Ausnahmen:
-        // Felder, die mit usr_ beginnen
-        // Felder, die sich nicht geändert haben
-        // Wenn usr_id ist 0 (der User neu angelegt wird; Das wird bereits dokumentiert)
-        if ($returnCode && $usrId > 0 && $gSettingsManager->getBool('profile_log_edit_fields'))
-        {
-            $logEntry = new TableAccess($this->db, TBL_USER_LOG, 'usl');
-            $logEntry->setValue('usl_usr_id', $usrId);
-            $logEntry->setValue('usl_usf_id', $this->mProfileFieldsData->getProperty($columnName, 'usf_id'));
-            $logEntry->setValue('usl_value_old', $oldFieldValue);
-            $logEntry->setValue('usl_value_new', $newValue);
-            $logEntry->setValue('usl_comm', '');
-            $logEntry->save();
+        // Felder, die mit usr_ beginnen (special case above)
+        // Felder, die sich nicht geändert haben (check above)
+        // Wenn usr_id ist 0 (der User neu angelegt wird; Das wird bereits dokumentiert) (check in logProfileChange)
+
+        if ($returnCode && !$this->newRecord) {
+            $gChangeNotification->logProfileChange(
+                (int)$this->getValue('usr_id'),
+                $this->mProfileFieldsData->getProperty($columnName, 'usf_id'),
+                $columnName, // TODO: is $columnName the internal name or the human-readable?
+                // Old and new values in human-readable version:
+                $oldFieldValue, $this->mProfileFieldsData->getValue($columnName, 'text'),
+                // Old and new values in raw dtabase:
+                $oldFieldValue_db, $newValue, $this
+            );
         }
 
         return $returnCode;
@@ -2148,4 +2190,14 @@ class User extends TableAccess
     {
         return $this->checkRolesRight('rol_weblinks');
     }
+
+    /**
+     * Return the (internal) representation of this user's profile fields
+     * @return array All profile fields of the user
+     */
+    public function getProfileFieldsData()
+    {
+        return $this->mProfileFieldsData;
+    }
+
 }

--- a/adm_program/system/common.php
+++ b/adm_program/system/common.php
@@ -137,6 +137,9 @@ $gL10n = new Language($gLanguageData);
 $orgId    = (int) $gCurrentOrganization->getValue('org_id');
 $sesUsrId = (int) $gCurrentSession->getValue('ses_usr_id');
 
+// Create a notification object to store and send change notifications to profile fields
+$gChangeNotification = new ChangeNotification();
+
 // now if auto login is done, read global user data
 if($gCurrentSession->hasObject('gCurrentUser'))
 {


### PR DESCRIPTION
Notifications for all changes to a user, their profile fields and memberships are implemented via a dedicated class ChangeNotification, which queues all changes and sends out the mail notifications (if system notifications are enabled in the configuration) when the PHP script is done processing the whole page (but just before all global objects are destroyed).
A global object gChangeNotifications is automatically created and all changes in the User and TableMembers classes are properly logged to this object. If any plugin or code directly modifies the database, it needs to use any of the member functions of the ChangeNotification class to register the change.
    
In the past, all profile field changes were logged to the database already. This functionality has now been moved to the ChangeNotification class, so this class is the control center for all change notifications and logging. Implementing history log entries for user creation/deletion, password/username changes or membership changes can be easily added in the corresponding functions in the ChangeNotification class.

Fixes #1067
    