### PR TITLE
Profile fields with Text(100) should also allow values up to 100 characters

### DIFF
--- a/adm_program/modules/profile/profile_new.php
+++ b/adm_program/modules/profile/profile_new.php
@@ -418,7 +418,7 @@ foreach($gProfileFields->getProfileFields() as $field)
             }
             else
             {
-                $maxlength = '50';
+                $maxlength = '100';
             }
 
             $form->addInput(


### PR DESCRIPTION
Profile fields with data type 'Text (100)' reserve 100 characters in the database, however, the form to input the text is limited to 50 characters. I ran into a problem entering a perfectly valid company name that is in actual use: 'Wiener Städtische Versicherung AG Vienna Insurance Group' (56 characters).