### PR TITLE
In all lists, make the running number a link to the user in html mode

### DIFF
--- a/adm_program/modules/groups-roles/lists_show.php
+++ b/adm_program/modules/groups-roles/lists_show.php
@@ -656,7 +656,12 @@ foreach ($membersList as $member)
         // before adding the first column, add a column with the row number
         if ($columnNumber === 1)
         {
-            if (in_array($getMode, array('html', 'print', 'pdf'), true))
+            if ($getMode === 'html')
+            {
+                // add serial
+                $columnValues[] = '<a href="'.SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/profile/profile.php', array('user_uuid' => $member['usr_uuid'])).'">'.$listRowNumber.'</a>';
+            }
+            if (in_array($getMode, array('print', 'pdf'), true))
             {
                 // add serial
                 $columnValues[] = $listRowNumber;


### PR DESCRIPTION
Currently, only first and last name columns in html lists were links to the user. If a list did not contain either of these columns (e.g. because it displayed the company name for corporate members), no link to edit the member was possible.

The first column of the list is always a running number, so this patch also adds the link to the line number, making sure there is always a way to got the member and edit it.