### PR TITLE
Rename user management to members

### DIFF
--- a/adm_program/installation/db_scripts/update_4_1.xml
+++ b/adm_program/installation/db_scripts/update_4_1.xml
@@ -48,7 +48,7 @@
     <step id="190">UPDATE %PREFIX%_components SET com_name = 'SYS_WEBLINKS' WHERE com_name = 'LNK_WEBLINKS'</step>
     <step id="200">UPDATE %PREFIX%_menu SET men_name = 'SYS_WEBLINKS', men_description = 'SYS_WEBLINKS_DESC' WHERE men_name_intern = 'weblinks'</step>
     <step id="210">UPDATE %PREFIX%_components SET com_name = 'SYS_USER_MANAGEMENT' WHERE com_name = 'MEM_USER_MANAGEMENT'</step>
-    <step id="220">UPDATE %PREFIX%_menu SET men_name = 'SYS_USER_MANAGEMENT', men_description = 'SYS_USER_MANAGEMENT_DESC' WHERE men_name_intern = 'usrmgt'</step>
+    <step id="220">UPDATE %PREFIX%_menu SET men_name = 'SYS_USER_MANAGEMENT', men_description = 'SYS_MEMBERS_DESC' WHERE men_name_intern = 'usrmgt'</step>
     <step id="230">UPDATE %PREFIX%_menu SET men_name = 'SYS_EMAIL', men_description = 'SYS_EMAIL_DESC' WHERE men_name_intern = 'mail'</step>
     <step id="240">UPDATE %PREFIX%_menu SET men_name = 'SYS_NEW_REGISTRATIONS', men_description = 'SYS_MANAGE_NEW_REGISTRATIONS_DESC' WHERE men_name_intern = 'newreg'</step>
     <step id="250">ALTER TABLE %PREFIX%_user_fields ADD COLUMN usf_description_inline boolean NOT NULL DEFAULT '0'</step>
@@ -155,5 +155,7 @@
         COLLATE = utf8_unicode_ci</step>
     <step id="880">ALTER TABLE %PREFIX%_category_report ADD CONSTRAINT %PREFIX%_fk_crt_org FOREIGN KEY (crt_org_id) REFERENCES %PREFIX%_organizations (org_id) ON DELETE RESTRICT ON UPDATE RESTRICT</step>
     <step id="890">ComponentUpdateSteps::updateStep41CategoryReportMigration</step>
+    <step id="900">UPDATE %PREFIX%_components SET com_name = 'SYS_MEMBERS' WHERE com_name = 'SYS_USER_MANAGEMENT'</step>
+    <step id="910">UPDATE %PREFIX%_menu SET men_name = 'SYS_MEMBERS', men_description = 'SYS_MEMBERS_DESC' WHERE men_name_intern = 'usrmgt'</step>
     <step>stop</step>
 </update>

--- a/adm_program/installation/install_steps/start_installation.php
+++ b/adm_program/installation/install_steps/start_installation.php
@@ -94,23 +94,23 @@ $gCurrentUserId = $gCurrentUser->getValue('usr_id');
 // create all modules components
 $sql = 'INSERT INTO '.TBL_COMPONENTS.'
                (com_type, com_name, com_name_intern, com_version, com_beta)
-        VALUES (\'MODULE\', \'SYS_ANNOUNCEMENTS\',       \'ANNOUNCEMENTS\',  \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_DATABASE_BACKUP\',     \'BACKUP\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_CATEGORIES\',          \'CATEGORIES\',     \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_CATEGORY_REPORT\',     \'CATEGORY-REPORT\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'DAT_DATES\',               \'DATES\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_DOCUMENTS_FILES\',     \'DOCUMENTS-FILES\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'GBO_GUESTBOOK\',           \'GUESTBOOK\',      \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_WEBLINKS\',            \'LINKS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_GROUPS_ROLES\',        \'GROUPS-ROLES\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_USER_MANAGEMENT\',     \'MEMBERS\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_MESSAGES\',            \'MESSAGES\',       \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_MENU\',                \'MENU\',           \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_PHOTOS\',              \'PHOTOS\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_SETTINGS\',            \'PREFERENCES\',    \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'PRO_PROFILE\',             \'PROFILE\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_REGISTRATION\',        \'REGISTRATION\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_ROOM_MANAGEMENT\',     \'ROOMS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')';
+        VALUES (\'MODULE\', \'SYS_ANNOUNCEMENTS\',   \'ANNOUNCEMENTS\',  \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_DATABASE_BACKUP\', \'BACKUP\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_CATEGORIES\',      \'CATEGORIES\',     \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_CATEGORY_REPORT\', \'CATEGORY-REPORT\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'DAT_DATES\',           \'DATES\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_DOCUMENTS_FILES\', \'DOCUMENTS-FILES\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'GBO_GUESTBOOK\',       \'GUESTBOOK\',      \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_WEBLINKS\',        \'LINKS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_GROUPS_ROLES\',    \'GROUPS-ROLES\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_MEMBERS\',         \'MEMBERS\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_MESSAGES\',        \'MESSAGES\',       \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_MENU\',            \'MENU\',           \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_PHOTOS\',          \'PHOTOS\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_SETTINGS\',        \'PREFERENCES\',    \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'PRO_PROFILE\',         \'PROFILE\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_REGISTRATION\',    \'REGISTRATION\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+             , (\'MODULE\', \'SYS_ROOM_MANAGEMENT\', \'ROOMS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')';
 $db->query($sql); // TODO add more params
 
 // create organization independent categories
@@ -289,7 +289,7 @@ $sql = 'INSERT INTO '.TBL_MENU.'
              , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PREFERENCES\'), 2, \'' . Uuid::uuid4() . '\', 0, 6, 1, \'orgprop\', \''.FOLDER_MODULES.'/preferences/preferences.php\', \'fa-cog\', \'SYS_SETTINGS\', \'ORG_ORGANIZATION_PROPERTIES_DESC\')
              , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MESSAGES\'), 1, \'' . Uuid::uuid4() . '\', 0, 4, 1, \'mail\', \''.FOLDER_MODULES.'/messages/messages_write.php\', \'fa-envelope\', \'SYS_EMAIL\', \'SYS_EMAIL_DESC\')
              , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'REGISTRATION\'), 2, \'' . Uuid::uuid4() . '\', 0, 1, 1, \'newreg\', \''.FOLDER_MODULES.'/registration/registration.php\', \'fa-address-card\', \'SYS_NEW_REGISTRATIONS\', \'SYS_MANAGE_NEW_REGISTRATIONS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MEMBERS\'), 2, \'' . Uuid::uuid4() . '\', 0, 2, 1, \'usrmgt\', \''.FOLDER_MODULES.'/members/members.php\', \'fa-users-cog\', \'SYS_USER_MANAGEMENT\', \'SYS_USER_MANAGEMENT_DESC\')
+             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MEMBERS\'), 2, \'' . Uuid::uuid4() . '\', 0, 2, 1, \'usrmgt\', \''.FOLDER_MODULES.'/members/members.php\', \'fa-users-cog\', \'SYS_MEMBERS\', \'SYS_MEMBERS_DESC\')
              , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MENU\'), 2, \'' . Uuid::uuid4() . '\', 0, 5, 1, \'menu\', \''.FOLDER_MODULES.'/menu/menu.php\', \'fa-stream\', \'SYS_MENU\', \'SYS_MENU_DESC\')';
 $db->query($sql);
 

--- a/adm_program/languages/da.xml
+++ b/adm_program/languages/da.xml
@@ -666,7 +666,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">Du kan oprette den nye bruger hvis brugeren ikke allerede findes i bruger listen.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Opret relation</string>
   <string name="SYS_CREATE_ROLE">Opret rolle</string>
-  <string name="SYS_CREATE_USER">Opret bruger</string>
+  <string name="SYS_CREATE_MEMBER">Opret bruger</string>
   <string name="SYS_CREATE_VAR">Opret #VAR1#</string>
   <string name="SYS_CREATED_BY">Oprettet af #VAR1# den #VAR2#</string>
   <string name="SYS_CREATION_DATE">Oprettet den</string>
@@ -832,7 +832,7 @@
   <string name="SYS_EXAMPLES">Eksempler</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Eksisterende bruger</string>
+  <string name="SYS_EXISTING_MEMBERS">Eksisterende bruger</string>
   <string name="SYS_EXPORT_LISTS">‎Eksportere lister‎</string>
   <string name="SYS_EXPORT_LISTS_DESC">‎Lister over grupper og roller kan eksporteres af brugere, forudsat at du har ret til at få vist disse lister. Denne indstilling kan bruges til at begrænse eksportfunktionen. (Standard: Alle)‎</string>
   <string name="SYS_EXPORT_TO">Eksport til</string>
@@ -925,7 +925,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">‎Regnearket #VAR1# findes ikke i den importerede fil!‎</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Importen forløb succesfuldt..\n\n#VAR1# nye brugere er blevet oprettet.\n#VAR2# Brugere er blevet rettet.\n#VAR3# rolle medlemskaber er blevet tildelt.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">‎Følgende kolonner i importfilen er ikke tildelt noget profilfelt:‎</string>
-  <string name="SYS_IMPORT_USERS">Importer bruger(e)</string>
+  <string name="SYS_IMPORT_MEMBERS">Importer bruger(e)</string>
   <string name="SYS_IMPRINT">Aftryk</string>
   <string name="SYS_IMPRINT_DESC">Her kan URL\'en til dit indtryk af din side deponeres. Hvis det valgte tema understøtter dette, vises et link på Admidio-siderne. (Eksempel: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Inaktive grupper og roller</string>
@@ -1402,8 +1402,8 @@
   <string name="SYS_USER_FOUND">Bruger fundet</string>
   <string name="SYS_USER_ID_NOT_FOUND">Der kunne ikke findes nogen bruger med dette ID!</string>
   <string name="SYS_USER_MANAGEMENT">Bruger Administration</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">‎En af de konfigurationer, der er angivet her, kan bruges til at få vist brugeradministrationen. Kolonnerne i den valgte listekonfiguration vises derefter i brugeradministrationen.‎</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Vis og organiser alle aktive og tidligere medlemmer her. Nye brugere kan oprettes eller importeres fra CSV fil.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">‎En af de konfigurationer, der er angivet her, kan bruges til at få vist brugeradministrationen. Kolonnerne i den valgte listekonfiguration vises derefter i brugeradministrationen.‎</string>
+  <string name="SYS_MEMBERS_DESC">Vis og organiser alle aktive og tidligere medlemmer her. Nye brugere kan oprettes eller importeres fra CSV fil.</string>
   <string name="SYS_USER_NO_EMAIL">Brugeren #VAR1_BOLD# har ikke nogen gyldig e-mail adresse i sin personlige information!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Denne bruger er ikke medlem af organisationen #VAR1# endnu.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Brugeren er ikke medlem af organisationen #VAR1#, men er i besiddelse af et login.</string>

--- a/adm_program/languages/de-DE.xml
+++ b/adm_program/languages/de-DE.xml
@@ -337,7 +337,7 @@
   <string name="ORG_SHOW_CREATE_EDIT">Ersteller und Zeitstempel anzeigen</string>
   <string name="ORG_SHOW_CREATE_EDIT_DESC">An einigen Stellen wird die Erstellerin bzw. der Ersteller zusammen mit der Benutzerin bzw. der Benutzer mit der letzten Änderung zu einem Datensatz zusammen mit einem Zeitstempel angezeigt. Mit dieser Einstellung kann festgelegt werden, ob diese Informationen überhaupt angezeigt werden und ob die Benutzerin oder der Benutzer mit dem Anmeldenamen oder mit ihrem Vor- und Nachnamen angezeigt werden soll.</string>
   <string name="ORG_SHOW_ALL_USERS">Optional alle Benutzer:innen anzeigen</string>
