### PR TITLE
Docker fixes for v4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,18 @@ FROM registry.access.redhat.com/ubi8/php-74:latest
 MAINTAINER Stefan Schatz
 
 # Build-time metadata as defined at http://label-schema.org
-ARG BUILD_DATE
-ARG VCS_REF
-ARG VERSION
-LABEL org.label-schema.build-date="${BUILD_DATE}" \
+ARG ADMIDIO_BUILD_DATE
+ARG ADMIDIO_VCS_REF
+ARG ADMIDIO_VERSION
+LABEL org.label-schema.build-date="${ADMIDIO_BUILD_DATE}" \
       org.label-schema.name="Admidio" \
       org.label-schema.description="Admidio is a free open source user management system for websites of organizations and groups." \
       org.label-schema.license="GPL-2.0", \
       org.label-schema.url="https://www.admidio.org/" \
-      org.label-schema.vcs-ref="${VCS_REF}" \
+      org.label-schema.vcs-ref="${ADMIDIO_VCS_REF}" \
       org.label-schema.vcs-url="https://github.com/Admidio/admidio" \
       org.label-schema.vendor="Admidio" \
-      org.label-schema.version="${VERSION}" \
+      org.label-schema.version="${ADMIDIO_VERSION}" \
       org.label-schema.schema-version="1.0"
 
 

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -21,8 +21,8 @@ like member lists, event manager, guestbook, photo album or a documents & files 
 ![Docker Pulls](https://img.shields.io/docker/pulls/admidio/admidio?style=plastic)
 
 -	[`latest`](https://github.com/Admidio/admidio/blob/master/Dockerfile)
--	[`branch-v4.0`](https://github.com/Admidio/admidio/blob/v4.0/Dockerfile)
-- `vN.N.N` (e.g.: `v4.0.4`)
+-	[`branch-v4.1`](https://github.com/Admidio/admidio/blob/v4.1/Dockerfile)
+- `vN.N.N` (e.g.: `v4.1.7`)
 - see https://hub.docker.com/r/admidio/admidio/tags for all available tags
 
 You can find the releasenotes on Github [admidio/releases](https://github.com/Admidio/admidio/releases) and the Docker images on Dockerhub [admidio/admidio](https://hub.docker.com/r/admidio/admidio/).
@@ -42,7 +42,7 @@ docker run --detach -it --name "Admidio-MariaDB" \
   -e MYSQL_ROOT_PASSWORD="my_VerySecureRootPassword.01" \
   -e MYSQL_USER="admidio" \
   -e MYSQL_PASSWORD="my_VerySecureAdmidioUserPassword.01" \
-  mariadb:10.5.8
+  mariadb:latest
 ```
 
 ## Start an `admidio` server instance
@@ -99,7 +99,7 @@ docker run --detach -it --name "Admidio" \
 * **`--name "Admidio"`:** Docker container name
 * **`--memory="1024m"`:** limit ram usage of docker container to 1GB
 * **`-p 8080:8080`:** published port (see https://docs.docker.com/config/containers/container-networking/#published-ports)
-* **admidio/admidio:latest:** Image name with version tag. We recommend a special version tag to be used instead of latest (e.g.: `admidio/admidio:v4.0.4`)
+* **admidio/admidio:latest:** Image name with version tag. We recommend a special version tag to be used instead of latest (e.g.: `admidio/admidio:v4.1.7`)
 
 ## Database container link
 * **`--link "Admidio-MariaDB:db"`:** connect to docker database server instance.  
@@ -196,7 +196,7 @@ see https://www.admidio.org/dokuwiki/doku.php?id=en:2.0:konfigurationsdatei_conf
 ### `TZ`
 Specifying the time zone that will be used for this organization. The value corresponds to one of PHP support Time Zone. The time zone is set once during installation and should not thereafter be changed. Must the time zone be nevertheless adjusted later, so the times already recorded are not adjusted to the new time zone.
 
-Possible values: `Europe/Berlin`
+Possible values: `Europe/Vienna`
 
 see https://www.admidio.org/dokuwiki/doku.php?id=en:2.0:konfigurationsdatei_config.php#gtimezone
 
@@ -244,45 +244,45 @@ version: '3.9'
 
 services:
   db:
-    restart: always
-    image: mariadb:10.5.8
+    restart: unless-stopped
+    image: mariadb:latest
     container_name: Admidio-MariaDB
     volumes:
-      - "Admidio-MariaDB-confd:/etc/mysql/conf.d"
-      - "Admidio-MariaDB-data:/var/lib/mysql"
-    ports:
-      - 3306:3306
+      - "Admidio_MariaDB_config:/etc/mysql/conf.d"
+      - "Admidio_MariaDB_data:/var/lib/mysql"
+    # ports:
+    #   - 3306:3306
     environment:
-      - MYSQL_ROOT_PASSWORD=secret-password
+      - MYSQL_ROOT_PASSWORD=password
       - MYSQL_DATABASE=admidio
       - MYSQL_USER=admidio
-      - MYSQL_PASSWORD=secret-password
+      - MYSQL_PASSWORD=password
 
   admidio:
-    restart: always
-    image: admidio/admidio:v4.0.4
+    restart: unless-stopped
+    image: admidio/admidio:latest
     container_name: Admidio
     depends_on:
       - db
     volumes:
-      - Admidio-files:/opt/app-root/src/adm_my_files
-      - Admidio-themes:/opt/app-root/src/adm_themes
-      - Admidio-plugins:/opt/app-root/src/adm_plugins
+      - Admidio_files:/opt/app-root/src/adm_my_files
+      - Admidio_themes:/opt/app-root/src/adm_themes
+      - Admidio_plugins:/opt/app-root/src/adm_plugins
     ports:
-      - 8080:8080
+      - 8084:8080
     environment:
       - ADMIDIO_DB_TYPE=mysql
       - ADMIDIO_DB_HOST=db:3306
       - ADMIDIO_DB_NAME=admidio
       - ADMIDIO_DB_USER=admidio
-      - ADMIDIO_DB_PASSWORD=secret-password
+      - ADMIDIO_DB_PASSWORD=password
       #- ADMIDIO_DB_TABLE_PRAEFIX=adm
-      #- ADMIDIO_MAIL_RELAYHOST=hostname.domain.at:25
+      # - ADMIDIO_MAIL_RELAYHOST=hostname.domain.at:25
       #- ADMIDIO_LOGIN_FOR_UPDATE=1
-      #- ADMIDIO_ORGANISATION=ADMIDIO
+      # - ADMIDIO_ORGANISATION=TEST02
       #- ADMIDIO_PASSWORD_HASH_ALGORITHM=DEFAULT
-      #- ADMIDIO_ROOT_PATH=https://www.mydomain.at/admidio
-      #- TZ=Europe/Vienna
+      # - ADMIDIO_ROOT_PATH=http://localhost:8084
+      - TZ=Europe/Vienna
       #- HTTPD_START_SERVERS=8
       #- DOCUMENTROOT=/
       #- PHP_MEMORY_LIMIT=256M
@@ -291,6 +291,13 @@ services:
       #- DISPLAY_STARTUP_ERRORS=OFF
       #- TRACK_ERRORS=OFF
       #- HTML_ERRORS=ON
+
+volumes:
+  Admidio_MariaDB_config:
+  Admidio_MariaDB_data:
+  Admidio_files:
+  Admidio_themes:
+  Admidio_plugins:
 ```
 
 ## Docker Compose Example with local build (docker-compose.yaml)
@@ -301,46 +308,46 @@ version: '3.9'
 
 services:
   db:
-    restart: always
-    image: mariadb:10.5.8
+    restart: unless-stopped
+    image: mariadb:latest
     container_name: Admidio-MariaDB
     volumes:
-      - "Admidio-MariaDB-confd:/etc/mysql/conf.d"
-      - "Admidio-MariaDB-data:/var/lib/mysql"
-    ports:
-      - 3306:3306
+      - "Admidio_MariaDB_config:/etc/mysql/conf.d"
+      - "Admidio_MariaDB_data:/var/lib/mysql"
+    # ports:
+    #   - 3306:3306
     environment:
-      - MYSQL_ROOT_PASSWORD=secret-password
+      - MYSQL_ROOT_PASSWORD=password
       - MYSQL_DATABASE=admidio
       - MYSQL_USER=admidio
-      - MYSQL_PASSWORD=secret-password
+      - MYSQL_PASSWORD=password
 
   admidio:
     build: .
-    image: yourUsername/admidio:v4.0.4
+    image: yourUsername/admidio:latest
     container_name: Admidio
-    restart: always
+    restart: unless-stopped
     depends_on:
       - db
     volumes:
-      - Admidio-files:/opt/app-root/src/adm_my_files
-      - Admidio-themes:/opt/app-root/src/adm_themes
-      - Admidio-plugins:/opt/app-root/src/adm_plugins
+      - Admidio_files:/opt/app-root/src/adm_my_files
+      - Admidio_themes:/opt/app-root/src/adm_themes
+      - Admidio_plugins:/opt/app-root/src/adm_plugins
     ports:
-      - 8080:8080
+      - 8084:8080
     environment:
       - ADMIDIO_DB_TYPE=mysql
       - ADMIDIO_DB_HOST=db:3306
       - ADMIDIO_DB_NAME=admidio
       - ADMIDIO_DB_USER=admidio
-      - ADMIDIO_DB_PASSWORD=secret-password
+      - ADMIDIO_DB_PASSWORD=password
       #- ADMIDIO_DB_TABLE_PRAEFIX=adm
-      #- ADMIDIO_MAIL_RELAYHOST=hostname.domain.at:25
+      # - ADMIDIO_MAIL_RELAYHOST=hostname.domain.at:25
       #- ADMIDIO_LOGIN_FOR_UPDATE=1
-      #- ADMIDIO_ORGANISATION=ADMIDIO
+      # - ADMIDIO_ORGANISATION=TEST02
       #- ADMIDIO_PASSWORD_HASH_ALGORITHM=DEFAULT
-      #- ADMIDIO_ROOT_PATH=https://www.mydomain.at/admidio
-      #- TZ=Europe/Vienna
+      # - ADMIDIO_ROOT_PATH=http://localhost:8084
+      - TZ=Europe/Vienna
       #- HTTPD_START_SERVERS=8
       #- DOCUMENTROOT=/
       #- PHP_MEMORY_LIMIT=256M
@@ -349,4 +356,11 @@ services:
       #- DISPLAY_STARTUP_ERRORS=OFF
       #- TRACK_ERRORS=OFF
       #- HTML_ERRORS=ON
+
+volumes:
+  Admidio_MariaDB_config:
+  Admidio_MariaDB_data:
+  Admidio_files:
+  Admidio_themes:
+  Admidio_plugins:
 ```

--- a/dockerscripts/startup.sh
+++ b/dockerscripts/startup.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
 # set -euf -o pipefail
-set -e  # If a command fails, set -e will make the whole script exit
+# set -e  # If a command fails, set -e will make the whole script exit
 # set -u  # Treat unset variables as an error, and immediately exit.
 set -f  # Disable filename expansion (globbing) upon seeing *, ?, etc.
 set -o pipefail  # causes a pipeline (for example, curl -s https://sipb.mit.edu/ | grep foo) to produce a failure return code if any command errors.
 # set -x
-
-# TODO:
-#   - write container config back to db to avoid duplicate configurations or get container config from db to avoid duplicate configurations
-#   - redirect to /adm_program/installation after startup, also if conf.php already exists.
-#     check for db connection and existing tables instead
 
 
 
@@ -23,6 +18,10 @@ for dir in "adm_plugins" "adm_themes" "adm_my_files" ; do
     fi
 done
 
+# fix permissions for docker filesystem volumes
+echo "[INFO ] set filesystem permissions (chown -R default:root .)"
+chown -R default:root .
+
 # configure apache
 echo "[INFO ] configure ServerName in /etc/httpd/conf/httpd.conf"
 sed -i "s/#ServerName.*/ServerName \$\{HOSTNAME\}/g" /etc/httpd/conf/httpd.conf
@@ -30,12 +29,13 @@ sed -i "s/#ServerName.*/ServerName \$\{HOSTNAME\}/g" /etc/httpd/conf/httpd.conf
 # configure postfix
 if [ "${ADMIDIO_MAIL_RELAYHOST}" != "" ]; then
     echo "[INFO ] configure postfix for ADMIDIO_MAIL_RELAYHOST=${ADMIDIO_MAIL_RELAYHOST}"
-    if [ "$(sysctl --values net.ipv6.conf.all.disable_ipv6 2>/dev/null)" == "1" ]; then
-        echo "[INFO ] configure postfix set inet_protocols to ipv4 since ipv6 is disabled (net.ipv6.conf.all.disable_ipv6=1)"
-        postconf -e "inet_protocols = ipv4"
-    fi
     postconf -e "inet_interfaces = all"
     postconf -e "relayhost = ${ADMIDIO_MAIL_RELAYHOST}"
+fi
+
+if [ "$(sysctl --values net.ipv6.conf.all.disable_ipv6 2>/dev/null)" == "1" ]; then
+    echo "[INFO ] configure postfix set inet_protocols to ipv4 since ipv6 is disabled (net.ipv6.conf.all.disable_ipv6=1)"
+    postconf -e "inet_protocols = ipv4"
 fi
 
 # start postfix to allow mail delivery
@@ -50,80 +50,85 @@ mailq
 
 
 # generate admidio config.php
-ADMIDIO_CONFIG_TEMPLATE="/opt/app-root/src/adm_my_files/config_example.php"
+# ADMIDIO_CONFIG_TEMPLATE="/opt/app-root/src/adm_my_files/config_example.php"
 ADMIDIO_CONFIG="/opt/app-root/src/adm_my_files/config.php"
-echo "[INFO ] generate admidio config.php file"
-cp --preserve=mode,ownership,timestamps "${ADMIDIO_CONFIG_TEMPLATE}" "${ADMIDIO_CONFIG}"
+# echo "[INFO ] generate admidio config.php file"
+# cp --preserve=mode,ownership,timestamps "${ADMIDIO_CONFIG_TEMPLATE}" "${ADMIDIO_CONFIG}"
 # chown default.root "${ADMIDIO_CONFIG}"
 # chmod 664 "${ADMIDIO_CONFIG}"
 
+if [ -f "${ADMIDIO_CONFIG}" ]; then
+    echo "[INFO ] configure admidio config.php file"
 
-# Select your database system for example 'mysql' or 'pgsql'
-# $gDbType = 'mysql';
-sed -i "s/^\$gDbType.*/\$gDbType = '${ADMIDIO_DB_TYPE:-mysql}';/g" "${ADMIDIO_CONFIG}"
+    # Select your database system for example 'mysql' or 'pgsql'
+    # $gDbType = 'mysql';
+    sed -i "s/^\$gDbType.*/\$gDbType = '${ADMIDIO_DB_TYPE:-mysql}';/g" "${ADMIDIO_CONFIG}"
 
-# // Table prefix for Admidio-Tables in database
-# // Example: 'adm'
-# $g_tbl_praefix = 'adm';
-sed -i "s/^\$g_tbl_praefix.*/\$g_tbl_praefix = '${ADMIDIO_DB_TABLE_PRAEFIX:-adm}';/g" "${ADMIDIO_CONFIG}"
-#
-# // Access to the database of the MySQL-Server
-# $g_adm_srv  = 'URL_to_your_MySQL-Server';    // Server
-if [ "${ADMIDIO_DB_HOST}" != "" ]; then
-    sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = '${ADMIDIO_DB_HOST%%:*}';/g" "${ADMIDIO_CONFIG}"
+    # // Table prefix for Admidio-Tables in database
+    # // Example: 'adm'
+    # $g_tbl_praefix = 'adm';
+    sed -i "s/^\$g_tbl_praefix.*/\$g_tbl_praefix = '${ADMIDIO_DB_TABLE_PRAEFIX:-adm}';/g" "${ADMIDIO_CONFIG}"
+    #
+    # // Access to the database of the MySQL-Server
+    # $g_adm_srv  = 'URL_to_your_MySQL-Server';    // Server
+    if [ "${ADMIDIO_DB_HOST}" != "" ]; then
+        sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = '${ADMIDIO_DB_HOST%%:*}';/g" "${ADMIDIO_CONFIG}"
+    else
+        sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = 'localhost';/g" "${ADMIDIO_CONFIG}"
+    fi
+
+    # $g_adm_port = null;                          // Port
+    if [ "${ADMIDIO_DB_PORT}" != "" ]; then
+        sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_PORT};/g" "${ADMIDIO_CONFIG}"
+    elif [ "${ADMIDIO_DB_HOST}" != "" ]; then
+        sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_HOST##*:};/g" "${ADMIDIO_CONFIG}"
+    else
+        sed -i "s/^\$g_adm_port.*/\$g_adm_port = null;/g" "${ADMIDIO_CONFIG}"
+    fi
+    # $g_adm_db   = 'Databasename';                // Database
+    sed -i "s/^\$g_adm_db.*/\$g_adm_db = '${ADMIDIO_DB_NAME:-admidio}';/g" "${ADMIDIO_CONFIG}"
+    # $g_adm_usr  = 'Username';                    // User
+    sed -i "s/^\$g_adm_usr.*/\$g_adm_usr = '${ADMIDIO_DB_USER:-admidio}';/g" "${ADMIDIO_CONFIG}"
+    # $g_adm_pw   = 'Password';                    // Password
+    sed -i "s/^\$g_adm_pw.*/\$g_adm_pw = '${ADMIDIO_DB_PASSWORD:-admidio}';/g" "${ADMIDIO_CONFIG}"
+
+    # // URL to this Admidio installation
+    # // Example: 'https://www.admidio.org/example'
+    # $g_root_path = 'https://www.your-website.de/admidio';
+    if [ "${ADMIDIO_ROOT_PATH}" != "" ]; then
+        sed -i "s#^\$g_root_path.*#\$g_root_path = '${ADMIDIO_ROOT_PATH}';#g" "${ADMIDIO_CONFIG}"
+    fi
+
+    # // Short description of the organization that is running Admidio
+    # // This short description must correspond to your input in the installation wizard !!!
+    # // Example: 'ADMIDIO'
+    # // Maximum of 10 characters !!!
+    # $g_organization = 'Shortcut';
+    if [ "${ADMIDIO_ORGANISATION}" != "" ]; then
+        sed -i "s/^\$g_organization.*/\$g_organization = '${ADMIDIO_ORGANISATION}';/g" "${ADMIDIO_CONFIG}"
+    fi
+
+    # // The name of the timezone in which your organization is located.
+    # // This must be one of the strings that are defined here https://www.php.net/manual/en/timezones.php
+    # // Example: 'Europe/Berlin'
+    # $gTimezone = 'Europe/Berlin';
+    if [ "${TZ}" != "" ]; then
+        sed -i "s#^\$gTimezone.*#\$gTimezone = '${TZ}';#g" "${ADMIDIO_CONFIG}"
+    fi
+
+    # // If this flag is set = 1 then you must enter your loginname and password
+    # // for an update of the Admidio database to a new version of Admidio.
+    # // For a more comfortable and easy update you can set this preference = 0.
+    # $gLoginForUpdate = 1;
+    sed -i "s/^\$gLoginForUpdate.*/\$gLoginForUpdate = ${ADMIDIO_LOGIN_FOR_UPDATE:-1};/g" "${ADMIDIO_CONFIG}"
+
+    # // Set the preferred password hashing algorithm.
+    # // Possible values are: 'DEFAULT', 'ARGON2ID', 'ARGON2I', 'BCRYPT', 'SHA512'
+    # $gPasswordHashAlgorithm = 'DEFAULT';
+    sed -i "s/^\$gPasswordHashAlgorithm.*/\$gPasswordHashAlgorithm = '${ADMIDIO_PASSWORD_HASH_ALGORITHM:-DEFAULT}';/g" "${ADMIDIO_CONFIG}"
 else
-    sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = 'localhost';/g" "${ADMIDIO_CONFIG}"
+    echo "[WARNING] admidio config.php file does not exist."
 fi
-
-# $g_adm_port = null;                          // Port
-if [ "${ADMIDIO_DB_PORT}" != "" ]; then
-    sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_PORT};/g" "${ADMIDIO_CONFIG}"
-elif [ "${ADMIDIO_DB_HOST}" != "" ]; then
-    sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_HOST##*:};/g" "${ADMIDIO_CONFIG}"
-else
-    sed -i "s/^\$g_adm_port.*/\$g_adm_port = null;/g" "${ADMIDIO_CONFIG}"
-fi
-# $g_adm_db   = 'Databasename';                // Database
-sed -i "s/^\$g_adm_db.*/\$g_adm_db = '${ADMIDIO_DB_NAME:-admidio}';/g" "${ADMIDIO_CONFIG}"
-# $g_adm_usr  = 'Username';                    // User
-sed -i "s/^\$g_adm_usr.*/\$g_adm_usr = '${ADMIDIO_DB_USER:-admidio}';/g" "${ADMIDIO_CONFIG}"
-# $g_adm_pw   = 'Password';                    // Password
-sed -i "s/^\$g_adm_pw.*/\$g_adm_pw = '${ADMIDIO_DB_PASSWORD:-admidio}';/g" "${ADMIDIO_CONFIG}"  # FIXME: where to get password?
-
-# // URL to this Admidio installation
-# // Example: 'https://www.admidio.org/example'
-# $g_root_path = 'https://www.your-website.de/admidio';
-if [ "${ADMIDIO_ROOT_PATH}" != "" ]; then
-    sed -i "s#^\$g_root_path.*#\$g_root_path = '${ADMIDIO_ROOT_PATH}';#g" "${ADMIDIO_CONFIG}"
-fi
-
-# // Short description of the organization that is running Admidio
-# // This short description must correspond to your input in the installation wizard !!!
-# // Example: 'ADMIDIO'
-# // Maximum of 10 characters !!!
-# $g_organization = 'Shortcut';
-if [ "${ADMIDIO_ORGANISATION}" != "" ]; then
-    sed -i "s/^\$g_organization.*/\$g_organization = '${ADMIDIO_ORGANISATION}';/g" "${ADMIDIO_CONFIG}"
-fi
-
-# // The name of the timezone in which your organization is located.
-# // This must be one of the strings that are defined here https://www.php.net/manual/en/timezones.php
-# // Example: 'Europe/Berlin'
-# $gTimezone = 'Europe/Berlin';
-if [ "${TZ}" != "" ]; then
-    sed -i "s#^\$gTimezone.*#\$gTimezone = '${TZ}';#g" "${ADMIDIO_CONFIG}"
-fi
-
-# // If this flag is set = 1 then you must enter your loginname and password
-# // for an update of the Admidio database to a new version of Admidio.
-# // For a more comfortable and easy update you can set this preference = 0.
-# $gLoginForUpdate = 1;
-sed -i "s/^\$gLoginForUpdate.*/\$gLoginForUpdate = ${ADMIDIO_LOGIN_FOR_UPDATE:-1};/g" "${ADMIDIO_CONFIG}"
-
-# // Set the preferred password hashing algorithm.
-# // Possible values are: 'DEFAULT', 'ARGON2ID', 'ARGON2I', 'BCRYPT', 'SHA512'
-# $gPasswordHashAlgorithm = 'DEFAULT';
-sed -i "s/^\$gPasswordHashAlgorithm.*/\$gPasswordHashAlgorithm = '${ADMIDIO_PASSWORD_HASH_ALGORITHM:-DEFAULT}';/g" "${ADMIDIO_CONFIG}"
 
 
 # run apache with php enabled as user default

--- a/hooks/build
+++ b/hooks/build
@@ -12,9 +12,9 @@ set -o pipefail  # causes a pipeline (for example, curl -s https://sipb.mit.edu/
 # https://docs.docker.com/docker-hub/builds/advanced/
 # $IMAGE_NAME var is injected into the build so the tag is correct.
 
-# docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-#              --build-arg VCS_REF=`git rev-parse --short HEAD` \
-#              --build-arg VERSION=`cat VERSION` .
+# docker build --build-arg ADMIDIO_BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+#              --build-arg ADMIDIO_VCS_REF=`git rev-parse --short HEAD` \
+#              --build-arg ADMIDIO_VERSION=`cat ADMIDIO_VERSION` .
 
 
 
@@ -22,11 +22,34 @@ set -o pipefail  # causes a pipeline (for example, curl -s https://sipb.mit.edu/
 # example usage:
 #   IMAGE_NAME="yourUsername/admidio:v4.0.4" ./hooks/build
 
+IMAGE_NAME="${IMAGE_NAME}"
+if [ "${IMAGE_NAME}" = "" ]; then
+    echo "[ERROR] IMAGE_NAME not specified."
+    exit 1
+fi
+
+for item in ${IMAGE_NAME}; do
+    IMAGE_NAMES="${IMAGE_NAMES} -t ${item}"
+done
+ADMIDIO_BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+ADMIDIO_VCS_REF="$(git describe --always --abbrev=7 --tags --long)"
+ADMIDIO_VERSION="$(git describe --always --abbrev=0 --tags)"
+
 echo "Build hook running"
+echo "docker build --build-arg ADMIDIO_BUILD_DATE=\"${ADMIDIO_BUILD_DATE}\" \
+--build-arg ADMIDIO_VCS_REF=\"${ADMIDIO_VCS_REF}\" \
+--build-arg ADMIDIO_VERSION=\"${ADMIDIO_VERSION}\" \
+--rm --force-rm \
+-f \"Dockerfile\" \
+${IMAGE_NAMES} \
+.
+"
+
 docker build \
-  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-  --build-arg VCS_REF="$(git describe --always --abbrev=7 --tags --long)" \
-  --build-arg VERSION="$(git describe --always --abbrev=0 --tags)" \
+  --build-arg ADMIDIO_BUILD_DATE="${ADMIDIO_BUILD_DATE}" \
+  --build-arg ADMIDIO_VCS_REF="${ADMIDIO_VCS_REF}" \
+  --build-arg ADMIDIO_VERSION="${ADMIDIO_VERSION}" \
   --rm --force-rm \
   -f "Dockerfile" \
-  -t "${IMAGE_NAME}" .
+  ${IMAGE_NAMES} \
+  .


### PR DESCRIPTION
- README-Docker.md: update to latest version, use latest tag in examples, fix docker-compose examples

- dockerscripts/startup.sh: fix permissions for docker filesystem volumes, fix postfix error for disabled ipv6, fix redirect to db setup for new installations
- Dockerfile: rename vars to unique names
- hooks/build: add support for multiple build tags