### PR TITLE
Fix profile field internal names (remove special chars, properly enclose all SQL field names with ticks in ListConfiguration::getSQL); escape input field values

### DIFF
--- a/adm_program/system/classes/HtmlElement.php
+++ b/adm_program/system/classes/HtmlElement.php
@@ -506,7 +506,7 @@ abstract class HtmlElement
         $attributes = array();
         foreach ($elementAttributes as $key => $value)
         {
-            $attributes[] = $key . '="' . $value . '"';
+            $attributes[] = $key . '="' . htmlspecialchars($value) . '"';
         }
 
         return ' ' . implode(' ', $attributes);

--- a/adm_program/system/classes/TableUserField.php
+++ b/adm_program/system/classes/TableUserField.php
@@ -126,7 +126,7 @@ class TableUserField extends TableAccess
      */
     private function getNewNameIntern($name, $index)
     {
-        $newNameIntern = strtoupper(str_replace(' ', '_', $name));
+        $newNameIntern = strtoupper(preg_replace('/[^A-Za-z0-9_]/', '', str_replace(' ', '_', $name)));
 
         if ($index > 1)
         {


### PR DESCRIPTION
1) If an internal profile field name contains a hyphen, ListConfiguraiton::getSQL creates invalid SQL, because it does not enclose all field names with ticks. Hyphens in SQL field names are only allowed if the field name is quoted with ticks.

This patch fixed the ListConfiguration::getSQL method to add the ticks, but the issue potentially also appears in other places.

2) When a new profile field is created, this patch also removes all special characters except Letters, Digits and Underscores (spaces are converted to underscore).

3) Input field values are written as html attributes, so their values need to be escapes before inserting it into html. E.g. if a name contains a double quote, invalid HTML will be generated and the field value will be truncated. With the htmlspecialchars, all special characters are properly escaped so that the displayed input field shows the correct (special) characters.


Fixes #1088