-  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Einstellung gesetzt, so werden in der Benutzerverwaltung neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen angezeigt. Wird die Einstellung deaktiviert, werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Benutzer:innen oder Zuordnen von Anmeldungen wird allerdings weiterhin im gesamten Datenbestand aller Organisationen nach bereits existierenden Benutzerinnen und Benutzern geschaut.</string>
+  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Einstellung gesetzt, so werden in der Mitgliederverwaltung neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen angezeigt. Wird die Einstellung deaktiviert, werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Benutzer:innen oder Zuordnen von Anmeldungen wird allerdings weiterhin im gesamten Datenbestand aller Organisationen nach bereits existierenden Benutzerinnen und Benutzern geschaut.</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT">Organisationsauswahl anzeigen</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT_DESC">Sind mehrere Organisationen in der Datenbank eingerichtet, so kann im Anmeldedialog eine Auswahlbox mit allen Organisationen angezeigt werden. Die Benutzerin oder der Benutzer kann dort eine andere Organisation (als in der config.php eingestellt) auswählen, an der er sich anmeldet. Allerdings muss die Benutzerin oder der Benutzer auch an der dieser Organisation registriert sein.</string>
   <string name="ORG_SYSTEM_INFORMATION">Systeminformationen</string>
@@ -666,7 +666,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">Falls die neue Benutzerin bzw. der neue Benutzer nicht unter den gefundenen Daten aufgelistet ist, können Sie diesen neu anlegen.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Beziehung anlegen</string>
   <string name="SYS_CREATE_ROLE">Rolle anlegen</string>
-  <string name="SYS_CREATE_USER">Benutzer:in anlegen</string>
+  <string name="SYS_CREATE_MEMBER">Mitglied anlegen</string>
   <string name="SYS_CREATE_VAR">#VAR1# anlegen</string>
   <string name="SYS_CREATED_BY">Angelegt von #VAR1# am #VAR2#</string>
   <string name="SYS_CREATION_DATE">Erstellungsdatum</string>
@@ -832,7 +832,7 @@
   <string name="SYS_EXAMPLES">Beispiele</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Existierende Benutzer:innen</string>
+  <string name="SYS_EXISTING_MEMBERS">Existierende Mitglieder</string>
   <string name="SYS_EXPORT_LISTS">Listen exportieren</string>
   <string name="SYS_EXPORT_LISTS_DESC">Listen von Gruppen und Rollen können von Benutzerinnnen und Benutzern exportiert werden, sofern sie das Recht haben diese Listen zu sehen. Mit dieser Einstellung kann die Exportfunktion eingeschränkt werden. (Voreinstellung: Alle)</string>
   <string name="SYS_EXPORT_TO">Exportieren nach</string>
