### PR TITLE
Fixed docker environment variables not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG ADMIDIO_VERSION
 LABEL org.label-schema.build-date="${ADMIDIO_BUILD_DATE}" \
       org.label-schema.name="Admidio" \
       org.label-schema.description="Admidio is a free open source user management system for websites of organizations and groups." \
-      org.label-schema.license="GPL-2.0", \
+      org.label-schema.license="GPL-2.0" \
       org.label-schema.url="https://www.admidio.org/" \
       org.label-schema.vcs-ref="${ADMIDIO_VCS_REF}" \
       org.label-schema.vcs-url="https://github.com/Admidio/admidio" \

--- a/dockerscripts/startup.sh
+++ b/dockerscripts/startup.sh
@@ -50,10 +50,14 @@ mailq
 
 
 # generate admidio config.php
-# ADMIDIO_CONFIG_TEMPLATE="/opt/app-root/src/adm_my_files/config_example.php"
+ADMIDIO_CONFIG_TEMPLATE="/opt/app-root/src/provisioning/adm_my_files/config_example.php"
 ADMIDIO_CONFIG="/opt/app-root/src/adm_my_files/config.php"
-# echo "[INFO ] generate admidio config.php file"
-# cp --preserve=mode,ownership,timestamps "${ADMIDIO_CONFIG_TEMPLATE}" "${ADMIDIO_CONFIG}"
+
+# if nessary environment variables exist, copy config template to config file
+if ! ( [ -z "${ADMIDIO_DB_HOST}" ] || ( [ -z "${ADMIDIO_DB_PORT}" ] && [ -z "${ADMIDIO_DB_HOST##*:}" ] ) || [ -z "${ADMIDIO_DB_NAME}" ] || [ -z "${ADMIDIO_DB_USER}" ] || [ -z "${ADMIDIO_DB_PASSWORD}" ] ) ; then
+    echo "[INFO ] generate admidio config.php file"
+    cp --preserve=mode,ownership,timestamps "${ADMIDIO_CONFIG_TEMPLATE}" "${ADMIDIO_CONFIG}"
+fi
 # chown default.root "${ADMIDIO_CONFIG}"
 # chmod 664 "${ADMIDIO_CONFIG}"
 


### PR DESCRIPTION
I had some problems running Admidio behind a reverse proxy, as my environment variables had no effect. So I went digging and found, that the Admidio config is actually not generated. I changed the script to check if necessary environment variables are set and generate the config.