### PR TITLE
Scan for vulnerabilities in Admidio Docker Images with trivy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ USER root
 RUN yum update -y --allowerasing --skip-broken --nobest --setopt=tsflags=nodocs && \
     yum install -y postfix && \
     yum reinstall -y tzdata && \
+    yum remove -y nodejs nodejs-docs npm && \
+    yum autoremove -y && \
+    rm -rf /usr/lib/node_modules && \
     yum -y clean all --enablerepo='*'
 
 COPY . .
@@ -50,7 +53,7 @@ RUN set -euf -o pipefail ; \
       trivy filesystem --exit-code 1 --severity CRITICAL --no-progress / && \
       echo "scan image with trivy (trivy filesystem --exit-code 1 --severity MEDIUM,HIGH --no-progress /)" && \
       trivy filesystem --exit-code 0 --severity MEDIUM,HIGH --no-progress / && \
-      trivy --clear-cache --reset ; \
+      rm -rf /opt/app-root/src/.cache/trivy ; \
     fi
 
 

--- a/hooks/build
+++ b/hooks/build
@@ -39,6 +39,7 @@ echo "Build hook running"
 echo "docker build --build-arg ADMIDIO_BUILD_DATE=\"${ADMIDIO_BUILD_DATE}\" \
 --build-arg ADMIDIO_VCS_REF=\"${ADMIDIO_VCS_REF}\" \
 --build-arg ADMIDIO_VERSION=\"${ADMIDIO_VERSION}\" \
+--build-arg ADMIDIO_TRIVY_ENABLED=\"${ADMIDIO_TRIVY_ENABLED:-false}\" \
 --rm --force-rm \
 -f \"Dockerfile\" \
 ${IMAGE_NAMES} \
@@ -49,6 +50,7 @@ docker build \
   --build-arg ADMIDIO_BUILD_DATE="${ADMIDIO_BUILD_DATE}" \
   --build-arg ADMIDIO_VCS_REF="${ADMIDIO_VCS_REF}" \
   --build-arg ADMIDIO_VERSION="${ADMIDIO_VERSION}" \
+  --build-arg ADMIDIO_TRIVY_ENABLED="${ADMIDIO_TRIVY_ENABLED:-false}" \
   --rm --force-rm \
   -f "Dockerfile" \
   ${IMAGE_NAMES} \


### PR DESCRIPTION
* hooks/build:
  * add ADMIDIO_TRIVY_ENABLED to build args
* Dockerfile:
  * delete trivy cache after testing
  * delete unused, old and unsecure nodejs version from image
