### PR TITLE
Fix password hashing (check for hashing need used other options than password hashing itself)

### DIFF
--- a/adm_program/system/classes/PasswordUtils.php
+++ b/adm_program/system/classes/PasswordUtils.php
@@ -165,7 +165,13 @@ final class PasswordUtils
 
         if (!array_key_exists('cost', $options) || !is_int($options['cost']))
         {
-            $options['cost'] = $defaultCost;
+            global $gSettingsManager;
+            if (isset($gSettingsManager) && $gSettingsManager->has('system_hashing_cost'))
+            {
+                $options['cost'] = $gSettingsManager->getInt('system_hashing_cost');
+            } else {
+                $options['cost'] = $defaultCost;
+            }
         }
         elseif ($options['cost'] < $minCost) // https://paragonie.com/blog/2016/02/how-safely-store-password-in-2016
         {


### PR DESCRIPTION
Without this patch, the check whether the password needs to be re-hashed on login used the default cost of 10, while the subsequent password hashing used the calculated cost of 11, so the password was re-hashed on each login. This patch makes sure that the same cost option is used for both the hash as well as the rehashing check.