@@ -925,7 +925,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">Das Arbeitsblatt #VAR1# existiert in der importierten Datei nicht!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Der Import ist erfolgreich verlaufen.\n\n#VAR1# neue Benutzer:innen wurden angelegt.\n#VAR2# Benutzer:innen wurden bearbeitet.\n#VAR3# Rollenmitgliedschaften wurden zugeordnet.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">Folgende Spalten der Importdatei sind keinen Feldern in Admidio zugeordnet:</string>
-  <string name="SYS_IMPORT_USERS">Benutzer:innen importieren</string>
+  <string name="SYS_IMPORT_MEMBERS">Mitglieder importieren</string>
   <string name="SYS_IMPRINT">Impressum</string>
   <string name="SYS_IMPRINT_DESC">Hier kann die URL zum Impressum deiner Seite hinterlegt werden. Sofern das gewählte Theme dies unterstützt, wird ein Link auf den Admidio-Seiten angezeigt. (Beispiel: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Inaktive Gruppen und Rollen</string>
@@ -1203,7 +1203,7 @@
   <string name="SYS_RIGHT_DOCUMENTS_FILES">Dokumente und Dateien verwalten</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES_DESC">Rollen mit dieser Berechtigung können im Modul für Dokumente und Dateien die Rechte vergeben, welche Rollen bestimme Ordner sehen oder Dateien hochladen dürfen.</string>
   <string name="SYS_RIGHT_EDIT_USER">Profildaten aller Benutzer:innen bearbeiten</string>
-  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Benutzerverwaltung und können dort Benutzer:innen anlegen oder löschen.</string>
+  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Mitgliederverwaltung und können dort Benutzer:innen anlegen oder löschen.</string>
   <string name="SYS_RIGHT_GUESTBOOK">Gästebucheinträge bearbeiten und löschen</string>
   <string name="SYS_RIGHT_GUESTBOOK_COMMENTS">Kommentare zu Gästebucheinträgen anlegen</string>
   <string name="SYS_RIGHT_MAIL_THIS_ROLE_DESC">Diese Einstellung steuert, wer das Recht hat über das Nachrichtenmodul E-Mails an diese Rolle zu versenden. Das Rollenrecht #VAR1_BOLD# steht allerdings noch über dieser Einstellung.</string>
@@ -1310,7 +1310,7 @@
   <string name="SYS_SET_FOLDER_PERMISSIONS">Ordnerberechtigungen setzen</string>
   <string name="SYS_SETTINGS">Einstellungen</string>
   <string name="SYS_SHOW_ALL_USERS">Alle Benutzer:innen anzeigen</string>
-  <string name="SYS_SHOW_ALL_USERS_DESC">Ist die Einstellung nicht gesetzt werden nur die aktiven Mitglieder dieser Organisation angezeigt. ist die Einstellung aktiviert werden alle Benutzer:innen der Datenbank angezeigt.</string>
+  <string name="SYS_SHOW_ALL_USERS_DESC">Bei gesetzter Einstellung werden neben den aktiven Mitgliedern dieser Organisation auch ehemalige Mitglieder, sowie Mitglieder anderer Organisationen angezeigt.</string>
   <string name="SYS_SHOW_CALENDAR">Kalender anzeigen</string>
   <string name="SYS_SHOW_CAPTCHA_DESC">Für nicht angemeldete Benutzer:innen wird im E-Mailformular bei aktiviertem Captcha ein alphanumerischer Code eingeblendet. Diesen muss die Benutzerin oder der Benutzer vor dem E-Mailversand korrekt eingeben. Dies soll sicherstellen, dass das Formular nicht von Spammern missbraucht werden kann. (Voreinstellung: ja)</string>
   <string name="SYS_SHOW_FORMER_MEMBERS">Zeige ehemalige Mitglieder</string>
@@ -1402,8 +1402,8 @@
   <string name="SYS_USER_FOUND">Gefundene Benutzer:innen</string>
   <string name="SYS_USER_ID_NOT_FOUND">Es konnte kein:e Benutzer:in zu der übergebenen ID gefunden werden!</string>
   <string name="SYS_USER_MANAGEMENT">Benutzerverwaltung</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Benutzerverwaltung genutzt werden. Es werden anschließend in der Benutzerverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Alle aktiven und ehemaligen Benutzer:innen können hier eingesehen und verwaltet werden. Neue Benutzer:innen können angelegt oder importiert werden.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Mitgliederverwaltung genutzt werden. Es werden anschließend in der Mitgliederverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>
+  <string name="SYS_MEMBERS_DESC">Alle aktiven und ehemaligen Mitglieder können hier eingesehen und verwaltet werden. Neue Mitglieder können angelegt oder importiert werden.</string>
   <string name="SYS_USER_NO_EMAIL">#VAR1_BOLD# hat keine gültige E-Mail-Adresse in seinem Profil hinterlegt!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Diese:r Benutzer:in ist noch kein Mitglied der Organisation #VAR1#.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Diese:r Benutzer:in ist noch kein Mitglied der Organisation #VAR1#, besitzt aber bereits Zugangsdaten.</string>

--- a/adm_program/languages/de-DE.xml
+++ b/adm_program/languages/de-DE.xml
@@ -337,7 +337,7 @@
   <string name="ORG_SHOW_CREATE_EDIT">Ersteller und Zeitstempel anzeigen</string>
   <string name="ORG_SHOW_CREATE_EDIT_DESC">An einigen Stellen wird die Erstellerin bzw. der Ersteller zusammen mit der Benutzerin bzw. der Benutzer mit der letzten Änderung zu einem Datensatz zusammen mit einem Zeitstempel angezeigt. Mit dieser Einstellung kann festgelegt werden, ob diese Informationen überhaupt angezeigt werden und ob die Benutzerin oder der Benutzer mit dem Anmeldenamen oder mit ihrem Vor- und Nachnamen angezeigt werden soll.</string>
   <string name="ORG_SHOW_ALL_USERS">Optional alle Benutzer:innen anzeigen</string>
-  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Einstellung gesetzt, so werden in der Mitgliederverwaltung neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen angezeigt. Wird die Einstellung deaktiviert, werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Benutzer:innen oder Zuordnen von Anmeldungen wird allerdings weiterhin im gesamten Datenbestand aller Organisationen nach bereits existierenden Benutzerinnen und Benutzern geschaut.</string>
+  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Option gesetzt, können neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen in der Mitgliederverwaltung angezeigt werden. Ansonsten werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Mitglieder oder beim Zuordnen von Registrierungen wird jedoch weiterhin in der gesamten Datenbank aller Organisationen nach vorhandenen Benutzern gesucht.</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT">Organisationsauswahl anzeigen</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT_DESC">Sind mehrere Organisationen in der Datenbank eingerichtet, so kann im Anmeldedialog eine Auswahlbox mit allen Organisationen angezeigt werden. Die Benutzerin oder der Benutzer kann dort eine andere Organisation (als in der config.php eingestellt) auswählen, an der er sich anmeldet. Allerdings muss die Benutzerin oder der Benutzer auch an der dieser Organisation registriert sein.</string>
   <string name="ORG_SYSTEM_INFORMATION">Systeminformationen</string>
@@ -1202,8 +1202,8 @@
   <string name="SYS_RIGHT_DATES">Termine verwalten</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES">Dokumente und Dateien verwalten</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES_DESC">Rollen mit dieser Berechtigung können im Modul für Dokumente und Dateien die Rechte vergeben, welche Rollen bestimme Ordner sehen oder Dateien hochladen dürfen.</string>
-  <string name="SYS_RIGHT_EDIT_USER">Profildaten aller Benutzer:innen bearbeiten</string>
-  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Mitgliederverwaltung und können dort Benutzer:innen anlegen oder löschen.</string>
+  <string name="SYS_RIGHT_EDIT_USER">Profildaten aller Mitglieder bearbeiten</string>
+  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Mitgliederverwaltung und können dort Mitglieder anlegen oder löschen.</string>
   <string name="SYS_RIGHT_GUESTBOOK">Gästebucheinträge bearbeiten und löschen</string>
   <string name="SYS_RIGHT_GUESTBOOK_COMMENTS">Kommentare zu Gästebucheinträgen anlegen</string>
   <string name="SYS_RIGHT_MAIL_THIS_ROLE_DESC">Diese Einstellung steuert, wer das Recht hat über das Nachrichtenmodul E-Mails an diese Rolle zu versenden. Das Rollenrecht #VAR1_BOLD# steht allerdings noch über dieser Einstellung.</string>
@@ -1418,7 +1418,7 @@
   <string name="SYS_USERNAME_OR_EMAIL">Anmeldename oder E-Mail</string>
   <string name="SYS_USERNAME_WITH_TIMESTAMP">#VAR1# am #VAR2# um #VAR3#</string>
   <string name="SYS_USERS_PER_PAGE">Anzahl Benutzer:innen pro Seite</string>
-  <string name="SYS_USERS_PER_PAGE_DESC">Die Anzahl Benutzer:innen die auf einer Seite in einer Liste aufgelistet werden. Gibt es mehr Benutzer:innen zu der Organisation, so kann man in der Liste blättern. (Voreinstellung: 25)</string>
+  <string name="SYS_USERS_PER_PAGE_DESC">Die Anzahl der Mitglieder die auf einer Seite in einer Mitgliederverwaltung aufgelistet werden. Gibt es mehr Mitglieder zu der Organisation, so kann man innerhalb der Übersicht blättern. (Voreinstellung: 25)</string>
   <string name="SYS_USING_CURRENT_VERSION">Sie benutzen eine aktuelle #VAR1#Version von Admidio!</string>
   <string name="SYS_UTF8">UTF-8</string>
   <string name="SYS_UTF16BE">UTF-16BE</string>

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -337,7 +337,7 @@
   <string name="ORG_SHOW_CREATE_EDIT">Ersteller und Zeitstempel anzeigen</string>
   <string name="ORG_SHOW_CREATE_EDIT_DESC">An einigen Stellen wird die Erstellerin bzw. der Ersteller zusammen mit der Benutzerin bzw. der Benutzer mit der letzten Änderung zu einem Datensatz zusammen mit einem Zeitstempel angezeigt. Mit dieser Einstellung kann festgelegt werden, ob diese Informationen überhaupt angezeigt werden und ob die Benutzerin oder der Benutzer mit dem Anmeldenamen oder mit ihrem Vor- und Nachnamen angezeigt werden soll.</string>
   <string name="ORG_SHOW_ALL_USERS">Optional alle Benutzer:innen anzeigen</string>
-  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Einstellung gesetzt, so werden in der Benutzerverwaltung neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen angezeigt. Wird die Einstellung deaktiviert, werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Benutzer:innen oder Zuordnen von Anmeldungen wird allerdings weiterhin im gesamten Datenbestand aller Organisationen nach bereits existierenden Benutzer:innen geschaut.</string>
+  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Einstellung gesetzt, so werden in der Mitgliederverwaltung neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen angezeigt. Wird die Einstellung deaktiviert, werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Benutzer:innen oder Zuordnen von Anmeldungen wird allerdings weiterhin im gesamten Datenbestand aller Organisationen nach bereits existierenden Benutzer:innen geschaut.</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT">Organisationsauswahl anzeigen</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT_DESC">Sind mehrere Organisationen in der Datenbank eingerichtet, so kann im Anmeldedialog eine Auswahlbox mit allen Organisationen angezeigt werden. Die Benutzerin oder der Benutzer kann dort eine andere Organisation (als in der config.php eingestellt) auswählen, an der er sich anmeldet. Allerdings muss die Benutzerin oder der Benutzer auch an der dieser Organisation registriert sein.</string>
   <string name="ORG_SYSTEM_INFORMATION">Systeminformationen</string>
@@ -661,12 +661,12 @@
   <string name="SYS_CREATE_FOLDER_DESC">Der neue Ordner wird im bestehenden Ordner #VAR1_BOLD# angelegt.</string>
   <string name="SYS_CREATE_HTACCESS">.htaccess erstellen</string>
   <string name="SYS_CREATE_LINK">Link anlegen</string>
+  <string name="SYS_CREATE_MEMBER">Mitglied anlegen</string>
   <string name="SYS_CREATE_NEW_CONFIGURATION">Neue Konfiguration erstellen</string>
   <string name="SYS_CREATE_NEW_USER">Neue:n Benutzer:in anlegen</string>
   <string name="SYS_CREATE_NOT_FOUND_USER">Falls die neue Benutzerin bzw. der neue Benutzer nicht unter den gefundenen Daten aufgelistet ist, kannst du diese:n neu anlegen.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Beziehung anlegen</string>
   <string name="SYS_CREATE_ROLE">Rolle anlegen</string>
-  <string name="SYS_CREATE_USER">Benutzer:in anlegen</string>
   <string name="SYS_CREATE_VAR">#VAR1# anlegen</string>
   <string name="SYS_CREATED_BY">Angelegt von #VAR1# am #VAR2#</string>
   <string name="SYS_CREATION_DATE">Erstellungsdatum</string>
@@ -832,7 +832,7 @@
   <string name="SYS_EXAMPLES">Beispiele</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Existierende Benutzer:innen</string>
+  <string name="SYS_EXISTING_MEMBERS">Existierende Mitglieder</string>
   <string name="SYS_EXPORT_LISTS">Listen exportieren</string>
   <string name="SYS_EXPORT_LISTS_DESC">Listen von Gruppen und Rollen können von Benutzerinnen und Benutzern exportiert werden, sofern sie das Recht haben diese Listen zu sehen. Mit dieser Einstellung kann die Exportfunktion eingeschränkt werden. (Voreinstellung: Alle)</string>
   <string name="SYS_EXPORT_TO">Exportieren nach</string>
@@ -925,7 +925,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">Das Arbeitsblatt #VAR1# existiert in der importierten Datei nicht!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Der Import ist erfolgreich verlaufen.\n\n#VAR1# neue Benutzer:innen wurden angelegt.\n#VAR2# Benutzer:innen wurden bearbeitet.\n#VAR3# Rollenmitgliedschaften wurden zugeordnet.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">Folgende Spalten der Importdatei sind keinen Feldern in Admidio zugeordnet:</string>
-  <string name="SYS_IMPORT_USERS">Benutzer:innen importieren</string>
+  <string name="SYS_IMPORT_MEMBERS">Mitglieder importieren</string>
   <string name="SYS_IMPRINT">Impressum</string>
   <string name="SYS_IMPRINT_DESC">Hier kann die URL zum Impressum deiner Seite hinterlegt werden. Sofern das gewählte Theme dies unterstützt, wird ein Link auf den Admidio-Seiten angezeigt. (Beispiel: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Inaktive Gruppen und Rollen</string>
@@ -1203,7 +1203,7 @@
   <string name="SYS_RIGHT_DOCUMENTS_FILES">Dokumente und Dateien verwalten</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES_DESC">Rollen mit dieser Berechtigung können im Modul für Dokumente und Dateien die Rechte vergeben, welche Rollen bestimme Ordner sehen oder Dateien hochladen dürfen.</string>
   <string name="SYS_RIGHT_EDIT_USER">Profildaten aller Benutzer:innen bearbeiten</string>
-  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Benutzerverwaltung und können dort Benutzer:innen anlegen oder löschen.</string>
+  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Mitgliederverwaltung und können dort Benutzer:innen anlegen oder löschen.</string>
   <string name="SYS_RIGHT_GUESTBOOK">Gästebucheinträge bearbeiten und löschen</string>
   <string name="SYS_RIGHT_GUESTBOOK_COMMENTS">Kommentare zu Gästebucheinträgen anlegen</string>
   <string name="SYS_RIGHT_MAIL_THIS_ROLE_DESC">Diese Einstellung steuert, wer das Recht hat über das Nachrichtenmodul E-Mails an diese Rolle zu versenden. Das Rollenrecht #VAR1_BOLD# steht allerdings noch über dieser Einstellung.</string>
@@ -1310,7 +1310,7 @@
   <string name="SYS_SET_FOLDER_PERMISSIONS">Ordnerberechtigungen setzen</string>
   <string name="SYS_SETTINGS">Einstellungen</string>
   <string name="SYS_SHOW_ALL_USERS">Alle Benutzer:innen anzeigen</string>
-  <string name="SYS_SHOW_ALL_USERS_DESC">Ist die Einstellung nicht gesetzt werden nur die aktiven Mitglieder dieser Organisation angezeigt. ist die Einstellung aktiviert werden alle Benutzer:innen der Datenbank angezeigt.</string>
+  <string name="SYS_SHOW_ALL_USERS_DESC">Bei gesetzter Einstellung werden neben den aktiven Mitgliedern dieser Organisation auch ehemalige Mitglieder, sowie Mitglieder anderer Organisationen angezeigt.</string>
   <string name="SYS_SHOW_CALENDAR">Kalender anzeigen</string>
   <string name="SYS_SHOW_CAPTCHA_DESC">Für nicht angemeldete Benutzer:innen wird im E-Mailformular bei aktiviertem Captcha ein alphanumerischer Code eingeblendet. Diesen muss die Benutzerin oder der Benutzer vor dem E-Mailversand korrekt eingeben. Dies soll sicherstellen, dass das Formular nicht von Spammern missbraucht werden kann. (Voreinstellung: ja)</string>
   <string name="SYS_SHOW_FORMER_MEMBERS">Zeige ehemalige Mitglieder</string>
@@ -1402,8 +1402,8 @@
   <string name="SYS_USER_FOUND">Gefundene Benutzer:innen</string>
   <string name="SYS_USER_ID_NOT_FOUND">Es konnte kein:e Benutzer:in zu der übergebenen ID gefunden werden!</string>
   <string name="SYS_USER_MANAGEMENT">Benutzerverwaltung</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Benutzerverwaltung genutzt werden. Es werden anschließend in der Benutzerverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Alle aktiven und ehemaligen Benutzer:innen können hier eingesehen und verwaltet werden. Neue Benutzer:innen können angelegt oder importiert werden.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Mitgliederverwaltung genutzt werden. Es werden anschließend in der Mitgliederverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>
+  <string name="SYS_MEMBERS_DESC">Alle aktiven und ehemaligen Mitglieder können hier eingesehen und verwaltet werden. Neue Mitglieder können angelegt oder importiert werden.</string>
   <string name="SYS_USER_NO_EMAIL">#VAR1_BOLD# hat keine gültige E-Mail-Adresse in seinem Profil hinterlegt!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Diese:r Benutzer:in ist noch kein Mitglied der Organisation #VAR1#.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Diese:r Benutzer:in ist noch kein Mitglied der Organisation #VAR1#, besitzt aber bereits Zugangsdaten.</string>

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -337,7 +337,7 @@
   <string name="ORG_SHOW_CREATE_EDIT">Ersteller und Zeitstempel anzeigen</string>
   <string name="ORG_SHOW_CREATE_EDIT_DESC">An einigen Stellen wird die Erstellerin bzw. der Ersteller zusammen mit der Benutzerin bzw. der Benutzer mit der letzten Änderung zu einem Datensatz zusammen mit einem Zeitstempel angezeigt. Mit dieser Einstellung kann festgelegt werden, ob diese Informationen überhaupt angezeigt werden und ob die Benutzerin oder der Benutzer mit dem Anmeldenamen oder mit ihrem Vor- und Nachnamen angezeigt werden soll.</string>
   <string name="ORG_SHOW_ALL_USERS">Optional alle Benutzer:innen anzeigen</string>
-  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Einstellung gesetzt, so werden in der Mitgliederverwaltung neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen angezeigt. Wird die Einstellung deaktiviert, werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Benutzer:innen oder Zuordnen von Anmeldungen wird allerdings weiterhin im gesamten Datenbestand aller Organisationen nach bereits existierenden Benutzer:innen geschaut.</string>
+  <string name="ORG_SHOW_ALL_USERS_DESC">Ist diese Option gesetzt, können neben den aktiven Mitgliedern der aktuellen Organisation optional auch ehemalige Mitglieder und Mitglieder anderer Organisationen in der Mitgliederverwaltung angezeigt werden. Ansonsten werden nur aktive Mitglieder der aktuellen Organisation angezeigt. Beim Anlegen neuer Mitglieder oder beim Zuordnen von Registrierungen wird jedoch weiterhin in der gesamten Datenbank aller Organisationen nach vorhandenen Benutzern gesucht.</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT">Organisationsauswahl anzeigen</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT_DESC">Sind mehrere Organisationen in der Datenbank eingerichtet, so kann im Anmeldedialog eine Auswahlbox mit allen Organisationen angezeigt werden. Die Benutzerin oder der Benutzer kann dort eine andere Organisation (als in der config.php eingestellt) auswählen, an der er sich anmeldet. Allerdings muss die Benutzerin oder der Benutzer auch an der dieser Organisation registriert sein.</string>
   <string name="ORG_SYSTEM_INFORMATION">Systeminformationen</string>
@@ -1202,8 +1202,8 @@
   <string name="SYS_RIGHT_DATES">Termine verwalten</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES">Dokumente und Dateien verwalten</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES_DESC">Rollen mit dieser Berechtigung können im Modul für Dokumente und Dateien die Rechte vergeben, welche Rollen bestimme Ordner sehen oder Dateien hochladen dürfen.</string>
-  <string name="SYS_RIGHT_EDIT_USER">Profildaten aller Benutzer:innen bearbeiten</string>
-  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Mitgliederverwaltung und können dort Benutzer:innen anlegen oder löschen.</string>
+  <string name="SYS_RIGHT_EDIT_USER">Profildaten aller Mitglieder bearbeiten</string>
+  <string name="SYS_RIGHT_EDIT_USER_DESC">Rollen mit dieser Berechtigung können alle Profildaten (außer Passwörter) anderer Mitglieder bearbeiten.\nAußerdem haben sie Zugriff auf die Mitgliederverwaltung und können dort Mitglieder anlegen oder löschen.</string>
   <string name="SYS_RIGHT_GUESTBOOK">Gästebucheinträge bearbeiten und löschen</string>
   <string name="SYS_RIGHT_GUESTBOOK_COMMENTS">Kommentare zu Gästebucheinträgen anlegen</string>
   <string name="SYS_RIGHT_MAIL_THIS_ROLE_DESC">Diese Einstellung steuert, wer das Recht hat über das Nachrichtenmodul E-Mails an diese Rolle zu versenden. Das Rollenrecht #VAR1_BOLD# steht allerdings noch über dieser Einstellung.</string>
@@ -1417,8 +1417,8 @@
   <string name="SYS_USERNAME">Anmeldename</string>
   <string name="SYS_USERNAME_OR_EMAIL">Anmeldename oder E-Mail</string>
   <string name="SYS_USERNAME_WITH_TIMESTAMP">#VAR1# am #VAR2# um #VAR3#</string>
-  <string name="SYS_USERS_PER_PAGE">Anzahl Benutzer:innen pro Seite</string>
-  <string name="SYS_USERS_PER_PAGE_DESC">Die Anzahl Benutzer:innen die auf einer Seite in einer Liste aufgelistet werden. Gibt es mehr Benutzer:innen zu der Organisation, so kann man in der Liste blättern. (Voreinstellung: 25)</string>
+  <string name="SYS_USERS_PER_PAGE">Anzahl Mitglieder pro Seite</string>
+  <string name="SYS_USERS_PER_PAGE_DESC">Die Anzahl der Mitglieder die auf einer Seite in einer Mitgliederverwaltung aufgelistet werden. Gibt es mehr Mitglieder zu der Organisation, so kann man innerhalb der Übersicht blättern. (Voreinstellung: 25)</string>
   <string name="SYS_USING_CURRENT_VERSION">Du benutzt eine aktuelle #VAR1#Version von Admidio!</string>
   <string name="SYS_UTF8">UTF-8</string>
   <string name="SYS_UTF16BE">UTF-16BE</string>

--- a/adm_program/languages/el.xml
+++ b/adm_program/languages/el.xml
@@ -666,7 +666,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">Εάν ο νέος χρήστης δεν περιλαμβάνεται στους χρήστες που βρέθηκαν, μπορείτε να τον δημιουργήσετε.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Δημιουργία σχέσης</string>
   <string name="SYS_CREATE_ROLE">Δημιουργία ρόλου</string>
-  <string name="SYS_CREATE_USER">Δημιουργία χρήστη</string>
+  <string name="SYS_CREATE_MEMBER">Δημιουργία χρήστη</string>
   <string name="SYS_CREATE_VAR">Δημιουργία #VAR1#</string>
   <string name="SYS_CREATED_BY">Δημιουργήθηκε από #VAR1# σε #VAR2#</string>
   <string name="SYS_CREATION_DATE">Δημιουργήθηκε στις</string>
@@ -831,7 +831,7 @@
   <string name="SYS_EXAMPLES">Παραδείγματα</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Υπάρχων χρήστης</string>
+  <string name="SYS_EXISTING_MEMBERS">Υπάρχων χρήστης</string>
   <string name="SYS_EXPORT_LISTS">Εξαγωγή λιστών</string>
   <string name="SYS_EXPORT_LISTS_DESC">Οι λίστες ομάδων και ρόλων μπορούν να εξαχθούν από τους χρήστες, υπό την προϋπόθεση ότι έχετε το δικαίωμα να προβάλετε αυτές τις λίστες. Αυτή η ρύθμιση μπορεί να χρησιμοποιηθεί για τον περιορισμό της λειτουργίας εξαγωγής. (Default: All)</string>
   <string name="SYS_EXPORT_TO">Εξαγωγή σε</string>
@@ -924,7 +924,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">Το φύλλο εργασίας #VAR1# δεν υπάρχει στο εισαγόμενο αρχείο!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Η εισαγωγή ήταν επιτυχής..\n\n#VAR1# δημιουργήθηκαν νέοι χρήστες.\nΈγινε επεξεργασία των χρηστών #VAR2#.\nΈχουν εκχωρηθεί συνδρομές ρόλων#VAR3#.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">Στις ακόλουθες στήλες του αρχείου εισαγωγής δεν εκχωρούνται πεδία προφίλ:</string>
-  <string name="SYS_IMPORT_USERS">Εισαγωγή χρήστη(ών)</string>
+  <string name="SYS_IMPORT_MEMBERS">Εισαγωγή χρήστη(ών)</string>
   <string name="SYS_IMPRINT">Αποτύπωμα</string>
   <string name="SYS_IMPRINT_DESC">Εδώ μπορεί να κατατεθεί η διεύθυνση URL για το αποτύπωμα της σελίδας σας. Εάν το επιλεγμένο θέμα το υποστηρίζει, θα εμφανιστεί ένας σύνδεσμος στις σελίδες Admidio. (Παράδειγμα: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Ανενεργά γκρουπ και ρόλοι</string>
@@ -1400,8 +1400,8 @@
   <string name="SYS_USER_FOUND">Βρέθηκε μέλος</string>
   <string name="SYS_USER_ID_NOT_FOUND">Δεν υπάρχει μέλος με αυτό το ID!</string>
   <string name="SYS_USER_MANAGEMENT">Διαχείριση μελών</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">Μία από τις διαμορφώσεις που καθορίζονται εδώ μπορεί να χρησιμοποιηθεί για την εμφάνιση της διαχείρισης του μέλους. Στη συνέχεια, οι στήλες της διαμόρφωσης της επιλεγμένης λίστας εμφανίζονται στη διαχείριση μέλους.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Προβολή και οργάνωση ενεργών και πρώην μελών. Νέοι χρήστες μπορούν να εισαχθούν ή να δημιουργηθούν.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">Μία από τις διαμορφώσεις που καθορίζονται εδώ μπορεί να χρησιμοποιηθεί για την εμφάνιση της διαχείρισης του μέλους. Στη συνέχεια, οι στήλες της διαμόρφωσης της επιλεγμένης λίστας εμφανίζονται στη διαχείριση μέλους.</string>
+  <string name="SYS_MEMBERS_DESC">Προβολή και οργάνωση ενεργών και πρώην μελών. Νέοι χρήστες μπορούν να εισαχθούν ή να δημιουργηθούν.</string>
   <string name="SYS_USER_NO_EMAIL">Ο χρήστης #VAR1_BOLD# δεν έχει έγκυρη διεύθυνση e-mail στις προσωπικές πληροφορίες!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Ο χρήστης δεν είναι μέλος του συλλόγου #VAR1# ακόμη.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Ο χρήστης δεν είναι μέλος του συλλόγου #VAR1# αλλά έχει καταχωρημένα στοιχεία σύνδεσης.</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -661,12 +661,12 @@
   <string name="SYS_CREATE_FOLDER_DESC">A new folder will be created in folder #VAR1_BOLD#.</string>
   <string name="SYS_CREATE_HTACCESS">Create .htaccess</string>
   <string name="SYS_CREATE_LINK">Create new link</string>
+  <string name="SYS_CREATE_MEMBER">Create member</string>
   <string name="SYS_CREATE_NEW_CONFIGURATION">Create a new configuration</string>
   <string name="SYS_CREATE_NEW_USER">Add new user</string>
   <string name="SYS_CREATE_NOT_FOUND_USER">If the new user is not listed among the users found, you can create it.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Create relationship</string>
   <string name="SYS_CREATE_ROLE">Create role</string>
-  <string name="SYS_CREATE_USER">Create user</string>
   <string name="SYS_CREATE_VAR">Create #VAR1#</string>
   <string name="SYS_CREATED_BY">Created by #VAR1# on #VAR2#</string>
   <string name="SYS_CREATION_DATE">Created on</string>
@@ -832,7 +832,7 @@
   <string name="SYS_EXAMPLES">Examples</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Existing user</string>
+  <string name="SYS_EXISTING_MEMBERS">Existing members</string>
   <string name="SYS_EXPORT_LISTS">Export lists</string>
   <string name="SYS_EXPORT_LISTS_DESC">Lists of groups and roles can be exported by users, provided that you have the right to view these lists. This setting can be used to restrict the export function. (Default: All)</string>
   <string name="SYS_EXPORT_TO">Export to</string>
@@ -921,11 +921,11 @@
   <string name="SYS_IMPORTANT">Important</string>
   <string name="SYS_IMPORT">Import</string>
   <string name="SYS_IMPORT_LOGIN_DATA_DESC">Login data can only be imported by an administrator. The rules of the organization must be observed (e.g. password length and password strength). Users with already existing login data keep them. No login data will be overwritten by the import.</string>
+  <string name="SYS_IMPORT_MEMBERS">Import members</string>
   <string name="SYS_IMPORT_MODE">Import mode</string>
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">The worksheet #VAR1# does not exist in the imported file!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Import was successful..\n\n#VAR1# new users have been created.\n#VAR2# users have been edited.\n#VAR3# role memberships have been assigned.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">The following columns of the import file are not assigned any profile fields:</string>
-  <string name="SYS_IMPORT_USERS">Import user(s)</string>
   <string name="SYS_IMPRINT">Imprint</string>
   <string name="SYS_IMPRINT_DESC">Here the URL for the imprint of your page can be deposited. If the selected theme supports this, a link will be displayed on the Admidio pages. (Example: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Inactive groups and roles</string>
@@ -1013,6 +1013,8 @@
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Member of organization #VAR1#</string>
   <string name="SYS_MEMBERS">Members</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Members between #VAR1# and #VAR2#</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">One of the configurations specified here can be used to display the members administration. The columns of the selected list configuration are then displayed in the members administration.</string>
+  <string name="SYS_MEMBERS_DESC">Display and organize all active and former members here. New members can be imported or created.</string>
   <string name="SYS_MEMBERS_PER_PAGE">Members displayed per page</string>
   <string name="SYS_MEMBERS_PER_PAGE_DESC">Number of members listed in the HTML view. More members can be listed by using the pagination function. This value won\'t affect print preview and export functionality (Default: 25).</string>
   <string name="SYS_MEMBERSHIP_END">End of membership</string>
@@ -1310,7 +1312,7 @@
   <string name="SYS_SET_FOLDER_PERMISSIONS">Set folder permissions</string>
   <string name="SYS_SETTINGS">Preferences</string>
   <string name="SYS_SHOW_ALL_USERS">Show all users</string>
-  <string name="SYS_SHOW_ALL_USERS_DESC">Only active members of this organization will be listed if this option is not set. Otherwise all users of the database will be listed.</string>
+  <string name="SYS_SHOW_ALL_USERS_DESC">If this setting is set, former members as well as members of other organizations are displayed in addition to the active members of this organization.</string>
   <string name="SYS_SHOW_CALENDAR">Display calendar</string>
   <string name="SYS_SHOW_CAPTCHA_DESC">For logged out users an alphanumeric text will appear when captcha module is activated. The provided text has to be entered into the proper field. This should prevent abuse of the form by spammers. (default: yes)</string>
   <string name="SYS_SHOW_FORMER_MEMBERS">Show former members</string>
@@ -1401,9 +1403,6 @@
   <string name="SYS_USER_DELETE_DESC">Would you like to delete #VAR1_BOLD#?\n\nUser is going to be physically deleted in the database which makes later access impossible.</string>
   <string name="SYS_USER_FOUND">User found</string>
   <string name="SYS_USER_ID_NOT_FOUND">No user could be found with this ID!</string>
-  <string name="SYS_USER_MANAGEMENT">User management</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">One of the configurations specified here can be used to display the user administration. The columns of the selected list configuration are then displayed in the user administration.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Display and organize all active and former members here. New users can be imported or created.</string>
   <string name="SYS_USER_NO_EMAIL">User #VAR1_BOLD# has no valid e-mail address in personal information!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">This user is not a member of organization #VAR1# yet.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">User is not a member of organization #VAR1# but has already login data assigned.</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -337,7 +337,7 @@
   <string name="ORG_SHOW_CREATE_EDIT">Show creator and timestamp of creation</string>
   <string name="ORG_SHOW_CREATE_EDIT_DESC">In some places the creator and the user with the last change to a record is displayed together with a timestamp. This setting can be used to determine whether this information is displayed at all and whether the user should be displayed with the user name or with their first and last name.</string>
   <string name="ORG_SHOW_ALL_USERS">Optional show all users</string>
-  <string name="ORG_SHOW_ALL_USERS_DESC">If this option is enabled, former members and members of other organizations will be displayed in addition to the active members of the current organization. Otherwise only members of the current organization will be displayed. When creating new users or assigning registrations all organizations will still be checked for existing users.</string>
+  <string name="ORG_SHOW_ALL_USERS_DESC">If this option is set, former members and members of other organizations can optionally be displayed in the member administration in addition to the active members of the current organization. Otherwise only active members of the current organization are displayed. When creating new members or assigning registrations, however, the system will continue to look for existing users in the entire database of all organizations.</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT">Display organisation selection</string>
   <string name="ORG_SHOW_ORGANIZATION_SELECT_DESC">In case of several organizations stored in the database, the log-in screen is able to display a selection box with all available organizations. The user is then able at log in to select another organization (other than defined in the config.php). However, the user must be a registered member of the selected organization.</string>
   <string name="ORG_SYSTEM_INFORMATION">System informations</string>
@@ -1204,8 +1204,8 @@
   <string name="SYS_RIGHT_DATES">Manage events</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES">Manage documents and files</string>
   <string name="SYS_RIGHT_DOCUMENTS_FILES_DESC">Roles having this permission can manage the rights for the documents and files module. This includes who can see folders and can upload files.</string>
-  <string name="SYS_RIGHT_EDIT_USER">Edit profile of all users</string>
-  <string name="SYS_RIGHT_EDIT_USER_DESC">Roles having this permission can edit the data of other users (except passwords).\n In addition they have access to the user administration and can add or delete users.</string>
+  <string name="SYS_RIGHT_EDIT_USER">Edit profile of all members</string>
+  <string name="SYS_RIGHT_EDIT_USER_DESC">Roles having this permission can edit the data of other members (except passwords).\n In addition they have access to the members administration and can add or delete members.</string>
   <string name="SYS_RIGHT_GUESTBOOK">Edit and delete guestbook entries</string>
   <string name="SYS_RIGHT_GUESTBOOK_COMMENTS">Create comments of guestbook entries</string>
   <string name="SYS_RIGHT_MAIL_THIS_ROLE_DESC">This setting controls who has the right to send emails to this role via the message module. The role right #VAR1_BOLD# is still above this setting.</string>
@@ -1415,8 +1415,8 @@
   <string name="SYS_USERNAME">Username</string>
   <string name="SYS_USERNAME_OR_EMAIL">Username or E-mail</string>
   <string name="SYS_USERNAME_WITH_TIMESTAMP">#VAR1# on #VAR2# at #VAR3#</string>
-  <string name="SYS_USERS_PER_PAGE">Number of users per page</string>
-  <string name="SYS_USERS_PER_PAGE_DESC">Number of users listed on each page. If there are multiple members in this group pages can be turned. (Default: 25)</string>
+  <string name="SYS_USERS_PER_PAGE">Number of members per page</string>
+  <string name="SYS_USERS_PER_PAGE_DESC">The number of members listed on a page in a member management. If there are more members to the organization, you can scroll to the next page within the overview. (Default: 25)</string>
   <string name="SYS_USING_CURRENT_VERSION">You are using a current #VAR1#version of Admidio!</string>
   <string name="SYS_UTF8">UTF-8</string>
   <string name="SYS_UTF16BE">UTF-16BE</string>

--- a/adm_program/languages/es.xml
+++ b/adm_program/languages/es.xml
@@ -355,7 +355,7 @@
   <string name="SYS_CREATE_NEW_CONFIGURATION">Crear nueva configuración</string>
   <string name="SYS_CREATE_NEW_USER">Crear un nuevo Usuario</string>
   <string name="SYS_CREATE_ROLE">crear rol</string>
-  <string name="SYS_CREATE_USER">Crear usuario</string>
+  <string name="SYS_CREATE_MEMBER">Crear usuario</string>
   <string name="SYS_CREATION_DATE">Fecha de creación</string>
   <string name="SYS_CSV">CSV</string>
   <string name="SYS_DATABASE">Base de datos</string>
@@ -412,7 +412,7 @@
   <string name="SYS_END_MEMBERSHIP_OF_USER_OK">La membresía del usuario #VAR1_BOLD# en #VAR2_BOLD# fue cancelada exitosamente.</string>
   <string name="SYS_ERROR">Error</string>
   <string name="SYS_ERROR_DELETE_DEFAULT_LIST">La configuración de la lista #VAR1_BOLD# es la predeterminada para las listas en esta organización, y no puede ser borrada. En el módulo de preferencias, seleccione como predeterminada una configuración diferente a la actual y después intente borrar esta configuración.</string>
-  <string name="SYS_EXISTING_USERS">Usuario existente</string>
+  <string name="SYS_EXISTING_MEMBERS">Usuario existente</string>
   <string name="SYS_EXPORT_TO">Exportar a</string>
   <string name="SYS_FAX">Fax</string>
   <string name="SYS_FEMALE">Feminino</string>
@@ -465,7 +465,7 @@
   <string name="SYS_IMPORTANT">Importante</string>
   <string name="SYS_IMPORT">Importar</string>
   <string name="SYS_IMPORT_SUCCESSFUL">La importación fue exitosa. \n\n#VAR1# nuevos usuarios han sido creados. \n#VAR2# usuarios han sido editados.\nSe han asignado #VAR3# membresías de roles.</string>
-  <string name="SYS_IMPORT_USERS">Importar usuario</string>
+  <string name="SYS_IMPORT_MEMBERS">Importar usuario</string>
   <string name="SYS_INFOBOX" description="A small html box that will show additional informations">Infobox</string>
   <string name="SYS_INFORMATIONS">Informaciónes</string>
   <string name="SYS_INPUT_FIRSTNAME_LASTNAME">Por favor escriba el nombre y apellido del nuevo usuario. Antes de crearlo, se verifica si ya existe un usuario con un nombre similar o igual en la base de datos.</string>
@@ -732,7 +732,7 @@
   <string name="SYS_USER_DELETE_DESC">¿Realmente desea eliminar a #VAR1_BOLD#?\n\nEl usuario será eliminado de la base de datos, lo que impedirá el acceso posterior a su información.</string>
   <string name="SYS_USER_FOUND">Usuarios encontrados</string>
   <string name="SYS_USER_MANAGEMENT">Administración de usuarios</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Aquí se pueden administrar y ver Todos los usuarios activos y antiguos. Se pueden importar o crear nuevos usuarios.</string>
+  <string name="SYS_MEMBERS_DESC">Aquí se pueden administrar y ver Todos los usuarios activos y antiguos. Se pueden importar o crear nuevos usuarios.</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Este usuario aún no es miembro de la organización #VAR1#.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">El usuario no es un miembro de la organización #VAR1#, pero ya tiene asignada información de acceso.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_NO_LOGIN">El usuario no es miembro de la organización #VAR1# y no tiene registrada información de acceso.</string>

--- a/adm_program/languages/fi.xml
+++ b/adm_program/languages/fi.xml
@@ -652,7 +652,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">Jos uutta käyttäjää ei ole löydettyjen käyttäjien joukossa, voit luoda sen.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Luo suhde</string>
   <string name="SYS_CREATE_ROLE">Luo rooli</string>
-  <string name="SYS_CREATE_USER">Luo uusi käyttäjä</string>
+  <string name="SYS_CREATE_MEMBER">Luo uusi käyttäjä</string>
   <string name="SYS_CREATE_VAR">Luo #VAR1#</string>
   <string name="SYS_CREATED_BY">Tekijä #VAR1# on #VAR2#</string>
   <string name="SYS_CREATION_DATE">Luotu</string>
@@ -801,7 +801,7 @@
   <string name="SYS_EXAMPLES">Esimerkkejä</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Olemassa oleva käyttäjä</string>
+  <string name="SYS_EXISTING_MEMBERS">Olemassa oleva käyttäjä</string>
   <string name="SYS_EXPORT_LISTS">Vie luettelot</string>
   <string name="SYS_EXPORT_LISTS_DESC">Käyttäjät voivat viedä ryhmien ja roolien luetteloita, jos sinulla on oikeus tarkastella näitä luetteloita. Tätä asetusta voidaan käyttää vientitoiminnon rajoittamiseen. (Oletus: Kaikki)</string>
   <string name="SYS_EXPORT_TO">Vie muotoon</string>
@@ -892,7 +892,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">Laskentataulukkoa #VAR1# ei ole tuodussa tiedostossa!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Tuonti onnistui .. \n\n#VAR1# uutta käyttäjää on luotu. \n#VAR2# käyttäjää on muokattu. \n#VAR3# roolijäseniä.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">Seuraaville tuontitiedoston sarakkeille ei ole määritetty profiilikenttiä:</string>
-  <string name="SYS_IMPORT_USERS">Tuo käyttäjätunnus(kset)</string>
+  <string name="SYS_IMPORT_MEMBERS">Tuo käyttäjätunnus(kset)</string>
   <string name="SYS_IMPRINT">Jälki</string>
   <string name="SYS_IMPRINT_DESC">Täällä voidaan tallentaa sivusi leiman URL -osoite. Jos valittu teema tukee tätä, Admidio -sivuilla näkyy linkki. (Esimerkki: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Ei aktiiviset ryhmät ja roolit</string>
@@ -1360,8 +1360,8 @@
   <string name="SYS_USER_FOUND">Käyttäjä löytyi</string>
   <string name="SYS_USER_ID_NOT_FOUND">Käyttäjää ei löydy tällä tunnuksella!</string>
   <string name="SYS_USER_MANAGEMENT">Käyttäjien hallinta</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">Käyttäjähallinnan näyttämiseen voidaan käyttää jotakin tässä määritetyistä kokoonpanoista. Valitun luettelon kokoonpanon sarakkeet näytetään sitten käyttäjän hallinnassa.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Näytä ja järjestä kaikki aktiiviset ja entiset jäsenet täällä. Uusia käyttäjiä voidaan tuoda tai luoda.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">Käyttäjähallinnan näyttämiseen voidaan käyttää jotakin tässä määritetyistä kokoonpanoista. Valitun luettelon kokoonpanon sarakkeet näytetään sitten käyttäjän hallinnassa.</string>
+  <string name="SYS_MEMBERS_DESC">Näytä ja järjestä kaikki aktiiviset ja entiset jäsenet täällä. Uusia käyttäjiä voidaan tuoda tai luoda.</string>
   <string name="SYS_USER_NO_EMAIL">Käyttäjällä #VAR1_BOLD# ei ole kelvollista sähköpostiosoitetta henkilökohtaisissa tiedoissa!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Tämä käyttäjä ei ole vielä organisaation #VAR1# jäsen.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Käyttäjä ei ole organisaation #VAR1# jäsen, mutta on jo määrittänyt kirjautumistiedot.</string>

--- a/adm_program/languages/fr.xml
+++ b/adm_program/languages/fr.xml
@@ -643,7 +643,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">Si le nouvel utilisateur ne figure pas dans la liste des utilisateurs trouvés, tu peux créer un nouvel utilisateur.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Créer relation</string>
   <string name="SYS_CREATE_ROLE">Création de rôles</string>
-  <string name="SYS_CREATE_USER">Créer un membre</string>
+  <string name="SYS_CREATE_MEMBER">Créer un membre</string>
   <string name="SYS_CREATE_VAR">Créer #VAR1#</string>
   <string name="SYS_CREATED_BY">Créé par #VAR1# le #VAR2#</string>
   <string name="SYS_CREATION_DATE">Date de création</string>
@@ -772,7 +772,7 @@
   <string name="SYS_EVENTS_CONFIRMATION_OF_PARTICIPATION">Evénements - Confirmation de participation</string>
   <string name="SYS_EXAMPLE">Exemple</string>
   <string name="SYS_EXAMPLES">Exemples</string>
-  <string name="SYS_EXISTING_USERS">Membres existants</string>
+  <string name="SYS_EXISTING_MEMBERS">Membres existants</string>
   <string name="SYS_EXPORT_TO">Exporter vers</string>
   <string name="SYS_FADE_IN">Fondre</string>
   <string name="SYS_FAX">Télécopieur</string>
@@ -854,7 +854,7 @@
   <string name="SYS_IMPORT">Importer</string>
   <string name="SYS_IMPORT_MODE">Mode importation</string>
   <string name="SYS_IMPORT_SUCCESSFUL">L\'importation a été réussie.\n\n#VAR1# nouveaux membres ont été créés.\n#VAR2# membres ont été modifiés.\n#VAR3# d\'appartenances aux rôle ont été assignés.</string>
-  <string name="SYS_IMPORT_USERS">Importer des membres</string>
+  <string name="SYS_IMPORT_MEMBERS">Importer des membres</string>
   <string name="SYS_IMPRINT">Impressum</string>
   <string name="SYS_IMPRINT_DESC">Ici, tu peux entrer l\'URL de l\'impressum de ta page. Si le thème sélectionné le supporte, un lien sera affiché sur les pages Admidio. (Exemple : https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Groupes et rôles inactifs</string>
@@ -1301,7 +1301,7 @@
   <string name="SYS_USER_FOUND">Utilisateurs trouvés</string>
   <string name="SYS_USER_ID_NOT_FOUND">Aucun utilisateur n\'a pu être trouvé pour l\'ID donnée !</string>
   <string name="SYS_USER_MANAGEMENT">Administration des membres</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Tous les membres actifs et anciens membres peuvent être consultés et gérés ici. De nouveaux membres peuvent être créés ou importés.</string>
+  <string name="SYS_MEMBERS_DESC">Tous les membres actifs et anciens membres peuvent être consultés et gérés ici. De nouveaux membres peuvent être créés ou importés.</string>
   <string name="SYS_USER_NO_EMAIL">L\'utilisateur #VAR1_BOLD# n\'a pas d\'adresse courriel valide dans son profil !</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Cet utilisateur n\'est pas encore membre de l\'organisation #VAR1#.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Cet utilisateur n\'est pas encore membre de l\'organisation #VAR1#, mais possède déjà des données de connexion.</string>

--- a/adm_program/languages/it.xml
+++ b/adm_program/languages/it.xml
@@ -610,7 +610,7 @@
   <string name="SYS_CREATE_NEW_USER">Aggiungi un nuovo utente</string>
   <string name="SYS_CREATE_NOT_FOUND_USER">Potrai creare un nuovo utente, se l\'utente non è elencato tra gli utenti trovati.</string>
   <string name="SYS_CREATE_ROLE">Crea ruolo</string>
-  <string name="SYS_CREATE_USER">Crea utente</string>
+  <string name="SYS_CREATE_MEMBER">Crea utente</string>
   <string name="SYS_CREATE_VAR">Crea #VAR1#</string>
   <string name="SYS_CREATED_BY">Creato da #VAR1# il #VAR2#</string>
   <string name="SYS_CREATION_DATE">Creato su</string>
@@ -699,7 +699,7 @@
   <string name="SYS_ERROR_PAGE_NOT_FOUND">ERRORE 404 - PAGINA NON TROVATA!</string>
   <string name="SYS_EXAMPLE">Esempio</string>
   <string name="SYS_EXAMPLES">Esempi</string>
-  <string name="SYS_EXISTING_USERS">Utente esistente</string>
+  <string name="SYS_EXISTING_MEMBERS">Utente esistente</string>
   <string name="SYS_EXPORT_TO">Esporta per</string>
   <string name="SYS_FADE_IN">Dissolvenza in</string>
   <string name="SYS_FAX">Fax</string>
@@ -762,7 +762,7 @@
   <string name="SYS_IDENTIFY_USERS">L\'identificazione degli utenti già esistenti è fatta sulla base del nome e del cognome.</string>
   <string name="SYS_IMPORT">Importa</string>
   <string name="SYS_IMPORT_SUCCESSFUL">L\'importazione ha avuto successo..\n\n#VAR1# nuovi utenti sono stati creati.\n#VAR2# utenti sono stati modificati.\n#VAR3# ruoli di membership sono stati assegnati.</string>
-  <string name="SYS_IMPORT_USERS">Importa utente(i)</string>
+  <string name="SYS_IMPORT_MEMBERS">Importa utente(i)</string>
   <string name="SYS_INFOBOX" description="A small html box that will show additional informations">Spazio informazioni</string>
   <string name="SYS_INFORMATIONS">informazioni</string>
   <string name="SYS_INPUT_FIRSTNAME_LASTNAME">Per favore fornisci il nome e il cognome del nuovo utente. Sarà effettuata una verifica nel database se un utente con lo stesso nome o con un nome simile esiste già.</string>
@@ -1089,7 +1089,7 @@
   <string name="SYS_USER_FOUND">Utente trovato</string>
   <string name="SYS_USER_ID_NOT_FOUND">Nessun utente è stato trovato con questo ID!</string>
   <string name="SYS_USER_MANAGEMENT">Gestione dell\'utente</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Visualizza e organizza qui tutti i membri attivi e gli ex membri. Nuovi utenti possono essere creati o importati.</string>
+  <string name="SYS_MEMBERS_DESC">Visualizza e organizza qui tutti i membri attivi e gli ex membri. Nuovi utenti possono essere creati o importati.</string>
   <string name="SYS_USER_NO_EMAIL">L\'utente #VAR1_BOLD# non ha alcun indirizzo email valido nelle informazioni personali!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Questo utente non è ancora membro dell\'organizzazione #VAR1#.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">L\'utente non è membro dell\'organizzazione #VAR1# ma ha già i dati di accesso assegnati</string>

--- a/adm_program/languages/nb.xml
+++ b/adm_program/languages/nb.xml
@@ -130,7 +130,7 @@
   <string name="SYS_CREATE">Opprett</string>
   <string name="SYS_CREATE_NEW_USER">Legg til ny bruker</string>
   <string name="SYS_CREATE_ROLE">Opprett rolle</string>
-  <string name="SYS_CREATE_USER">Opprett bruker</string>
+  <string name="SYS_CREATE_MEMBER">Opprett bruker</string>
   <string name="SYS_CREATION_DATE">Opprettet</string>
   <string name="SYS_CSV">CSV</string>
   <string name="SYS_DATABASE">Database</string>
@@ -162,7 +162,7 @@
   <string name="SYS_ERROR">Feil</string>
   <string name="SYS_EXAMPLE">Eksempel</string>
   <string name="SYS_EXAMPLES">Eksempler</string>
-  <string name="SYS_EXISTING_USERS">Eksisterende bruker</string>
+  <string name="SYS_EXISTING_MEMBERS">Eksisterende bruker</string>
   <string name="SYS_FAX">Faks</string>
   <string name="SYS_FEMALE">Kvinne</string>
   <string name="SYS_FIELD">Felt</string>
@@ -193,7 +193,7 @@
   <string name="SYS_HOURS_VAR">#VAR1# timer</string>
   <string name="SYS_ICON">Ikon</string>
   <string name="SYS_IMPORT">Import</string>
-  <string name="SYS_IMPORT_USERS">Brukerimport</string>
+  <string name="SYS_IMPORT_MEMBERS">Brukerimport</string>
   <string name="SYS_INFORMATIONS">informasjon</string>
   <string name="SYS_INSTALLED">Installert</string>
   <string name="SYS_INTERNAL_NAME">Internt navn</string>

--- a/adm_program/languages/nl.xml
+++ b/adm_program/languages/nl.xml
@@ -652,7 +652,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">U kunt nieuwe gebruiker aanmaken, als deze gebruiker niet voorkomt in de lijst met gevonden gebruikers.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Maak relatie</string>
   <string name="SYS_CREATE_ROLE">Maak rol</string>
-  <string name="SYS_CREATE_USER">Maak gebruiker</string>
+  <string name="SYS_CREATE_MEMBER">Maak gebruiker</string>
   <string name="SYS_CREATE_VAR">Maak #VAR1#</string>
   <string name="SYS_CREATED_BY">Gemaakt door #VAR1# op #VAR2#</string>
   <string name="SYS_CREATION_DATE">Gemaakt op</string>
@@ -801,7 +801,7 @@
   <string name="SYS_EXAMPLES">Voorbeelden</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Bestaande gebruiker</string>
+  <string name="SYS_EXISTING_MEMBERS">Bestaande gebruiker</string>
   <string name="SYS_EXPORT_LISTS">Exporteer lijsten</string>
   <string name="SYS_EXPORT_LISTS_DESC">Lijsten met groepen en rollen kunnen door gebruikers worden geëxporteerd, op voorwaarde dat u het recht heeft om deze lijsten te bekijken. Deze instelling kan worden gebruikt om de exportfunctie te beperken. (Standaard: alles)</string>
   <string name="SYS_EXPORT_TO">Exporteer</string>
@@ -892,7 +892,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">Het werkblad #VAR1# bestaat niet in het geïmporteerde bestand!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Importeren is gelukt..\n\n#VAR1# nieuwe gebruikers zijn gemaakt.\n#VAR2# gebruikers zijn bewerkt.\n#VAR3# rol lidmaatschappen zijn toegewezen.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">Aan de volgende kolommen van het importbestand zijn geen profielvelden toegewezen:</string>
-  <string name="SYS_IMPORT_USERS">Importeer gebruiker(s)</string>
+  <string name="SYS_IMPORT_MEMBERS">Importeer gebruiker(s)</string>
   <string name="SYS_IMPRINT">Afdruk</string>
   <string name="SYS_IMPRINT_DESC">Hier kan de URL voor de afdruk van uw pagina worden ingesteld. Als het geselecteerde thema dit ondersteunt, wordt er ook een link weergegeven op de Admidio-pagina\'s. (Voorbeeld: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Inactieve groepen en rollen</string>
@@ -1362,8 +1362,8 @@
   <string name="SYS_USER_FOUND">Gebruiker gevonden</string>
   <string name="SYS_USER_ID_NOT_FOUND">Geen gebruiker kon gevonden worden met deze ID!</string>
   <string name="SYS_USER_MANAGEMENT">Gebruikersbeheer</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">Een van de hier gespecificeerde configuraties kan worden gebruikt om het gebruikersbeheer weer te geven. De kolommen van de geselecteerde lijst-configuratie worden vervolgens weergegeven in het gebruikersbeheer.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Hier worden alle actieve en voormalige leden getoond. U kunt leden importeren uit een bestand, aanmaken of beheren.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">Een van de hier gespecificeerde configuraties kan worden gebruikt om het gebruikersbeheer weer te geven. De kolommen van de geselecteerde lijst-configuratie worden vervolgens weergegeven in het gebruikersbeheer.</string>
+  <string name="SYS_MEMBERS_DESC">Hier worden alle actieve en voormalige leden getoond. U kunt leden importeren uit een bestand, aanmaken of beheren.</string>
   <string name="SYS_USER_NO_EMAIL">Gebruiker #VAR1_BOLD# heeft geen geldig e-mailadres in zijn profiel!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">De gebruiker is nog geen lid van organisatie #VAR1#.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Gebruiker is geen lid van organisatie #VAR1# maar er is al inloginformatie toegewezen.</string>

--- a/adm_program/languages/pt-BR.xml
+++ b/adm_program/languages/pt-BR.xml
@@ -633,7 +633,7 @@
   <string name="SYS_CREATE_NEW_USER">Adicionar novo usuário</string>
   <string name="SYS_CREATE_NOT_FOUND_USER">Se o novo usuário não estiver na lista, podes criá-lo.</string>
   <string name="SYS_CREATE_ROLE">Criar cargo</string>
-  <string name="SYS_CREATE_USER">Criar usuário</string>
+  <string name="SYS_CREATE_MEMBER">Criar usuário</string>
   <string name="SYS_CREATE_VAR">Criar #VAR1#</string>
   <string name="SYS_CREATED_BY">Criado por #VAR1# em #VAR2#</string>
   <string name="SYS_CREATION_DATE">Criada em</string>
@@ -745,7 +745,7 @@
   <string name="SYS_EVENTS_CONFIRMATION_OF_PARTICIPATION">Eventos - Confirmação de comparecimento</string>
   <string name="SYS_EXAMPLE">Exemplo</string>
   <string name="SYS_EXAMPLES">Exemplos</string>
-  <string name="SYS_EXISTING_USERS">Usuário existente</string>
+  <string name="SYS_EXISTING_MEMBERS">Usuário existente</string>
   <string name="SYS_EXPORT_TO">Exportar para</string>
   <string name="SYS_FADE_IN">Aparecer gradualmente</string>
   <string name="SYS_FAX">Fax</string>
@@ -823,7 +823,7 @@
   <string name="SYS_IMPORT">Importar</string>
   <string name="SYS_IMPORT_MODE">Modo de importação</string>
   <string name="SYS_IMPORT_SUCCESSFUL">A importação está completa.\n\n#VAR1# novos usuários foram criados.\n#VAR2# usuários foram editados.\n#VAR3# filiações de cargos foram atribuídas.</string>
-  <string name="SYS_IMPORT_USERS">Importar usuário(s)</string>
+  <string name="SYS_IMPORT_MEMBERS">Importar usuário(s)</string>
   <string name="SYS_IMPRINT">Imprimir</string>
   <string name="SYS_IMPRINT_DESC">Insira a URL para a impressão da sua página. Se o tema selecionado suportar, um link será exibido nas páginas do Admidio. (Example: https://www.example.com/imprint.html)</string>
   <string name="SYS_INFOBOX" description="A small html box that will show additional informations">Caixa de informações</string>
@@ -1243,7 +1243,7 @@
   <string name="SYS_USER_FOUND">Usuário encontrado</string>
   <string name="SYS_USER_ID_NOT_FOUND">Nenhum usuário encontrado com este ID!</string>
   <string name="SYS_USER_MANAGEMENT">Gestão de usuários</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Exibir todos os membros aqui. Novos usuários podem ser importados ou criados.</string>
+  <string name="SYS_MEMBERS_DESC">Exibir todos os membros aqui. Novos usuários podem ser importados ou criados.</string>
   <string name="SYS_USER_NO_EMAIL">O usuário #VAR1_BOLD# não possui nenhum endereço de e-mail em suas informações pessoais!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Este usuário não é um membro da organização #VAR1# ainda.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">O usuário não é um membro da organização #VAR1# mas já possui informações de sessão atribuídas.</string>

--- a/adm_program/languages/pt.xml
+++ b/adm_program/languages/pt.xml
@@ -630,7 +630,7 @@
   <string name="SYS_CREATE_NEW_USER">Adicionar novo usuário</string>
   <string name="SYS_CREATE_NOT_FOUND_USER">Se o novo usuário não estiver na lista, podes criá-lo.</string>
   <string name="SYS_CREATE_ROLE">Criar função</string>
-  <string name="SYS_CREATE_USER">Criar usuário</string>
+  <string name="SYS_CREATE_MEMBER">Criar usuário</string>
   <string name="SYS_CREATE_VAR">Criar #VAR1#</string>
   <string name="SYS_CREATED_BY">Criado por #VAR1# em #VAR2#</string>
   <string name="SYS_CREATION_DATE">Criada em</string>
@@ -743,7 +743,7 @@
   <string name="SYS_EVENTS_CONFIRMATION_OF_PARTICIPATION">Eventos - Confirmação de comparecimento</string>
   <string name="SYS_EXAMPLE">Exemplo</string>
   <string name="SYS_EXAMPLES">Exemplos</string>
-  <string name="SYS_EXISTING_USERS">Usuário existente</string>
+  <string name="SYS_EXISTING_MEMBERS">Usuário existente</string>
   <string name="SYS_EXPORT_TO">Exportar para</string>
   <string name="SYS_FADE_IN">Aparecer gradualmente</string>
   <string name="SYS_FAX">Fax</string>
@@ -820,7 +820,7 @@
   <string name="SYS_IMPORT">Importar</string>
   <string name="SYS_IMPORT_MODE">Modo de importação</string>
   <string name="SYS_IMPORT_SUCCESSFUL">A importação está completa.\n\n#VAR1# novos usuários foram criados.\n#VAR2# usuários foram editados.\n#VAR3# filiações de cargos foram atribuídas.</string>
-  <string name="SYS_IMPORT_USERS">Importar usuário(s)</string>
+  <string name="SYS_IMPORT_MEMBERS">Importar usuário(s)</string>
   <string name="SYS_IMPRINT">Nome</string>
   <string name="SYS_IMPRINT_DESC">Aqui o URL para o nome da sua página pode ser depositado. Se o tema selecionado suportar isto, será exibida uma hiperligação nas páginas do Admidio. (Por exemplo: https://www.example.com/imprint.html)</string>
   <string name="SYS_INFOBOX" description="A small html box that will show additional informations">Caixa de informações</string>
@@ -1239,7 +1239,7 @@
   <string name="SYS_USER_FOUND">Usuário encontrado</string>
   <string name="SYS_USER_ID_NOT_FOUND">Nenhum usuário encontrado com este ID!</string>
   <string name="SYS_USER_MANAGEMENT">Gestão de usuários</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Exibir todos os membros aqui. Novos usuários podem ser importados ou criados.</string>
+  <string name="SYS_MEMBERS_DESC">Exibir todos os membros aqui. Novos usuários podem ser importados ou criados.</string>
   <string name="SYS_USER_NO_EMAIL">O usuário #VAR1_BOLD# não possui nenhum endereço de e-mail em suas informações pessoais!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Este usuário não é um membro da organização #VAR1# ainda.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">O usuário não é um membro da organização #VAR1# mas já possui informações de sessão atribuídas.</string>

--- a/adm_program/languages/sv.xml
+++ b/adm_program/languages/sv.xml
@@ -652,7 +652,7 @@
   <string name="SYS_CREATE_NOT_FOUND_USER">Om den nya användaren inte är listad bland de hittade användare kan du skapa den.</string>
   <string name="SYS_CREATE_RELATIONSHIP">Skapa relation</string>
   <string name="SYS_CREATE_ROLE">Skapa roll</string>
-  <string name="SYS_CREATE_USER">Skapa användare</string>
+  <string name="SYS_CREATE_MEMBER">Skapa användare</string>
   <string name="SYS_CREATE_VAR">Skapa #VAR1#</string>
   <string name="SYS_CREATED_BY">Skapad av #VAR1# på #VAR2#</string>
   <string name="SYS_CREATION_DATE">Skapad</string>
@@ -801,7 +801,7 @@
   <string name="SYS_EXAMPLES">Exempel</string>
   <string name="SYS_EXCEL_2007_365">Excel 2007-365 (*.xlsx, *.xlsm, *.xlsb)</string>
   <string name="SYS_EXCEL_97_2003">Excel 97-2003 (*.xls, *.xlm)</string>
-  <string name="SYS_EXISTING_USERS">Befintlig användare:</string>
+  <string name="SYS_EXISTING_MEMBERS">Befintlig användare:</string>
   <string name="SYS_EXPORT_LISTS">Exportera listor</string>
   <string name="SYS_EXPORT_LISTS_DESC">Listor över grupper och roller kan exporteras av användare, förutsatt att du har rätt att se dessa listor. Denna inställning kan användas för att begränsa exportfunktionen. (Standard: Alla)</string>
   <string name="SYS_EXPORT_TO">Exportera till</string>
@@ -892,7 +892,7 @@
   <string name="SYS_IMPORT_SHEET_NOT_EXISTS">Arbetsbladet #VAR1# finns inte i den importerade filen!</string>
   <string name="SYS_IMPORT_SUCCESSFUL">Importen lyckades .. \n\n #VAR1# nya användare har skapats. \n #VAR2# användare har redigerats. \n #VAR3# rollmedlemskap har tilldelats.</string>
   <string name="SYS_IMPORT_UNUSED_HEAD">Följande kolumner i importfilen tilldelas inga profilfält:</string>
-  <string name="SYS_IMPORT_USERS">Importera användare</string>
+  <string name="SYS_IMPORT_MEMBERS">Importera användare</string>
   <string name="SYS_IMPRINT">Information</string>
   <string name="SYS_IMPRINT_DESC">Här kan URL: en för avtrycket på din sida deponeras. Om det valda temat stöder detta kommer en länk att visas på Admidio-sidorna. (Exempel: https://www.example.com/imprint.html)</string>
   <string name="SYS_INACTIVE_GROUPS_ROLES">Inaktiva grupper och roller</string>
@@ -1360,8 +1360,8 @@
   <string name="SYS_USER_FOUND">Ingen användare hittades</string>
   <string name="SYS_USER_ID_NOT_FOUND">Ingen användare kunde hittas med detta ID!</string>
   <string name="SYS_USER_MANAGEMENT">Användarhantering</string>
-  <string name="SYS_USER_MANAGEMENT_CONFIGURATION_DESC">En av de konfigurationer som anges här kan användas för att visa användaradministrationen. Kolumnerna i den valda listkonfigurationen visas sedan i användaradministrationen.</string>
-  <string name="SYS_USER_MANAGEMENT_DESC">Visa och organisera alla aktiva och tidigare medlemmar här. Nya användare kan importeras eller skapas.</string>
+  <string name="SYS_MEMBERS_CONFIGURATION_DESC">En av de konfigurationer som anges här kan användas för att visa användaradministrationen. Kolumnerna i den valda listkonfigurationen visas sedan i användaradministrationen.</string>
+  <string name="SYS_MEMBERS_DESC">Visa och organisera alla aktiva och tidigare medlemmar här. Nya användare kan importeras eller skapas.</string>
   <string name="SYS_USER_NO_EMAIL">Användare #VAR1_BOLD# har ingen giltig e-postadress i personlig information!</string>
   <string name="SYS_USER_NO_MEMBERSHIP">Den här användaren är inte medlem i organisationen #VAR1# än.</string>
   <string name="SYS_USER_NO_MEMBERSHIP_LOGIN">Användaren är inte medlem i organisationen #VAR1# men har redan inloggningsinformation tilldelad.</string>

--- a/adm_program/languages/zh.xml
+++ b/adm_program/languages/zh.xml
@@ -95,7 +95,7 @@
   <string name="SYS_COMPLEMENT">补充</string>
   <string name="SYS_COUNTER">计数器</string>
   <string name="SYS_CREATE_FOLDER">创建文件夹</string>
-  <string name="SYS_CREATE_USER">创建用户</string>
+  <string name="SYS_CREATE_MEMBER">创建用户</string>
   <string name="SYS_CREATION_DATE">创建于</string>
   <string name="SYS_DATABASE_BACKUP">数据库备份</string>
   <string name="SYS_DATABASE_BACKUP_DESC">创建和下载系统表的数据库备份。</string>
@@ -123,7 +123,7 @@
   <string name="SYS_EMAIL_TO_LIST">向列表发送电子邮件</string>
   <string name="SYS_ENABLE_USER_RELATIONS">保持和显示关系</string>
   <string name="SYS_ENABLE_USER_RELATIONS_DESC">如果设置为有效的，则可以保持和显示用户之间的关系。(默认值：是)</string>
-  <string name="SYS_EXISTING_USERS">现有用户</string>
+  <string name="SYS_EXISTING_MEMBERS">现有用户</string>
   <string name="SYS_EXPORT_TO">导出到</string>
   <string name="SYS_FILE_COLUMN">文件列</string>
   <string name="SYS_FILE_EXTENSION_INVALID">不被允许的文件类型。</string>
@@ -147,7 +147,7 @@
   <string name="SYS_HOURS_VAR">#VAR1# 小时</string>
   <string name="SYS_IDENTIFY_USERS">现有用户的通过姓氏和名字进行识别。</string>
   <string name="SYS_IMPORT">导入</string>
-  <string name="SYS_IMPORT_USERS">导入用户</string>
+  <string name="SYS_IMPORT_MEMBERS">导入用户</string>
   <string name="SYS_INPUT_FIRSTNAME_LASTNAME">请提供新用户的姓和名字。如果已存在有相同或相似名称的同一用户，将执行数据库检查。</string>
   <string name="SYS_LAYOUT">布局</string>
   <string name="SYS_MAKE_FORMER">用户可以更改为形式成员，将保留包括成员角色资格的所有用户信息，以供以后使用。</string>

--- a/adm_program/modules/groups-roles/members_assignment.php
+++ b/adm_program/modules/groups-roles/members_assignment.php
@@ -201,7 +201,7 @@ if ($getMode === 'assign') {
     if ($gCurrentUser->editUsers()) {
         $page->addPageFunctionsMenuItem(
             'menu_item_members_assign_create_user',
-            $gL10n->get('SYS_CREATE_USER'),
+            $gL10n->get('SYS_CREATE_MEMBER'),
             ADMIDIO_URL.FOLDER_MODULES.'/members/members_new.php',
             'fa-plus-circle'
         );

--- a/adm_program/modules/members/import.php
+++ b/adm_program/modules/members/import.php
@@ -23,7 +23,7 @@ if (!PhpIniUtils::isFileUploadEnabled()) {
     // => EXIT
 }
 
-$headline = $gL10n->get('SYS_IMPORT_USERS');
+$headline = $gL10n->get('SYS_IMPORT_MEMBERS');
 
 // add current url to navigation stack
 $gNavigation->addUrl(CURRENT_URL, $headline);
@@ -200,7 +200,7 @@ $selectBoxEntries = array(
 );
 $form->addSelectBox(
     'user_import_mode',
-    $gL10n->get('SYS_EXISTING_USERS'),
+    $gL10n->get('SYS_EXISTING_MEMBERS'),
     $selectBoxEntries,
     array(
         'property'                       => HtmlForm::FIELD_REQUIRED,

--- a/adm_program/modules/members/members.php
+++ b/adm_program/modules/members/members.php
@@ -32,7 +32,7 @@ if (!$gCurrentUser->editUsers()) {
 }
 
 // set headline of the script
-$headline = $gL10n->get('SYS_USER_MANAGEMENT');
+$headline = $gL10n->get('SYS_MEMBERS');
 
 // Navigation of the module starts here
 $gNavigation->addStartUrl(CURRENT_URL, $headline);
@@ -58,7 +58,7 @@ $page->addJavascript('
 
 $page->addPageFunctionsMenuItem(
     'menu_item_members_create_user',
-    $gL10n->get('SYS_CREATE_USER'),
+    $gL10n->get('SYS_CREATE_MEMBER'),
     ADMIDIO_URL.FOLDER_MODULES.'/members/members_new.php',
     'fa-plus-circle'
 );
@@ -86,7 +86,7 @@ if ($gSettingsManager->getBool('members_show_all_users')) {
 // show link to import users
 $page->addPageFunctionsMenuItem(
     'menu_item_members_import_users',
-    $gL10n->get('SYS_IMPORT_USERS'),
+    $gL10n->get('SYS_IMPORT_MEMBERS'),
     ADMIDIO_URL.FOLDER_MODULES.'/members/import.php',
     'fa-upload'
 );

--- a/adm_program/modules/members/members_new.php
+++ b/adm_program/modules/members/members_new.php
@@ -57,7 +57,7 @@ echo '
 </script>
 
 <div class="modal-header">
-    <h3 class="modal-title">'.$gL10n->get('SYS_CREATE_USER').'</h3>
+    <h3 class="modal-title">'.$gL10n->get('SYS_CREATE_MEMBER').'</h3>
     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 </div>
 <div class="modal-body">
@@ -78,7 +78,7 @@ echo '
     );
     $form->addSubmitButton(
         'btn_add',
-        $gL10n->get('SYS_CREATE_USER'),
+        $gL10n->get('SYS_CREATE_MEMBER'),
         array('icon' => 'fa-plus-circle', 'class' => ' offset-sm-3')
     );
     echo $form->show();

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -1038,7 +1038,7 @@ $formUserManagement->addSelectBoxFromSql(
     $gL10n->get('SYS_CONFIGURATION_LIST'),
     $gDb,
     $sqlData,
-    array('defaultValue' => $formValues['members_list_configuration'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_USER_MANAGEMENT_CONFIGURATION_DESC')
+    array('defaultValue' => $formValues['members_list_configuration'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MEMBERS_CONFIGURATION_DESC')
 );
 $selectBoxEntries = array('10' => '10', '25' => '25', '50' => '50', '100' => '100');
 $formUserManagement->addSelectBox(
@@ -1076,7 +1076,7 @@ $formUserManagement->addSubmitButton(
     array('icon' => 'fa-check', 'class' => ' offset-sm-3')
 );
 
-$page->addHtml(getPreferencePanel('modules', 'user_administration', 'accordion_modules', $gL10n->get('SYS_USER_MANAGEMENT'), 'fas fa-users-cog', $formUserManagement->show()));
+$page->addHtml(getPreferencePanel('modules', 'user_administration', 'accordion_modules', $gL10n->get('SYS_MEMBERS'), 'fas fa-users-cog', $formUserManagement->show()));
 
 // PANEL: DOCUMENTS-FILES
 

--- a/adm_program/system/classes/ComponentUpdateSteps.php
+++ b/adm_program/system/classes/ComponentUpdateSteps.php
@@ -268,7 +268,7 @@ final class ComponentUpdateSteps
         foreach ($organizationsArray as $organization) {
             // add default configuration
             $userManagementList = new ListConfiguration(self::$db);
-            $userManagementList->setValue('lst_name', $gL10n->get('SYS_USER_MANAGEMENT'));
+            $userManagementList->setValue('lst_name', $gL10n->get('SYS_MEMBERS'));
             $userManagementList->setValue('lst_org_id', (int) $organization['org_id']);
             $userManagementList->setValue('lst_global', 1);
             $userManagementList->addColumn(1, (int) $gProfileFields->getProperty('LAST_NAME', 'usf_id'), 'ASC');
@@ -640,7 +640,7 @@ final class ComponentUpdateSteps
                      , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PREFERENCES\'), 2, 0, 6, 1, \'orgprop\', \''.FOLDER_MODULES.'/preferences/preferences.php\', \'options.png\', \'SYS_SETTINGS\', \'ORG_ORGANIZATION_PROPERTIES_DESC\')
                      , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MESSAGES\'), 1, 0, 4, 1, \'mail\', \''.FOLDER_MODULES.'/messages/messages_write.php\', \'email.png\', \'SYS_EMAIL\', \'SYS_EMAIL_DESC\')
                      , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'REGISTRATION\'), 2, 0, 1, 1, \'newreg\', \''.FOLDER_MODULES.'/registration/registration.php\', \'new_registrations.png\', \'SYS_NEW_REGISTRATIONS\', \'SYS_MANAGE_NEW_REGISTRATIONS_DESC\')
-                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MEMBERS\'), 2, 0, 2, 1, \'usrmgt\', \''.FOLDER_MODULES.'/members/members.php\', \'user_administration.png\', \'SYS_USER_MANAGEMENT\', \'SYS_USER_MANAGEMENT_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MEMBERS\'), 2, 0, 2, 1, \'usrmgt\', \''.FOLDER_MODULES.'/members/members.php\', \'user_administration.png\', \'SYS_USER_MANAGEMENT\', \'SYS_MEMBERS_DESC\')
                      , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MENU\'), 2, 0, 5, 1, \'menu\', \''.FOLDER_MODULES.'/menu/menu.php\', \'application_view_tile.png\', \'SYS_MENU\', \'\')';
         self::$db->query($sql);
     }

--- a/adm_program/system/classes/Organization.php
+++ b/adm_program/system/classes/Organization.php
@@ -340,7 +340,7 @@ class Organization extends TableAccess
         $participantList->save();
 
         $userManagementList = new ListConfiguration($this->db);
-        $userManagementList->setValue('lst_name', $gL10n->get('SYS_USER_MANAGEMENT'));
+        $userManagementList->setValue('lst_name', $gL10n->get('SYS_MEMBERS'));
         $userManagementList->setValue('lst_org_id', $orgId);
         $userManagementList->setValue('lst_global', 1);
         $userManagementList->addColumn(1, (int) $gProfileFields->getProperty('LAST_NAME', 'usf_id'), 'ASC');

--- a/adm_program/system/classes/TableLists.php
+++ b/adm_program/system/classes/TableLists.php
@@ -50,7 +50,7 @@ class TableLists extends TableAccess
             throw new AdmException('SYS_ERROR_DELETE_DEFAULT_LIST', array($this->getValue('lst_name'), $gL10n->get('DAT_DATES')));
         }
         if ($lstId === $gSettingsManager->getInt('members_list_configuration')) {
-            throw new AdmException('SYS_ERROR_DELETE_DEFAULT_LIST', array($this->getValue('lst_name'), $gL10n->get('SYS_USER_MANAGEMENT')));
+            throw new AdmException('SYS_ERROR_DELETE_DEFAULT_LIST', array($this->getValue('lst_name'), $gL10n->get('SYS_MEMBERS')));
         }
 
         $this->db->startTransaction();

--- a/demo_data/data.sql
+++ b/demo_data/data.sql
@@ -13,7 +13,7 @@ INSERT INTO %PREFIX%_components (com_id, com_type, com_name, com_name_intern, co
                               , (70, 'MODULE', 'GBO_GUESTBOOK', 'GUESTBOOK', '4.1.0', 0, 0)
                               , (80, 'MODULE', 'SYS_WEBLINKS', 'LINKS', '4.1.0', 0, 0)
                               , (90, 'MODULE', 'SYS_GROUPS_ROLES', 'GROUPS-ROLES', '4.1.0', 0, 0)
-                              , (100, 'MODULE', 'SYS_USER_MANAGEMENT', 'MEMBERS', '4.1.0', 0, 0)
+                              , (100, 'MODULE', 'SYS_MEMBERS', 'MEMBERS', '4.1.0', 0, 0)
                               , (110, 'MODULE', 'SYS_MENU', 'MENU', '4.1.0', 0, 0)
                               , (120, 'MODULE', 'SYS_MESSAGES', 'MESSAGES', '4.1.0', 0, 0)
                               , (130, 'MODULE', 'SYS_PHOTOS', 'PHOTOS', '4.1.0', 0, 0)
@@ -52,7 +52,7 @@ INSERT INTO %PREFIX%_menu (men_com_id, men_men_id_parent, men_node, men_order, m
 (140, 2, false, 6, true, 'orgprop', '/adm_program/modules/preferences/preferences.php', 'fa-cog', 'SYS_SETTINGS', 'ORG_ORGANIZATION_PROPERTIES_DESC', '2965d083-8dd3-4a43-9b27-53018e5f22c1'),
 (120, 1, false, 4, true, 'mail', '/adm_program/modules/messages/messages_write.php', 'fa-envelope', 'SYS_EMAIL', 'SYS_EMAIL_DESC', 'edb6a573-fb66-4dfb-ba90-466317572204'),
 (160, 2, false, 1, true, 'newreg', '/adm_program/modules/registration/registration.php', 'fa-address-card', 'SYS_NEW_REGISTRATIONS', 'SYS_MANAGE_NEW_REGISTRATIONS_DESC', '62330cbc-4c15-4860-b841-10a35d88cd3c'),
-(100, 2, false, 2, true, 'usrmgt', '/adm_program/modules/members/members.php', 'fa-users-cog', 'SYS_USER_MANAGEMENT', 'SYS_USER_MANAGEMENT_DESC', '168ad66e-e34d-4f14-8a65-a78dd7dbd058'),
+(100, 2, false, 2, true, 'usrmgt', '/adm_program/modules/members/members.php', 'fa-users-cog', 'SYS_MEMBERS', 'SYS_MEMBERS_DESC', '168ad66e-e34d-4f14-8a65-a78dd7dbd058'),
 (110, 2, false, 5, true, 'menu', '/adm_program/modules/menu/menu.php', 'fa-stream', 'SYS_MENU', 'SYS_MENU_DESC', 'ef4b5380-3500-4ec4-a432-a7f4099a2a92');
 
 
@@ -757,8 +757,8 @@ INSERT INTO %PREFIX%_lists (lst_id, lst_uuid, lst_org_id, lst_usr_id, lst_name, 
 (12, 'a834cebe-3592-4f05-8c9b-73551615f570', 2, 1, 'INS_MEMBERSHIP', '2012-02-27 21:50:57',  true),
 (13, 'afc87e5f-fffa-46f3-82d1-6e8c65472ae4', 1, 1, 'SYS_PARTICIPANTS', '2018-04-05 21:50:57',  true),
 (14, 'a94a023b-56fa-4d6e-b05e-267a3d37ba09', 2, 1, 'SYS_PARTICIPANTS', '2018-04-05 21:50:57',  true),
-(15, 'd39d0642-c367-43ca-bc73-578219febbc6', 1, 1, 'SYS_USER_MANAGEMENT', '2021-11-13 15:08:45',  true),
-(16, '6efad974-5b15-4bb7-a1f8-350fa4b7a452', 2, 1, 'SYS_USER_MANAGEMENT', '2021-11-13 15:08:45',  true);
+(15, 'd39d0642-c367-43ca-bc73-578219febbc6', 1, 1, 'SYS_MEMBERS', '2021-11-13 15:08:45',  true),
+(16, '6efad974-5b15-4bb7-a1f8-350fa4b7a452', 2, 1, 'SYS_MEMBERS', '2021-11-13 15:08:45',  true);
 
 --
 -- Data for table adm_list_columns


### PR DESCRIPTION
We should rename "user management" to "members" because we show members within that module and not only users of the system.