### PR TITLE
Simplify sending email

### DIFF
--- a/adm_plugins/login_form/login_form.php
+++ b/adm_plugins/login_form/login_form.php
@@ -196,7 +196,7 @@ if ($gValidLogin) {
         $linkText = $gL10n->get('SYS_LOGIN_PROBLEMS');
 
         // show link if user has login problems
-        if ($gSettingsManager->getBool('enable_password_recovery') && $gSettingsManager->getBool('enable_system_mails')) {
+        if ($gSettingsManager->getBool('enable_password_recovery') && $gSettingsManager->getBool('system_notifications_enabled')) {
             // request to reset the password
             $linkUrl  = ADMIDIO_URL.FOLDER_SYSTEM.'/password_reset.php';
             $linkText = $gL10n->get('SYS_PASSWORD_FORGOTTEN');

--- a/adm_program/installation/db_scripts/preferences.php
+++ b/adm_program/installation/db_scripts/preferences.php
@@ -49,7 +49,7 @@ $defaultOrgPreferences = array(
 
     // E-mail dispatch
     'mail_send_method'               => 'phpmail',
-    'mail_bcc_count'                 => '50',
+    'mail_number_recipients'         => '50',
     'mail_recipients_with_roles'     => '1',
     'mail_character_encoding'        => 'utf-8',
     'mail_save_attachments'          => '1',

--- a/adm_program/installation/db_scripts/preferences.php
+++ b/adm_program/installation/db_scripts/preferences.php
@@ -63,10 +63,10 @@ $defaultOrgPreferences = array(
     'mail_smtp_password'             => '',
 
     // System notifications
-    'enable_system_mails'             => '1',
-    'system_notification_role'        => '',
-    'enable_email_notification'       => '0',
-    'enable_email_changenotification' => '0',
+    'system_notifications_enabled'         => '1',
+    'system_notifications_role'            => '',
+    'system_notifications_new_entries'     => '0',
+    'system_notifications_profile_changes' => '0',
 
     // Captcha
     'captcha_type'                => 'pic',

--- a/adm_program/installation/db_scripts/preferences.php
+++ b/adm_program/installation/db_scripts/preferences.php
@@ -49,8 +49,9 @@ $defaultOrgPreferences = array(
 
     // E-mail dispatch
     'mail_send_method'               => 'phpmail',
-    'mail_number_recipients'         => '50',
     'mail_recipients_with_roles'     => '1',
+    'mail_number_recipients'         => '50',
+    'mail_into_to'                   => '0',
     'mail_character_encoding'        => 'utf-8',
     'mail_save_attachments'          => '1',
     'mail_smtp_host'                 => '',
@@ -133,7 +134,6 @@ $defaultOrgPreferences = array(
     'enable_mail_captcha'         => '1',
     'mail_max_receiver'           => '10',
     'mail_show_former'            => '1',
-    'mail_into_to'                => '0',
     'max_email_attachment_size'   => '1',
     'mail_sendmail_address'       => '',
     'mail_sendmail_name'          => '',

--- a/adm_program/installation/db_scripts/update_4_2.xml
+++ b/adm_program/installation/db_scripts/update_4_2.xml
@@ -2,5 +2,8 @@
 <update>
     <step id="10" database="mysql">UPDATE %PREFIX%_preferences INNER JOIN %PREFIX%_roles ON rol_administrator = true SET prf_value = rol_uuid WHERE prf_name = 'system_notification_role'</step>
     <step id="20" database="pgsql">UPDATE %PREFIX%_preferences SET prf_value = rol_uuid FROM %PREFIX%_preferences WHERE prf_name = 'system_notification_role' AND rol_administrator = true</step>
+    <step id="30" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'mail_bcc_count' SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'mail_number_recipients'</step>
+    <step id="40" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'mail_bcc_count' AND pr1.prf_name = 'mail_number_recipients'</step>
+    <step id="50">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'mail_bcc_count'</step>
     <step>stop</step>
 </update>

--- a/adm_program/installation/db_scripts/update_4_2.xml
+++ b/adm_program/installation/db_scripts/update_4_2.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <update>
-    <step id="10" database="mysql">UPDATE %PREFIX%_preferences INNER JOIN %PREFIX%_roles ON rol_administrator = true SET prf_value = rol_uuid WHERE prf_name = 'system_notification_role'</step>
-    <step id="20" database="pgsql">UPDATE %PREFIX%_preferences SET prf_value = rol_uuid FROM %PREFIX%_preferences WHERE prf_name = 'system_notification_role' AND rol_administrator = true</step>
+    <step id="10" database="mysql">UPDATE %PREFIX%_preferences INNER JOIN %PREFIX%_roles ON rol_administrator = true SET prf_value = rol_uuid WHERE prf_name = 'system_notifications_role'</step>
+    <step id="20" database="pgsql">UPDATE %PREFIX%_preferences SET prf_value = rol_uuid FROM %PREFIX%_preferences WHERE prf_name = 'system_notifications_role' AND rol_administrator = true</step>
     <step id="30" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'mail_bcc_count' SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'mail_number_recipients'</step>
     <step id="40" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'mail_bcc_count' AND pr1.prf_name = 'mail_number_recipients'</step>
     <step id="50">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'mail_bcc_count'</step>
+    <step id="60" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'enable_email_notification' SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'system_notifications_new_entries'</step>
+    <step id="70" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'enable_email_notification' AND pr1.prf_name = 'system_notifications_new_entries'</step>
+    <step id="80">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'enable_email_notification'</step>
+    <step id="90" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'enable_email_changenotification' SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'system_notifications_profile_changes'</step>
+    <step id="100" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'enable_email_changenotification' AND pr1.prf_name = 'system_notifications_profile_changes'</step>
+    <step id="110">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'enable_email_changenotification'</step>
+    <step id="120" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'enable_system_mails' SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'system_notifications_enabled'</step>
+    <step id="130" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'enable_system_mails' AND pr1.prf_name = 'system_notifications_enabled'</step>
+    <step id="140">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'enable_system_mails'</step>
     <step>stop</step>
 </update>

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -646,8 +646,8 @@
   <string name="SYS_COPY_OF_YOUR_EMAIL">Hier ist Deine angeforderte Kopie der Nachricht</string>
   <string name="SYS_COPY_ENTRY">Eintrag kopieren</string>
   <string name="SYS_COPY_VAR">#VAR1# kopieren</string>
-  <string name="SYS_COUNT_BCC">Anzahl der BCC Empfänger:innen</string>
-  <string name="SYS_COUNT_BCC_DESC">E-Mails an Rollen mit mehreren Mitgliedern werden als Blindkopie (BCC) versendet. So kann von der Empfängerin oder dem Empfänger nicht eingesehen werden, wer diese E-Mail noch bekommen hat. Die Anzahl in diesem Feld gibt die maximale Anzahl an Empfängerinnen oder Empfängern pro E-Mail an. Diese Anzahl kann von Providern beschränkt werden. Besitzt eine Rolle mehr Mitglieder als die eingestellte Zahl, so werden mehrere E-Mails erzeugt. Wird der Wert auf 1 gesetzt, so werden die E-Mails nicht als Blindkopie versendet, sondern direkt an die Empfängerin oder den Empfänger. Die Anzahl der möglichen zu versendenden E-Mails innerhalb eines Zeitraums kann auch von Providern beschränkt werden. (Voreinstellung: 50)</string>
+  <string name="SYS_NUMBER_RECIPIENTS">Anzahl der Empfänger:innen</string>
+  <string name="SYS_NUMBER_RECIPIENTS_DESC">Die Anzahl in diesem Feld gibt die maximale Anzahl an Empfängerinnen oder Empfängern in einer E-Mail an. Diese Anzahl kann von Providern beschränkt werden. Soll eine E-Mail an mehr Empfänger gesendet werden als die hier eingestellte Anzahl, so werden mehrere E-Mails erzeugt. Die Anzahl der möglichen zu versendenden E-Mails innerhalb eines Zeitraums kann auch von Providern beschränkt werden. (Voreinstellung: 50)</string>
   <string name="SYS_COUNT_INDIVIDUAL_RECIPIENT" description="Singular">#VAR1# individuelle empfangende Person</string>
   <string name="SYS_COUNT_INDIVIDUAL_RECIPIENTS" description="Plural">#VAR1# individuelle Empfangende</string>
   <string name="SYS_COUNTER">Zähler</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -641,8 +641,8 @@
   <string name="SYS_COPY_OF_YOUR_EMAIL">Your requested copy of the message</string>
   <string name="SYS_COPY_ENTRY">Copy entry</string>
   <string name="SYS_COPY_VAR">Copy #VAR1#</string>
-  <string name="SYS_COUNT_BCC">Number of BCC recipients</string>
-  <string name="SYS_COUNT_BCC_DESC">E-Mails to roles of several members will be sent as blind copy (BCC). This way, the recipients will not be able to see who else received the message. The amount indicated in the current field is defining the number of maximum recipients of an e-mail message. The maximum number of recipients might also be restricted by the hosting provider. In case of more e-mail recipients than allowed, several e-mail messages will be generated. Should the value be set to 1, each recipient will receive directly an individual message. The number of outgoing e-mail messages within a certain time period might be restricted by the hosting provider, too. (Default: 50)</string>
+  <string name="SYS_NUMBER_RECIPIENTS">Number of recipients</string>
+  <string name="SYS_NUMBER_RECIPIENTS_DESC">The number in this field indicates the maximum number of recipients in an email. This number can be limited by providers. If an e-mail should be sent to more recipients than the number set here, multiple e-mails will be generated. The number of possible e-mails to be sent within a period can also be limited by providers. (Default: 50)</string>
   <string name="SYS_COUNT_INDIVIDUAL_RECIPIENT" description="Singular">#VAR1# individual recipient</string>
   <string name="SYS_COUNT_INDIVIDUAL_RECIPIENTS" description="Plural">#VAR1# individual recipients</string>
   <string name="SYS_COUNTER">Counter</string>

--- a/adm_program/modules/dates/dates_function.php
+++ b/adm_program/modules/dates/dates_function.php
@@ -334,7 +334,7 @@ if ($getMode === 1) {  // Create a new event or edit an existing event
     $rightEventParticipation = new RolesRights($gDb, 'event_participation', $datId);
     $rightEventParticipation->saveRoles($eventParticipationRoles);
 
-    if ($returnCode === true && $gSettingsManager->getBool('enable_email_notification')) {
+    if ($returnCode === true && $gSettingsManager->getBool('system_notifications_new_entries')) {
         // Notification email for new entries
 
         $sqlCal = 'SELECT cat_name

--- a/adm_program/modules/members/members_data.php
+++ b/adm_program/modules/members/members_data.php
@@ -250,7 +250,7 @@ while ($row = $mglStatement->fetch(\PDO::FETCH_BOTH)) {
     // Administrators can change or send password if login is configured and user is member of current organization
     if ($memberOfThisOrganization && $gCurrentUser->isAdministrator()
     && strlen($row['loginname']) > 0 && (int) $row['usr_id'] !== $gCurrentUserId) {
-        if (strlen($row['member_email']) > 0 && $gSettingsManager->getBool('enable_system_mails')) {
+        if (strlen($row['member_email']) > 0 && $gSettingsManager->getBool('system_notifications_enabled')) {
             // if email is set and systemmails are activated then administrators can send a new password to user
             $userAdministration = '<a class="admidio-icon-link" href="'.SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/members/members_function.php', array('user_uuid' => $row['usr_uuid'], 'mode' => 5)).'">'.
                 '<i class="fas fa-key" data-toggle="tooltip" title="' . $gL10n->get('SYS_SEND_USERNAME_PASSWORD') . '"></i></a>';

--- a/adm_program/modules/members/members_function.php
+++ b/adm_program/modules/members/members_function.php
@@ -135,7 +135,7 @@ if ($getMode === 2) {
     // E-Mail support must be enabled
     // Only administrators are allowed to send new login data or users who want to approve login data
     if (isMember($user->getValue('usr_id'))
-    && $gSettingsManager->getBool('enable_system_mails')
+    && $gSettingsManager->getBool('system_notifications_enabled')
     && ($gCurrentUser->isAdministrator() || $gCurrentUser->approveUsers())) {
         try {
             // Generate new secure-random password and save it

--- a/adm_program/modules/messages/messages_send.php
+++ b/adm_program/modules/messages/messages_send.php
@@ -307,18 +307,7 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_EMAIL) {
     if (isset($postCarbonCopy) && $postCarbonCopy) {
         $email->setCopyToSenderFlag();
     }
-/*
-    // get array with unique receivers
-    $sendResults = array_map('unserialize', array_unique(array_map('serialize', $receiver)));
-    $receivers = count($sendResults);
-    foreach ($sendResults as $address) {
-        if ($receivers === 1) {
-            $email->addRecipient($address[0], $address[1]);
-        } else {
-            $email->addRecipient($address[0], $address[1]);
-        }
-    }
-*/
+
     if ($email->countRecipients() > 1) {
         // normally we need no To-address and set "undisclosed recipients", but if
         // that won't work than the following address will be set

--- a/adm_program/modules/messages/messages_send.php
+++ b/adm_program/modules/messages/messages_send.php
@@ -400,7 +400,7 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_EMAIL) {
         if ($receivers === 1) {
             $email->addRecipient($address[0], $address[1]);
         } else {
-            $email->addBlindCopy($address[0], $address[1]);
+            $email->addRecipient($address[0], $address[1]);
         }
     }
 

--- a/adm_program/modules/messages/messages_send.php
+++ b/adm_program/modules/messages/messages_send.php
@@ -308,18 +308,6 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_EMAIL) {
         $email->setCopyToSenderFlag();
     }
 
-    if ($email->countRecipients() > 1) {
-        // normally we need no To-address and set "undisclosed recipients", but if
-        // that won't work than the following address will be set
-        if ((int) $gSettingsManager->get('mail_recipients_with_roles') === 1) {
-            // fill recipient with sender address to prevent problems with provider
-            $email->addRecipient($postFrom, $postName);
-        } elseif ((int) $gSettingsManager->get('mail_recipients_with_roles') === 2) {
-            // fill recipient with administrators address to prevent problems with provider
-            $email->addRecipient($gSettingsManager->getString('email_administrator'), $gL10n->get('SYS_ADMINISTRATOR'));
-        }
-    }
-
     // add confirmation mail to the sender
     if ($postDeliveryConfirmation) {
         $email->ConfirmReadingTo = $gCurrentUser->getValue('EMAIL');

--- a/adm_program/modules/messages/messages_send.php
+++ b/adm_program/modules/messages/messages_send.php
@@ -196,7 +196,8 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_EMAIL) {
                 $email->addRecipientsByRole($group['uuid'], $group['status']);
             } else {
                 // create user object
-                $user = new User($gDb, $gProfileFields, $value);
+                $user = new User($gDb, $gProfileFields);
+                $user->readDataByUuid($value);
 
                 // only send email to user if current user is allowed to view this user, and he has a valid email address
                 if ($gCurrentUser->hasRightViewProfile($user)) {
@@ -205,32 +206,6 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_EMAIL) {
 
                     // add user as recipients to the email
                     $email->addRecipientsByUserId((int) $user->getValue('usr_id'));
-
-                    /*
-                    $sql = 'SELECT first_name.usd_value AS firstname, last_name.usd_value AS lastname, email.usd_value AS email
-                              FROM ' . TBL_USERS . '
-                        INNER JOIN ' . TBL_USER_DATA . ' AS email
-                                ON email.usd_usr_id = usr_id
-                               AND LENGTH(email.usd_value) > 0
-                        INNER JOIN ' . TBL_USER_FIELDS . ' AS field
-                                ON field.usf_id = email.usd_usf_id
-                               AND field.usf_type = \'EMAIL\'
-                                   ' . $sqlEmailField . '
-                         LEFT JOIN ' . TBL_USER_DATA . ' AS last_name
-                                ON last_name.usd_usr_id = usr_id
-                               AND last_name.usd_usf_id = ? -- $gProfileFields->getProperty(\'LAST_NAME\', \'usf_id\')
-                         LEFT JOIN '.TBL_USER_DATA.' AS first_name
-                                ON first_name.usd_usr_id = usr_id
-                               AND first_name.usd_usf_id = ? -- $gProfileFields->getProperty(\'FIRST_NAME\', \'usf_id\')
-                             WHERE usr_id = ? -- $user->getValue(\'usr_id\')
-                               AND usr_valid = true ';
-                    $statement = $gDb->queryPrepared($sql, array((int) $gProfileFields->getProperty('LAST_NAME', 'usf_id'), (int) $gProfileFields->getProperty('FIRST_NAME', 'usf_id'), (int) $user->getValue('usr_id')));
-
-                    while ($row = $statement->fetch()) {
-                        if (StringUtils::strValidCharacters($row['email'], 'email')) {
-                            $receiver[] = array($row['email'], $row['firstname'] . ' ' . $row['lastname']);
-                        }
-                    }*/
                 }
             }
         }

--- a/adm_program/modules/messages/messages_write.php
+++ b/adm_program/modules/messages/messages_write.php
@@ -308,7 +308,7 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
             $listVisibleRoleArray = $gCurrentUser->getAllVisibleRoles();
         } else {
             // list array with all roles where user is allowed to send mail to
-            $sql = 'SELECT rol_id, rol_name
+            $sql = 'SELECT rol_id, rol_uuid, rol_name
                       FROM '.TBL_ROLES.'
                 INNER JOIN '.TBL_CATEGORIES.'
                         ON cat_id = rol_cat_id
@@ -322,16 +322,15 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
             $rolesArray = $rolesStatement->fetchAll();
 
             foreach ($rolesArray as $roleArray) {
-                // Rollenobjekt anlegen
                 $role = new TableRoles($gDb);
                 $role->setArray($roleArray);
-                $list[] = array('groupID: '.$roleArray['rol_id'], $roleArray['rol_name'], $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_ACTIVE_MEMBERS') . ')');
+                $list[] = array('groupID: '.$roleArray['rol_uuid'], $roleArray['rol_name'], $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_ACTIVE_MEMBERS') . ')');
                 $listRoleIdsArray[] = $roleArray['rol_id'];
                 if ($role->hasFormerMembers() > 0 && $gSettingsManager->getBool('mail_show_former')) {
                     // list role with former members
-                    $listFormer[] = array('groupID: '.$roleArray['rol_id'].'-1', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_FORMER_PL').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_FORMER_MEMBERS') . ')');
+                    $listFormer[] = array('groupID: '.$roleArray['rol_uuid'].'-1', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_FORMER_PL').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_FORMER_MEMBERS') . ')');
                     // list role with active and former members
-                    $listActiveAndFormer[] = array('groupID: '.$roleArray['rol_id'].'-2', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS_SHORT').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS') . ')');
+                    $listActiveAndFormer[] = array('groupID: '.$roleArray['rol_uuid'].'-2', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS_SHORT').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS') . ')');
                 }
             }
 
@@ -403,7 +402,7 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
     } else {
         $maxNumberRecipients = 1;
         // list all roles where guests could send mails to
-        $sql = 'SELECT rol_id, rol_name
+        $sql = 'SELECT rol_uuid, rol_name
                   FROM '.TBL_ROLES.'
             INNER JOIN '.TBL_CATEGORIES.'
                     ON cat_id = rol_cat_id
@@ -415,7 +414,7 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
 
         $statement = $gDb->queryPrepared($sql, array($gCurrentOrgId));
         while ($row = $statement->fetch()) {
-            $list[] = array('groupID: '.$row['rol_id'], $row['rol_name'], '');
+            $list[] = array('groupID: '.$row['rol_uuid'], $row['rol_name'], '');
         }
     }
 

--- a/adm_program/modules/messages/messages_write.php
+++ b/adm_program/modules/messages/messages_write.php
@@ -340,7 +340,7 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
 
         if ($getRoleUuid === '' && count($listVisibleRoleArray) > 0) {
             // if no special role was preselected then list users
-            $sql = 'SELECT usr_id, first_name.usd_value AS first_name, last_name.usd_value AS last_name, rol_id, mem_begin, mem_end
+            $sql = 'SELECT usr_uuid, first_name.usd_value AS first_name, last_name.usd_value AS last_name, rol_id, mem_begin, mem_end
                       FROM '.TBL_MEMBERS.'
                 INNER JOIN '.TBL_ROLES.'
                         ON rol_id = mem_rol_id
@@ -378,21 +378,20 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
             }
             $statement = $gDb->queryPrepared($sql, $queryParams);
 
-            $passiveList = array();
-            $activeList = array();
+            $passiveList   = array();
+            $activeList    = array();
+            $currentUserId = '';
 
             while ($row = $statement->fetch()) {
-                $usrId = (int) $row['usr_id'];
-
                 // every user should only be once in the list
-                if (!isset($currentUserId) || $currentUserId !== $usrId) {
+                if ($currentUserId !== $row['usr_uuid']) {
                     // if membership is active then show them as active members
                     if ($row['mem_begin'] <= DATE_NOW && $row['mem_end'] >= DATE_NOW) {
-                        $activeList[]  = array($usrId, $row['last_name'].' '.$row['first_name'], $gL10n->get('SYS_ACTIVE_MEMBERS'));
-                        $currentUserId = $usrId;
+                        $activeList[]  = array($row['usr_uuid'], $row['last_name'].' '.$row['first_name'], $gL10n->get('SYS_ACTIVE_MEMBERS'));
+                        $currentUserId = $row['usr_uuid'];
                     } elseif ($gSettingsManager->getBool('mail_show_former')) {
-                        $passiveList[] = array($usrId, $row['last_name'].' '.$row['first_name'], $gL10n->get('SYS_FORMER_MEMBERS'));
-                        $currentUserId = $usrId;
+                        $passiveList[] = array($row['usr_uuid'], $row['last_name'].' '.$row['first_name'], $gL10n->get('SYS_FORMER_MEMBERS'));
+                        $currentUserId = $row['usr_uuid'];
                     }
                 }
             }

--- a/adm_program/modules/messages/messages_write.php
+++ b/adm_program/modules/messages/messages_write.php
@@ -328,9 +328,9 @@ if ($getMsgType === TableMessage::MESSAGE_TYPE_PM) {
                 $listRoleIdsArray[] = $roleArray['rol_id'];
                 if ($role->hasFormerMembers() > 0 && $gSettingsManager->getBool('mail_show_former')) {
                     // list role with former members
-                    $listFormer[] = array('groupID: '.$roleArray['rol_uuid'].'-1', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_FORMER_PL').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_FORMER_MEMBERS') . ')');
+                    $listFormer[] = array('groupID: '.$roleArray['rol_uuid'].'+1', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_FORMER_PL').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_FORMER_MEMBERS') . ')');
                     // list role with active and former members
-                    $listActiveAndFormer[] = array('groupID: '.$roleArray['rol_uuid'].'-2', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS_SHORT').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS') . ')');
+                    $listActiveAndFormer[] = array('groupID: '.$roleArray['rol_uuid'].'+2', $roleArray['rol_name'].' '.'('.$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS_SHORT').')', $gL10n->get('SYS_ROLES'). ' (' .$gL10n->get('SYS_ACTIVE_FORMER_MEMBERS') . ')');
                 }
             }
 

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -613,22 +613,22 @@ $formSystemNotification = new HtmlForm(
 );
 
 $formSystemNotification->addCheckbox(
-    'enable_system_mails',
+    'system_notifications_enabled',
     $gL10n->get('ORG_ACTIVATE_SYSTEM_MAILS'),
-    (bool) $formValues['enable_system_mails'],
+    (bool) $formValues['system_notifications_enabled'],
     array('helpTextIdInline' => 'ORG_ACTIVATE_SYSTEM_MAILS_DESC')
 );
 
 $formSystemNotification->addCheckbox(
-    'enable_email_notification',
+    'system_notifications_new_entries',
     $gL10n->get('ORG_SYSTEM_MAIL_NEW_ENTRIES'),
-    (bool) $formValues['enable_email_notification'],
+    (bool) $formValues['system_notifications_new_entries'],
     array('helpTextIdInline' => array('ORG_SYSTEM_MAIL_NEW_ENTRIES_DESC', array('<em>'.$gSettingsManager->getString('email_administrator').'</em>')))
 );
 $formSystemNotification->addCheckbox(
-    'enable_email_changenotification',
+    'system_notifications_profile_changes',
     $gL10n->get('ORG_SYSTEM_MAIL_CHANGES'),
-    (bool) $formValues['enable_email_changenotification'],
+    (bool) $formValues['system_notifications_profile_changes'],
     array('helpTextIdInline' => array('ORG_SYSTEM_MAIL_CHANGES_DESC', array('<em>'.$gSettingsManager->getString('email_administrator').'</em>')))
 );
 
@@ -647,11 +647,11 @@ $sqlData['query'] = 'SELECT rol_uuid, rol_name, cat_name
            ORDER BY cat_name, rol_name';
 $sqlData['params'] = array($gCurrentOrgId);
 $formSystemNotification->addSelectBoxFromSql(
-    'system_notification_role',
+    'system_notifications_role',
     $gL10n->get('SYS_ROLE'),
     $gDb,
     $sqlData,
-    array('defaultValue' => $formValues['system_notification_role'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_NOTIFICATION_ROLE_DESC')
+    array('defaultValue' => $formValues['system_notifications_role'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_NOTIFICATION_ROLE_DESC')
 );
 
 $formSystemNotification->addCustomContent(

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -520,6 +520,12 @@ $formEmailDispatch->addSelectBox(
     $selectBoxEntries,
     array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
 );
+$formEmailDispatch->addCheckbox(
+    'mail_into_to',
+    $gL10n->get('SYS_INTO_TO'),
+    (bool) $formValues['mail_into_to'],
+    array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
+);
 $formEmailDispatch->addInput(
     'mail_number_recipients',
     $gL10n->get('SYS_NUMBER_RECIPIENTS'),
@@ -1543,12 +1549,6 @@ $formMessages->addCheckbox(
     $gL10n->get('SYS_SEND_EMAIL_FORMER'),
     (bool) $formValues['mail_show_former'],
     array('helpTextIdInline' => 'SYS_SEND_EMAIL_FORMER_DESC')
-);
-$formMessages->addCheckbox(
-    'mail_into_to',
-    $gL10n->get('SYS_INTO_TO'),
-    (bool) $formValues['mail_into_to'],
-    array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
 );
 $formMessages->addInput(
     'max_email_attachment_size',

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -521,10 +521,10 @@ $formEmailDispatch->addSelectBox(
     array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
 );
 $formEmailDispatch->addInput(
-    'mail_bcc_count',
-    $gL10n->get('SYS_COUNT_BCC'),
-    $formValues['mail_bcc_count'],
-    array('type' => 'number', 'minNumber' => 0, 'maxNumber' => 9999, 'step' => 1, 'helpTextIdInline' => 'SYS_COUNT_BCC_DESC')
+    'mail_number_recipients',
+    $gL10n->get('SYS_NUMBER_RECIPIENTS'),
+    $formValues['mail_number_recipients'],
+    array('type' => 'number', 'minNumber' => 0, 'maxNumber' => 9999, 'step' => 1, 'helpTextIdInline' => 'SYS_NUMBER_RECIPIENTS_DESC')
 );
 $selectBoxEntries = array('iso-8859-1' => $gL10n->get('SYS_ISO_8859_1'), 'utf-8' => $gL10n->get('SYS_UTF8'));
 $formEmailDispatch->addSelectBox(

--- a/adm_program/modules/preferences/preferences_function.php
+++ b/adm_program/modules/preferences/preferences_function.php
@@ -130,7 +130,7 @@ switch ($getMode) {
                     break;
 
                 case 'email_dispatch':
-                    $checkboxes = array('mail_smtp_auth');
+                    $checkboxes = array('mail_into_to', 'mail_smtp_auth');
 
                     if ($_POST['mail_sendmail_address'] !== '') {
                         if (!StringUtils::strValidCharacters($_POST['mail_sendmail_address'], 'email')) {
@@ -177,7 +177,7 @@ switch ($getMode) {
 
                 case 'messages':
                     $checkboxes = array('enable_mail_module', 'enable_pm_module', 'enable_mail_captcha',
-                                        'mail_send_to_all_addresses', 'mail_html_registered_users', 'mail_into_to', 'mail_show_former', 'mail_save_attachments');
+                                        'mail_send_to_all_addresses', 'mail_html_registered_users', 'mail_show_former', 'mail_save_attachments');
                     break;
 
                 case 'photos':

--- a/adm_program/modules/preferences/preferences_function.php
+++ b/adm_program/modules/preferences/preferences_function.php
@@ -141,7 +141,7 @@ switch ($getMode) {
                     break;
 
                 case 'system_notification':
-                    $checkboxes = array('enable_system_mails', 'enable_email_notification', 'enable_email_changenotification');
+                    $checkboxes = array('system_notifications_enabled', 'system_notifications_new_entries', 'system_notifications_profile_changes');
                     break;
 
                 case 'captcha':

--- a/adm_program/modules/profile/password.php
+++ b/adm_program/modules/profile/password.php
@@ -39,7 +39,7 @@ $userId    = $user->getValue('usr_id');
 if ($gCurrentUserId !== $userId
 && (!isMember($userId)
 || (!$gCurrentUser->isAdministrator() && $gCurrentUserId !== $userId)
-|| ($gCurrentUser->isAdministrator() && $user->getValue('EMAIL') !== '' && $gSettingsManager->getBool('enable_system_mails')))) {
+|| ($gCurrentUser->isAdministrator() && $user->getValue('EMAIL') !== '' && $gSettingsManager->getBool('system_notifications_enabled')))) {
     $gMessage->show($gL10n->get('SYS_NO_RIGHTS'));
     // => EXIT
 }

--- a/adm_program/modules/profile/profile.php
+++ b/adm_program/modules/profile/profile.php
@@ -220,7 +220,7 @@ if ($userId === $gCurrentUserId) {
 } elseif ($gCurrentUser->isAdministrator() && isMember($userId) && strlen($user->getValue('usr_login_name')) > 0) {
     // Administrators can change or send password if login is configured and user is member of current organization
 
-    if (strlen($user->getValue('EMAIL')) > 0 && $gSettingsManager->getBool('enable_system_mails')) {
+    if (strlen($user->getValue('EMAIL')) > 0 && $gSettingsManager->getBool('system_notifications_enabled')) {
         // if email is set and systemmails are activated then administrator can send a new password to user
         $page->addPageFunctionsMenuItem(
             'menu_item_profile_send_password',

--- a/adm_program/modules/registration/registration_assign.php
+++ b/adm_program/modules/registration/registration_assign.php
@@ -159,7 +159,7 @@ while ($row = $usrStatement->fetch()) {
         if (strlen($row['usr_login_name']) > 0) {
             // Logindaten sind bereits vorhanden -> Logindaten neu zuschicken
             $page->addHtml('<p>'.$gL10n->get('SYS_USER_VALID_LOGIN'));
-            if ($gSettingsManager->getBool('enable_system_mails')) {
+            if ($gSettingsManager->getBool('system_notifications_enabled')) {
                 $page->addHtml('<br />'.$gL10n->get('SYS_REMINDER_SEND_LOGIN').'</p>
 
                 <button class="btn btn-primary" onclick="window.location.href=\''.SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/registration/registration_function.php', array('new_user_uuid' => $getNewUserUuid, 'user_uuid' => $row['usr_uuid'], 'mode' => '6')).'\'">

--- a/adm_program/modules/registration/registration_function.php
+++ b/adm_program/modules/registration/registration_function.php
@@ -87,7 +87,7 @@ if ($getMode === 1 || $getMode === 2) {
     $gMessage->setForwardUrl(ADMIDIO_URL.FOLDER_MODULES.'/registration/registration.php');
 
     // execute only if system mails are supported
-    if ($gSettingsManager->getBool('enable_system_mails')) {
+    if ($gSettingsManager->getBool('system_notifications_enabled')) {
         try {
             // Send mail to the user to confirm the registration or the assignment to the new organization
             $systemMail = new SystemMail($gDb);

--- a/adm_program/system/bootstrap/function.php
+++ b/adm_program/system/bootstrap/function.php
@@ -648,25 +648,3 @@ function getExecutionTime($startTime)
 
     return number_format(($stopTime - $startTime) * 1000, 6, '.', '') . ' ms';
 }
-
-/**
- * Search all visible files or directories in the specified directory.
- * @deprecated 4.0.0:4.1.0 "admFuncGetDirectoryEntries()" is deprecated, use "FileSystemUtils::getDirectoryContent()" instead.
- * @param string $directory  The directory where the files or directories should be searched.
- * @param string $searchType This could be **file**, **dir**, **both** or **all** and represent
- *                           the type of entries that should be searched.
- * @return false|array<string,string> Returns an array with all found entries or false if an error occurs.
- */
-function admFuncGetDirectoryEntries($directory, $searchType = 'file')
-{
-    switch ($searchType) {
-        case 'file':
-            return array_keys(FileSystemUtils::getDirectoryContent($directory, false, false, array(FileSystemUtils::CONTENT_TYPE_FILE)));
-        case 'dir':
-            return array_keys(FileSystemUtils::getDirectoryContent($directory, false, false, array(FileSystemUtils::CONTENT_TYPE_DIRECTORY)));
-        case 'both':
-            return array_keys(FileSystemUtils::getDirectoryContent($directory, false, false));
-        case 'all':
-            return array_keys(FileSystemUtils::getDirectoryContent($directory, false, false));
-    }
-}

--- a/adm_program/system/classes/ChangeNotification.php
+++ b/adm_program/system/classes/ChangeNotification.php
@@ -379,8 +379,8 @@ class ChangeNotification
     {
         global $gSettingsManager, $gL10n, $gCurrentUser;
 
-        if ($gSettingsManager->has('enable_email_changenotification')
-            && $gSettingsManager->getBool('enable_email_changenotification')
+        if ($gSettingsManager->has('system_notifications_profile_changes')
+            && $gSettingsManager->getBool('system_notifications_profile_changes')
             && is_object($gCurrentUser)) {
             $currfullname = $gCurrentUser->getValue('FIRST_NAME') . ' ' . $gCurrentUser->getValue('LAST_NAME');
             $currname = $currfullname . ' (login: ' . $gCurrentUser->getValue('usr_login_name') . ')';
@@ -467,7 +467,7 @@ class ChangeNotification
                         $message,
                         $currfullname,
                         $gCurrentUser->getValue('EMAIL'),
-                        'enable_email_changenotification'
+                        'system_notifications_profile_changes'
                     );
                 }
             }

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -145,17 +145,19 @@ class Email extends PHPMailer
     }
 
     /**
-     * Adds the name and address to the recipients list. If the recipient will be sent as TO or BCC will be later
-     * independence of other preference be set.
-     * @param string $address
-     * @param string $name
-     * @return true|string
+     * Adds the name and address to the recipients list. The valid email address will only be added if it's not already
+     * in the recipients list. The decision if the recipient will be sent as TO or BCC will be done later
+     * in the email send process.
+     * @param string $address A valid email address to which the email should be sent.
+     * @param string $name    The name of the recipient that will be shown in the email header.
+     * @return bool Returns **true** if the address was added to the recipients list.
      */
     public function addRecipient($address, $name = '')
     {
         // Recipients must be Ascii-US formatted, so encode in MimeHeader
         $asciiName = stripslashes($name);
 
+        // check if valid email address and if email not in the recipients array
         if (StringUtils::strValidCharacters($address, 'email')
         && array_search($address, array_column($this->emRecipientsArray, 'address')) === false) {
             $this->emRecipientsArray[] = array('name' => $asciiName, 'address' => $address);
@@ -362,7 +364,7 @@ class Email extends PHPMailer
      */
     public function adminNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'enable_email_notification')
     {
-        $this->sendNotification($subject, $message, $editorName, $editorEmail, $enable_flag);
+        return $this->sendNotification($subject, $message, $editorName, $editorEmail, $enable_flag);
     }
 
     /**

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -156,7 +156,8 @@ class Email extends PHPMailer
         // Recipients must be Ascii-US formatted, so encode in MimeHeader
         $asciiName = stripslashes($name);
 
-        if (StringUtils::strValidCharacters($address, 'email')) {
+        if (StringUtils::strValidCharacters($address, 'email')
+        && array_search($address, array_column($this->emRecipientsArray, 'address')) === false) {
             $this->emRecipientsArray[] = array('name' => $asciiName, 'address' => $address);
             $this->emRecipientsNames[] = $name;
             return true;

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -641,7 +641,7 @@ class Email extends PHPMailer
 
         try {
             // if there is a limit of email recipients than split the recipients into smaller packages
-            $recipientsArrays = array_chunk($this->emBccArray, $gSettingsManager->getInt('mail_bcc_count'));
+            $recipientsArrays = array_chunk($this->emBccArray, $gSettingsManager->getInt('mail_number_recipients'));
 
             foreach ($recipientsArrays as $recipientsArray) {
                 // if number of bcc recipients = 1 then send the mail directly to the user and not as bcc

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -146,25 +146,23 @@ class Email extends PHPMailer
     }
 
     /**
-     * method adds main recipients to mail
+     * Adds the name and address to the recipients list. If the recipient will be sent as TO or BCC will be later
+     * independence of other preference be set.
      * @param string $address
      * @param string $name
      * @return true|string
      */
     public function addRecipient($address, $name = '')
     {
-        return $this->addBlindCopy($address, $name);
-        /*try {
-            $this->addAddress($address, $name);
-        } catch (Exception $e) {
-            return $e->errorMessage();
-        } catch (\Exception $e) {
-            return $e->getMessage();
+        // Recipients must be Ascii-US formatted, so encode in MimeHeader
+        $asciiName = stripslashes($name);
+
+        if (StringUtils::strValidCharacters($address, 'email')) {
+            $this->emBccArray[] = array('name' => $asciiName, 'address' => $address);
+            $this->emRecipientsNames[] = $name;
+            return true;
         }
-
-        $this->emRecipientsNames[] = $name;
-
-        return true;*/
+        return false;
     }
 
     /**
@@ -252,7 +250,7 @@ class Email extends PHPMailer
             // all email addresses will be attached as BCC
             while ($row = $statement->fetch()) {
                 if (StringUtils::strValidCharacters($row['email'], 'email')) {
-                    $this->addBlindCopy($row['email'], $row['firstname'] . ' ' . $row['lastname']);
+                    $this->addRecipient($row['email'], $row['firstname'] . ' ' . $row['lastname']);
                     ++$numberRecipientsAdded;
                 }
             }
@@ -267,7 +265,7 @@ class Email extends PHPMailer
     /**
      * Add the name and email address of the given user id to the email as a normal recipient. If the system setting
      * **mail_send_to_all_addresses** is set than all email addresses of the given user id will be added.
-     * @param int $userId ID of an user who should be the recipient of the email.
+     * @param int $userId ID of a user who should be the recipient of the email.
      * @throws AdmException in case of errors. exception->text contains a string with the reason why no recipient could be added.
      *                     Possible reasons: SYS_NO_VALID_RECIPIENTS
      * @return int Returns the number of added email addresses.
@@ -306,7 +304,7 @@ class Email extends PHPMailer
             // all email addresses will be attached as BCC
             while ($row = $statement->fetch()) {
                 if (StringUtils::strValidCharacters($row['email'], 'email')) {
-                    $this->addBlindCopy($row['email'], $row['firstname'] . ' ' . $row['lastname']);
+                    $this->addRecipient($row['email'], $row['firstname'] . ' ' . $row['lastname']);
                     ++$numberRecipientsAdded;
                 }
             }
@@ -344,18 +342,11 @@ class Email extends PHPMailer
      * @param string $address
      * @param string $name
      * @return bool
+     * @deprecated 4.2.0:4.3.0 "addBlindCopy()" is deprecated, use "addRecipient()" instead.
      */
     public function addBlindCopy($address, $name = '')
     {
-        // Blindcopy must be Ascii-US formated, so encode in MimeHeader
-        $asciiName = stripslashes($name);
-
-        if (StringUtils::strValidCharacters($address, 'email')) {
-            $this->emBccArray[] = array('name' => $asciiName, 'address' => $address);
-            $this->emRecipientsNames[] = $name;
-            return true;
-        }
-        return false;
+        return $this->addRecipient($address, $name);
     }
 
     /**

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -353,7 +353,7 @@ class Email extends PHPMailer
 
     /**
      * Send a notification email to all members of the notification role. This role is configured within the
-     * global preference **system_notification_role**.
+     * global preference **system_notifications_role**.
      * @param string $subject     The subject of the email.
      * @param string $message     The body of the email.
      * @param string $editorName  The name of the sender of the email.
@@ -362,7 +362,7 @@ class Email extends PHPMailer
      * @return bool|string
      * @deprecated 4.2.0:4.3.0 "adminNotification()" is deprecated, use "sendNotification()" instead.
      */
-    public function adminNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'enable_email_notification')
+    public function adminNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'system_notifications_new_entries')
     {
         return $this->sendNotification($subject, $message, $editorName, $editorEmail, $enable_flag);
     }
@@ -713,7 +713,7 @@ class Email extends PHPMailer
 
     /**
      * Send a notification email to all members of the notification role. This role is configured within the
-     * global preference **system_notification_role**.
+     * global preference **system_notifications_role**.
      * @param string $subject     The subject of the email.
      * @param string $message     The body of the email.
      * @param string $editorName  The name of the sender of the email.
@@ -721,7 +721,7 @@ class Email extends PHPMailer
      * @throws AdmException 'SYS_EMAIL_NOT_SEND'
      * @return bool|string
      */
-    public function sendNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'enable_email_notification')
+    public function sendNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'system_notifications_new_entries')
     {
         global $gSettingsManager, $gCurrentOrganization;
 
@@ -730,7 +730,7 @@ class Email extends PHPMailer
         }
 
         // Send notification to configured role
-        $this->addRecipientsByRole($gSettingsManager->getString('system_notification_role'));
+        $this->addRecipientsByRole($gSettingsManager->getString('system_notifications_role'));
 
         // Set Sender
         if ($editorEmail === '') {

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -650,7 +650,7 @@ class Email extends PHPMailer
 
                     $this->addAddress($recipientsArray[0]['address'], $recipientsArray[0]['name']);
                     if ($gDebug) {
-                        $gLogger->notice('Email send as TO to ' . $recipientsArray[0]['name'] . ' (' . $recipientsArray[0]['address']) . ')';
+                        $gLogger->notice('Email send as TO to ' . $recipientsArray[0]['name'] . ' (' . $recipientsArray[0]['address'] . ')');
                     }
                 } elseif ($gSettingsManager->getBool('mail_into_to')) {
                     // remove all current recipients from mail
@@ -660,7 +660,7 @@ class Email extends PHPMailer
                     foreach ($recipientsArray as $recipientTO) {
                         $this->addAddress($recipientTO['address'], $recipientTO['name']);
                         if ($gDebug) {
-                            $gLogger->notice('Email send as TO to ' . $recipientTO['name'] . ' (' . $recipientTO['address']) . ')';
+                            $gLogger->notice('Email send as TO to ' . $recipientTO['name'] . ' (' . $recipientTO['address'] . ')');
                         }
                     }
                 } else {
@@ -671,7 +671,7 @@ class Email extends PHPMailer
                     foreach ($recipientsArray as $recipientBCC) {
                         $this->addBCC($recipientBCC['address'], $recipientBCC['name']);
                         if ($gDebug) {
-                            $gLogger->notice('Email send as BCC to ' . $recipientBCC['name'] . ' (' . $recipientBCC['address']) . ')';
+                            $gLogger->notice('Email send as BCC to ' . $recipientBCC['name'] . ' (' . $recipientBCC['address'] . ')');
                         }
                     }
                 }

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -104,21 +104,20 @@ class Email extends PHPMailer
     /**
      * @var array<int,array<string,string>>
      */
-    private $emBccArray = array();
+    private $emRecipientsArray = array();
 
     /**
      * Email constructor.
      */
     public function __construct()
     {
-        // Übername Einstellungen
         global $gL10n, $gSettingsManager, $gDebug;
 
         parent::__construct(true); // enable exceptions in PHPMailer
 
         $this->Timeout = 30; // set timeout to 30 seconds
 
-        // Versandmethode festlegen
+        // set sending method
         if ($gSettingsManager->getString('mail_send_method') === 'SMTP') {
             $this->isSMTP();
 
@@ -158,7 +157,7 @@ class Email extends PHPMailer
         $asciiName = stripslashes($name);
 
         if (StringUtils::strValidCharacters($address, 'email')) {
-            $this->emBccArray[] = array('name' => $asciiName, 'address' => $address);
+            $this->emRecipientsArray[] = array('name' => $asciiName, 'address' => $address);
             $this->emRecipientsNames[] = $name;
             return true;
         }
@@ -363,6 +362,15 @@ class Email extends PHPMailer
     public function adminNotification($subject, $message, $editorName = '', $editorEmail = '', $enable_flag = 'enable_email_notification')
     {
         $this->sendNotification($subject, $message, $editorName, $editorEmail, $enable_flag);
+    }
+
+    /**
+     * Get the count of all recipients that are currently set for this email.
+     * @return int Returns the number of recipients currently set for this email.
+     */
+    public function countRecipients()
+    {
+        return count($this->emRecipientsArray);
     }
 
     /**
@@ -632,7 +640,7 @@ class Email extends PHPMailer
 
         try {
             // if there is a limit of email recipients than split the recipients into smaller packages
-            $recipientsArrays = array_chunk($this->emBccArray, $gSettingsManager->getInt('mail_number_recipients'));
+            $recipientsArrays = array_chunk($this->emRecipientsArray, $gSettingsManager->getInt('mail_number_recipients'));
 
             foreach ($recipientsArrays as $recipientsArray) {
                 // if number of bcc recipients = 1 then send the mail directly to the user and not as bcc

--- a/adm_program/system/classes/ModuleMessages.php
+++ b/adm_program/system/classes/ModuleMessages.php
@@ -72,13 +72,13 @@ class ModuleMessages
 
     /**
      * check for Group and give back a array with group ID[0] and if it is active, inactive or both [1].
-     * @param string $groupString (e.g: "groupID: 4-2")
+     * @param string $groupString (e.g: "groupID: 93ce816e-7cfd-45e1-b025-a3644828c47c+2")
      * @return array<string,string|int> Returns the groupId and status
      */
     public static function msgGroupSplit($groupString)
     {
         $groupSplit = explode(':', $groupString);
-        $groupIdAndStatus = explode('-', trim($groupSplit[1]));
+        $groupIdAndStatus = explode('+', trim($groupSplit[1]));
 
         if (count($groupIdAndStatus) === 1) {
             $status = Email::EMAIL_ONLY_ACTIVE_MEMBERS;
@@ -92,7 +92,7 @@ class ModuleMessages
         }
 
         return array(
-            'id'        => $groupIdAndStatus[0],
+            'uuid'      => $groupIdAndStatus[0],
             'status'    => $status,
             'role_mode' => $groupIdAndStatus[1]
         );

--- a/adm_program/system/classes/ModuleMessages.php
+++ b/adm_program/system/classes/ModuleMessages.php
@@ -81,18 +81,18 @@ class ModuleMessages
         $groupIdAndStatus = explode('-', trim($groupSplit[1]));
 
         if (count($groupIdAndStatus) === 1) {
-            $status = 'active';
+            $status = Email::EMAIL_ONLY_ACTIVE_MEMBERS;
             $groupIdAndStatus[] = 0;
         } elseif ($groupIdAndStatus[1] === '1') {
-            $status = 'former';
+            $status = Email::EMAIL_ONLY_FORMER_MEMBERS;
         } elseif ($groupIdAndStatus[1] === '2') {
-            $status = 'active_former';
+            $status = Email::EMAIL_ALL_MEMBERS;
         } else {
-            $status = 'unknown';
+            $status = Email::EMAIL_ONLY_ACTIVE_MEMBERS;
         }
 
         return array(
-            'id'        => (int) $groupIdAndStatus[0],
+            'id'        => $groupIdAndStatus[0],
             'status'    => $status,
             'role_mode' => $groupIdAndStatus[1]
         );

--- a/adm_program/system/classes/Organization.php
+++ b/adm_program/system/classes/Organization.php
@@ -372,7 +372,7 @@ class Organization extends TableAccess
         // set new default configuration to the module settings
         $organizationSettings = new SettingsManager($this->db, $orgId);
         $organizationSettings->getAll();
-        $organizationSettings->set('system_notification_role', $roleAdministrator->getValue('rol_uuid'));
+        $organizationSettings->set('system_notifications_role', $roleAdministrator->getValue('rol_uuid'));
         $organizationSettings->set('groups_roles_default_configuration', $addressList->getValue('lst_id'));
         $organizationSettings->set('dates_default_list_configuration', $participantList->getValue('lst_id'));
         $organizationSettings->set('members_list_configuration', $userManagementList->getValue('lst_id'));

--- a/adm_program/system/classes/UserRegistration.php
+++ b/adm_program/system/classes/UserRegistration.php
@@ -95,7 +95,7 @@ class UserRegistration extends User
         $this->db->endTransaction();
 
         // only send mail if systemmails are enabled
-        if ($GLOBALS['gSettingsManager']->getBool('enable_system_mails') && $this->sendEmail) {
+        if ($GLOBALS['gSettingsManager']->getBool('system_notifications_enabled') && $this->sendEmail) {
             // send mail to user that his registration was accepted
             $sysmail = new SystemMail($this->db);
             $sysmail->addRecipientsByUserId((int) $this->getValue('usr_id'));
@@ -138,7 +138,7 @@ class UserRegistration extends User
     {
         // only send mail if systemmails are enabled and user has email address
         // mail must be send before user data is removed from this object
-        if ($GLOBALS['gSettingsManager']->getBool('enable_system_mails') && $this->sendEmail && $this->getValue('EMAIL') !== '') {
+        if ($GLOBALS['gSettingsManager']->getBool('system_notifications_enabled') && $this->sendEmail && $this->getValue('EMAIL') !== '') {
             // send mail to user that his registration was rejected
             $sysmail = new SystemMail($this->db);
             $sysmail->addRecipientsByUserId((int) $this->getValue('usr_id'));
@@ -225,7 +225,7 @@ class UserRegistration extends User
 
             // send a notification mail to all role members of roles that can approve registrations
             // therefore the flags system mails and notification mail for roles with approve registration must be activated
-            if ($GLOBALS['gSettingsManager']->getBool('enable_system_mails')
+            if ($GLOBALS['gSettingsManager']->getBool('system_notifications_enabled')
                 && $GLOBALS['gSettingsManager']->getBool('enable_registration_admin_mail') && $this->sendEmail) {
                 $sql = 'SELECT DISTINCT first_name.usd_value AS first_name, last_name.usd_value AS last_name, email.usd_value AS email
                           FROM '.TBL_MEMBERS.'

--- a/adm_program/system/login.php
+++ b/adm_program/system/login.php
@@ -77,7 +77,7 @@ if ($gSettingsManager->getBool('registration_enable_module')) {
 }
 
 // show link if user has login problems
-if ($gSettingsManager->getBool('enable_password_recovery') && $gSettingsManager->getBool('enable_system_mails')) {
+if ($gSettingsManager->getBool('enable_password_recovery') && $gSettingsManager->getBool('system_notifications_enabled')) {
     // request to reset the password
     $forgotPasswordLink = ADMIDIO_URL.FOLDER_SYSTEM.'/password_reset.php';
 } elseif ($gSettingsManager->getBool('enable_mail_module') && $roleAdministrator->getValue('rol_mail_this_role') == 3) {

--- a/adm_program/system/password_reset.php
+++ b/adm_program/system/password_reset.php
@@ -20,7 +20,7 @@ $getResetId  = admFuncVariableIsValid($_GET, 'id', 'string');
 $getUserUuid = admFuncVariableIsValid($_GET, 'user_uuid', 'string');
 
 // "systemmail" and "request password" must be activated
-if (!$gSettingsManager->getBool('enable_system_mails') || !$gSettingsManager->getBool('enable_password_recovery')) {
+if (!$gSettingsManager->getBool('system_notifications_enabled') || !$gSettingsManager->getBool('enable_password_recovery')) {
     $gMessage->show($gL10n->get('SYS_MODULE_DISABLED'));
     // => EXIT
 }


### PR DESCRIPTION
The following changes are done:
- new recipients will be always set through one method. If a recipients will get the mail as TO or BCC will be choosen later when the mail will be send.
- all checks to the recipients will be done within the email class
- Some preferences have new better descriptions and a new position within the preferences dialog.