### PR TITLE
Also display the username field when creating a new user in the backend (e.g. by the admin)

### DIFF
--- a/adm_program/modules/profile/profile_new.php
+++ b/adm_program/modules/profile/profile_new.php
@@ -191,7 +191,7 @@ foreach($gProfileFields->getProfileFields() as $field)
 
         if($field->getValue('cat_name_intern') === 'BASIC_DATA')
         {
-            if($userId > 0 || $getNewUser === 2)
+            if($userId > 0 || $getNewUser === 2 || $getNewUser === 1)
             {
                 // add username to form
                 $fieldProperty = HtmlForm::FIELD_DEFAULT;
@@ -202,7 +202,7 @@ foreach($gProfileFields->getProfileFields() as $field)
                     $fieldProperty = HtmlForm::FIELD_DISABLED;
                     $fieldHelpId   = '';
                 }
-                elseif($getNewUser > 0)
+                elseif($getNewUser >= 2)
                 {
                     $fieldProperty = HtmlForm::FIELD_REQUIRED;
                 }


### PR DESCRIPTION
While the argument is true that the user does not automatically know the username generated for him/her, there are many cases where the admin that creates an account will send a detailed welcome mail to the new user anyway and in that mail can include the new user name.