### PR TITLE
Receipient Placeholder in email wrapper

### DIFF
--- a/adm_program/installation/db_scripts/preferences.php
+++ b/adm_program/installation/db_scripts/preferences.php
@@ -49,6 +49,7 @@ $defaultOrgPreferences = array(
 
     // E-mail dispatch
     'mail_send_method'               => 'phpmail',
+    'mail_sending_mode'              => '0',
     'mail_recipients_with_roles'     => '1',
     'mail_number_recipients'         => '50',
     'mail_into_to'                   => '0',

--- a/adm_program/languages/de-DE.xml
+++ b/adm_program/languages/de-DE.xml
@@ -1043,6 +1043,10 @@
   <string name="SYS_MOVE_VAR">#VAR1# verschieben</string>
   <string name="SYS_MULTIPLE_RECIPIENTS">Mehrere Empfänger:innen</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-Mails an mehrere Empfänger:innen enthalten alle Empfänger:innen im BCC-Feld. Damit ist sichergestellt, dass keiner die E-Mail-Adressen der anderen Empfänger:innen sieht. Das TO-Feld muss allerdings auch befüllt werden. Über diese Einstellung kann festgelegt werden, was im Empfängerfeld (TO) hinterlegt wird. Dies kein ein versteckter Wert \"Undisclosed Recipients\" sein, was aber bei manchen Providern zu Problemen führt. Alternativ kann das Empfängerfeld (TO) mit der Absenderadresse bzw. der Administrator:innen-Adresse aus den Systembenachrichtigungen gefüllt werden. Hinweis: Alle Emails an mehrere Empfänger:innen werden dann auch an die E-Mail-Adresse im Empfängerfeld (TO) geschickt. (Voreinstellung: Absender:in)</string>
+  <string name="SYS_MAIL_SENDING_MODE">E-mail Versand</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">Im Modus "Gebündelter versandt" werden E-Mails in einer oder mehrerer gebündelten E-Mails versendet. Dabei werden die Empfänger als BCC oder TO eingefügt. Im Modus "Einzelempfänger" wird jede E-Mail einzeln an den entsprechenden Empfänger im TO Feld versendet. In diesem Modus gibt es weitere Platzhalter die verwendet werden können:\nEmpfänger Vorname:\n#receiver_first_name# #receiver_firstname# #receiver_surname#\nEmpfänger Nachname:\n#receiver_lastname#\nEmpfänger E-Mail:\n#receiver_email#\nEmpfänger Name:\n#receiver_name#</string>
+  <string name="SYS_MAIL_BULK">Gebündelter versandt</string>
+  <string name="SYS_MAIL_SINGLE">Einzelempfänger</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">Die Rolle Administrator:in muss mindestens ein Mitglied haben!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Hier können Sie Bedingungen zu jedem Feld in Ihrer Liste hinterlegen. Damit werden die ermittelten Mitglieder der ausgewählten Rolle mit Ihren Bedingungen weiter eingeschränkt.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/languages/de-DE.xml
+++ b/adm_program/languages/de-DE.xml
@@ -1043,10 +1043,10 @@
   <string name="SYS_MOVE_VAR">#VAR1# verschieben</string>
   <string name="SYS_MULTIPLE_RECIPIENTS">Mehrere Empfänger:innen</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-Mails an mehrere Empfänger:innen enthalten alle Empfänger:innen im BCC-Feld. Damit ist sichergestellt, dass keiner die E-Mail-Adressen der anderen Empfänger:innen sieht. Das TO-Feld muss allerdings auch befüllt werden. Über diese Einstellung kann festgelegt werden, was im Empfängerfeld (TO) hinterlegt wird. Dies kein ein versteckter Wert \"Undisclosed Recipients\" sein, was aber bei manchen Providern zu Problemen führt. Alternativ kann das Empfängerfeld (TO) mit der Absenderadresse bzw. der Administrator:innen-Adresse aus den Systembenachrichtigungen gefüllt werden. Hinweis: Alle Emails an mehrere Empfänger:innen werden dann auch an die E-Mail-Adresse im Empfängerfeld (TO) geschickt. (Voreinstellung: Absender:in)</string>
-  <string name="SYS_MAIL_SENDING_MODE">E-mail Versand</string>
-  <string name="SYS_MAIL_SENDING_MODE_DESC">Im Modus "Gebündelter versandt" werden E-Mails in einer oder mehrerer gebündelten E-Mails versendet. Dabei werden die Empfänger als BCC oder TO eingefügt. Im Modus "Einzelempfänger" wird jede E-Mail einzeln an den entsprechenden Empfänger im TO Feld versendet. In diesem Modus gibt es weitere Platzhalter die verwendet werden können:\nEmpfänger Vorname:\n#receiver_first_name# #receiver_firstname# #receiver_surname#\nEmpfänger Nachname:\n#receiver_lastname#\nEmpfänger E-Mail:\n#receiver_email#\nEmpfänger Name:\n#receiver_name#</string>
-  <string name="SYS_MAIL_BULK">Gebündelter versandt</string>
-  <string name="SYS_MAIL_SINGLE">Einzelempfänger</string>
+  <string name="SYS_MAIL_SENDING_MODE">Versandmodus</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">Im Modus 'Gebündelt' werden E-Mails an mehrere Empfänger zusammengefasst. Eine E-Mail erhält dann eine konfigurierte Anzahl an Empfänger im TO oder BCC Feld. Dies ist sinnvoll, wenn der Hoster den Versand von vielen E-Mails nicht erlaubt. Im Modus 'Einzeln' erhält jeder Empfänger eine separate E-Mail. In diesem Modus können einer E-Mail-Vorlage weitere Felder hinzugefügt werden.</string>
+  <string name="SYS_MAIL_BULK">Gebündelt</string>
+  <string name="SYS_MAIL_SINGLE">Einzeln</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">Die Rolle Administrator:in muss mindestens ein Mitglied haben!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Hier können Sie Bedingungen zu jedem Feld in Ihrer Liste hinterlegen. Damit werden die ermittelten Mitglieder der ausgewählten Rolle mit Ihren Bedingungen weiter eingeschränkt.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -1039,6 +1039,10 @@
   <string name="SYS_MOVE_VAR">#VAR1# verschieben</string>
   <string name="SYS_MULTIPLE_RECIPIENTS">Mehrere Empfänger:innen</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-Mails an mehrere Empfänger:innen enthalten alle Empfänger:innen im BCC-Feld. Damit ist sichergestellt, dass keiner die E-Mail-Adressen der anderen Empfänger:innen sieht. Das TO-Feld muss allerdings auch befüllt werden. Über diese Einstellung kann festgelegt werden, was im Empfängerfeld (TO) hinterlegt wird. Dies kein ein versteckter Wert \"Undisclosed Recipients\" sein, was aber bei manchen Providern zu Problemen führt. Alternativ kann das Empfängerfeld (TO) mit der Absenderadresse bzw. der Administrator:innen-Adresse aus den Systembenachrichtigungen gefüllt werden. Hinweis: Alle Emails an mehrere Empfänger:innen werden dann auch an die E-Mail-Adresse im Empfängerfeld (TO) geschickt. (Voreinstellung: Absender:in)</string>
+  <string name="SYS_MAIL_SENDING_MODE">E-mail Versand</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">Im Modus "Gebündelter versandt" werden E-Mails in einer oder mehrerer gebündelten E-Mails versendet. Dabei werden die Empfänger als BCC oder TO eingefügt. Im Modus "Einzelempfänger" wird jede E-Mail einzeln an den entsprechenden Empfänger im TO Feld versendet. In diesem Modus gibt es weitere Platzhalter die verwendet werden können:\nEmpfänger Vorname:\n#receiver_first_name# #receiver_firstname# #receiver_surname#\nEmpfänger Nachname:\n#receiver_lastname#\nEmpfänger E-Mail:\n#receiver_email#\nEmpfänger Name:\n#receiver_name#</string>
+  <string name="SYS_MAIL_BULK">Gebündelter versandt</string>
+  <string name="SYS_MAIL_SINGLE">Einzelempfänger</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">Die Rolle Administrator:in muss mindestens ein Mitglied haben!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Hier kannst du Bedingungen zu jedem Feld in deiner Liste hinterlegen. Damit werden die ermittelten Mitglieder der ausgewählten Rolle mit deinen Bedingungen weiter eingeschränkt.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -1039,10 +1039,10 @@
   <string name="SYS_MOVE_VAR">#VAR1# verschieben</string>
   <string name="SYS_MULTIPLE_RECIPIENTS">Mehrere Empfänger:innen</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-Mails an mehrere Empfänger:innen enthalten alle Empfänger:innen im BCC-Feld. Damit ist sichergestellt, dass keiner die E-Mail-Adressen der anderen Empfänger:innen sieht. Das TO-Feld muss allerdings auch befüllt werden. Über diese Einstellung kann festgelegt werden, was im Empfängerfeld (TO) hinterlegt wird. Dies kein ein versteckter Wert \"Undisclosed Recipients\" sein, was aber bei manchen Providern zu Problemen führt. Alternativ kann das Empfängerfeld (TO) mit der Absenderadresse bzw. der Administrator:innen-Adresse aus den Systembenachrichtigungen gefüllt werden. Hinweis: Alle Emails an mehrere Empfänger:innen werden dann auch an die E-Mail-Adresse im Empfängerfeld (TO) geschickt. (Voreinstellung: Absender:in)</string>
-  <string name="SYS_MAIL_SENDING_MODE">E-mail Versand</string>
-  <string name="SYS_MAIL_SENDING_MODE_DESC">Im Modus "Gebündelter versandt" werden E-Mails in einer oder mehrerer gebündelten E-Mails versendet. Dabei werden die Empfänger als BCC oder TO eingefügt. Im Modus "Einzelempfänger" wird jede E-Mail einzeln an den entsprechenden Empfänger im TO Feld versendet. In diesem Modus gibt es weitere Platzhalter die verwendet werden können:\nEmpfänger Vorname:\n#receiver_first_name# #receiver_firstname# #receiver_surname#\nEmpfänger Nachname:\n#receiver_lastname#\nEmpfänger E-Mail:\n#receiver_email#\nEmpfänger Name:\n#receiver_name#</string>
-  <string name="SYS_MAIL_BULK">Gebündelter versandt</string>
-  <string name="SYS_MAIL_SINGLE">Einzelempfänger</string>
+  <string name="SYS_MAIL_SENDING_MODE">Versandmodus</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">Im Modus 'Gebündelt' werden E-Mails an mehrere Empfänger zusammengefasst. Eine E-Mail erhält dann eine konfigurierte Anzahl an Empfänger im TO oder BCC Feld. Dies ist sinnvoll, wenn der Hoster den Versand von vielen E-Mails nicht erlaubt. Im Modus 'Einzeln' erhält jeder Empfänger eine separate E-Mail. In diesem Modus können einer E-Mail-Vorlage weitere Felder hinzugefügt werden.</string>
+  <string name="SYS_MAIL_BULK">Gebündelt</string>
+  <string name="SYS_MAIL_SINGLE">Einzeln</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">Die Rolle Administrator:in muss mindestens ein Mitglied haben!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Hier kannst du Bedingungen zu jedem Feld in deiner Liste hinterlegen. Damit werden die ermittelten Mitglieder der ausgewählten Rolle mit deinen Bedingungen weiter eingeschränkt.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -1039,6 +1039,10 @@
   <string name="SYS_MOVE_VAR">Move #VAR1#</string>
   <string name="SYS_MULTIPLE_RECIPIENTS">Multiple recipients</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-mails to multiple recipients contain all recipients in the BCC field. This ensures that nobody sees the e-mail addresses of the other recipients. However, the TO field must also be filled. This setting can be used to define what is entered in the recipient (TO) field. This could be a hidden value "Undisclosed Recipients", but this causes problems with some providers. Alternatively the recipient field (TO) can be filled with the sender address or the administrator address from the system notifications. Note: All emails to multiple recipients will then also be sent to the email address in the recipient field (TO). (Default: Sender)</string>
+  <string name="SYS_MAIL_SENDING_MODE">E-mail sending mode</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">When sending emails as "Bulk", the recipients are entered in the TO or BCC field. When sent as "Single", each email is sent individually, giving you additional placeholders and personalization options.</string>
+  <string name="SYS_MAIL_BULK">Bulk recipients</string>
+  <string name="SYS_MAIL_SINGLE">Single recipients</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">The role \'administrator\' must have at least one member assigned!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Here you can define conditions for each field in your list. This will further restrict the determined members of the selected role with your conditions.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -1040,9 +1040,9 @@
   <string name="SYS_MULTIPLE_RECIPIENTS">Multiple recipients</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-mails to multiple recipients contain all recipients in the BCC field. This ensures that nobody sees the e-mail addresses of the other recipients. However, the TO field must also be filled. This setting can be used to define what is entered in the recipient (TO) field. This could be a hidden value "Undisclosed Recipients", but this causes problems with some providers. Alternatively the recipient field (TO) can be filled with the sender address or the administrator address from the system notifications. Note: All emails to multiple recipients will then also be sent to the email address in the recipient field (TO). (Default: Sender)</string>
   <string name="SYS_MAIL_SENDING_MODE">E-mail sending mode</string>
-  <string name="SYS_MAIL_SENDING_MODE_DESC">When sending emails as "Bulk", the recipients are entered in the TO or BCC field. When sent as "Single", each email is sent individually, giving you additional placeholders and personalization options.</string>
-  <string name="SYS_MAIL_BULK">Bulk recipients</string>
-  <string name="SYS_MAIL_SINGLE">Single recipients</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">In the "Bundled sent" mode, emails are sent in one or more bundled emails. The recipients are inserted as BCC or TO. In the "Single recipient" mode, each e-mail is sent individually to the corresponding recipient in the TO field. In this mode there are additional placeholders that can be used:\nReceiver first name:\n#receiver_first_name# #receiver_firstname# #receiver_surname#\nReceiver last name:\n#receiver_lastname#\nReceiver email:\n#receiver_email#\nReceiver name:\n#receiver_name#</string>
+  <string name="SYS_MAIL_BULK">Bundled sent</string>
+  <string name="SYS_MAIL_SINGLE">Single recipient</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">The role \'administrator\' must have at least one member assigned!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Here you can define conditions for each field in your list. This will further restrict the determined members of the selected role with your conditions.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/languages/en.xml
+++ b/adm_program/languages/en.xml
@@ -1040,9 +1040,9 @@
   <string name="SYS_MULTIPLE_RECIPIENTS">Multiple recipients</string>
   <string name="SYS_MULTIPLE_RECIPIENTS_DESC">E-mails to multiple recipients contain all recipients in the BCC field. This ensures that nobody sees the e-mail addresses of the other recipients. However, the TO field must also be filled. This setting can be used to define what is entered in the recipient (TO) field. This could be a hidden value "Undisclosed Recipients", but this causes problems with some providers. Alternatively the recipient field (TO) can be filled with the sender address or the administrator address from the system notifications. Note: All emails to multiple recipients will then also be sent to the email address in the recipient field (TO). (Default: Sender)</string>
   <string name="SYS_MAIL_SENDING_MODE">E-mail sending mode</string>
-  <string name="SYS_MAIL_SENDING_MODE_DESC">In the "Bundled sent" mode, emails are sent in one or more bundled emails. The recipients are inserted as BCC or TO. In the "Single recipient" mode, each e-mail is sent individually to the corresponding recipient in the TO field. In this mode there are additional placeholders that can be used:\nReceiver first name:\n#receiver_first_name# #receiver_firstname# #receiver_surname#\nReceiver last name:\n#receiver_lastname#\nReceiver email:\n#receiver_email#\nReceiver name:\n#receiver_name#</string>
-  <string name="SYS_MAIL_BULK">Bundled sent</string>
-  <string name="SYS_MAIL_SINGLE">Single recipient</string>
+  <string name="SYS_MAIL_SENDING_MODE_DESC">In 'Bundled' mode, emails to multiple recipients are grouped together. An e-mail then receives a configured number of recipients in the TO or BCC field. This is useful if the hoster does not allow sending many emails. In 'Single' mode, each recipient receives a separate e-mail. In this mode, additional fields can be added to an email template.</string>
+  <string name="SYS_MAIL_BULK">Bundled</string>
+  <string name="SYS_MAIL_SINGLE">Single</string>
   <string name="SYS_MUST_HAVE_ADMINISTRATOR">The role \'administrator\' must have at least one member assigned!</string>
   <string name="SYS_MYLIST_CONDITION_DESC">Here you can define conditions for each field in your list. This will further restrict the determined members of the selected role with your conditions.</string>
   <string name="SYS_NAME">Name</string>

--- a/adm_program/modules/ecards/ecard_function.php
+++ b/adm_program/modules/ecards/ecard_function.php
@@ -156,7 +156,7 @@ class FunctionClass
      * @param string $photoServerPath der Pfad wo die Bilder in der Grußkarte am Server liegen
      * @return bool|string
      */
-    public function sendEcard($senderName, $senderEmail, $ecardHtmlData, $recipientName, $recipientEmail, $photoServerPath)
+    public function sendEcard($senderName, $senderEmail, $ecardHtmlData, $recipientFirstName, $recipientName, $recipientEmail, $photoServerPath)
     {
         global $gSettingsManager, $gLogger;
 
@@ -166,7 +166,7 @@ class FunctionClass
         $email = new Email();
         $email->setSender($senderEmail, $senderName);
         $email->setSubject($this->newMessageReceivedString);
-        $email->addRecipient($recipientEmail, $recipientName);
+        $email->addRecipient($recipientEmail, $recipientFirstName, $recipientName);
 
         // alle Bilder werden aus dem Template herausgeholt, damit diese als Anhang verschickt werden koennen
         if (preg_match_all('/(<img .*src=")(.*)(".*>)/Uim', $ecardHtmlData, $matchArray)) {

--- a/adm_program/modules/ecards/ecard_function.php
+++ b/adm_program/modules/ecards/ecard_function.php
@@ -151,12 +151,13 @@ class FunctionClass
      * @param string $senderName
      * @param string $senderEmail
      * @param string $ecardHtmlData   geparste Daten vom Template
-     * @param string $recipientName   der Name des Empfaengers
+     * @param string $recipientFirstName   der Name des Empfaengers
+     * @param string $recipientLastName   der Name des Empfaengers
      * @param string $recipientEmail  die Email des Empfaengers
      * @param string $photoServerPath der Pfad wo die Bilder in der Grußkarte am Server liegen
      * @return bool|string
      */
-    public function sendEcard($senderName, $senderEmail, $ecardHtmlData, $recipientFirstName, $recipientName, $recipientEmail, $photoServerPath)
+    public function sendEcard($senderName, $senderEmail, $ecardHtmlData, $recipientFirstName, $recipientLastName, $recipientEmail, $photoServerPath)
     {
         global $gSettingsManager, $gLogger;
 
@@ -166,7 +167,7 @@ class FunctionClass
         $email = new Email();
         $email->setSender($senderEmail, $senderName);
         $email->setSubject($this->newMessageReceivedString);
-        $email->addRecipient($recipientEmail, $recipientFirstName, $recipientName);
+        $email->addRecipient($recipientEmail, $recipientFirstName, $recipientLastName);
 
         // alle Bilder werden aus dem Template herausgeholt, damit diese als Anhang verschickt werden koennen
         if (preg_match_all('/(<img .*src=")(.*)(".*>)/Uim', $ecardHtmlData, $matchArray)) {

--- a/adm_program/modules/ecards/ecard_send.php
+++ b/adm_program/modules/ecards/ecard_send.php
@@ -144,7 +144,7 @@ if (count($arrayRoles) > 0) {
         if ($ecardSendResult) {
             // create and send ecard
             $ecardHtmlData   = $funcClass->parseEcardTemplate($imageUrl, $postMessage, $ecardDataToParse, $row['first_name'].' '.$row['last_name'], $row['email']);
-            $ecardSendResult = $funcClass->sendEcard($senderName, $senderEmail, $ecardHtmlData, $row['first_name'].' '.$row['last_name'], $row['email'], $imageServerPath);
+            $ecardSendResult = $funcClass->sendEcard($senderName, $senderEmail, $ecardHtmlData, $row['first_name'], $row['last_name'], $row['email'], $imageServerPath);
         }
     }
 
@@ -183,7 +183,7 @@ if (count($arrayUsers) > 0) {
         if ($ecardSendResult) {
             // create and send ecard
             $ecardHtmlData   = $funcClass->parseEcardTemplate($imageUrl, $postMessage, $ecardDataToParse, $row['first_name'].' '.$row['last_name'], $row['email']);
-            $ecardSendResult = $funcClass->sendEcard($senderName, $senderEmail, $ecardHtmlData, $row['first_name'].' '.$row['last_name'], $row['email'], $imageServerPath);
+            $ecardSendResult = $funcClass->sendEcard($senderName, $senderEmail, $ecardHtmlData, $row['first_name'], $row['last_name'], $row['email'], $imageServerPath);
         }
     }
 

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -513,19 +513,6 @@ $formEmailDispatch->addInput(
     $formValues['mail_sendmail_name'],
     array('maxLength' => 50, 'helpTextIdInline' => 'SYS_SENDER_NAME_DESC')
 );
-$selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
-$formEmailDispatch->addSelectBox(
-    'mail_recipients_with_roles',
-    $gL10n->get('SYS_MULTIPLE_RECIPIENTS'),
-    $selectBoxEntries,
-    array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
-);
-$formEmailDispatch->addCheckbox(
-    'mail_into_to',
-    $gL10n->get('SYS_INTO_TO'),
-    (bool) $formValues['mail_into_to'],
-    array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
-);
 $formEmailDispatch->addInput(
     'mail_number_recipients',
     $gL10n->get('SYS_NUMBER_RECIPIENTS'),

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -520,25 +520,31 @@ $formEmailDispatch->addSelectBox(
     $selectBoxEntries,
     array('defaultValue' => $formValues['mail_sending_mode'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MAIL_SENDING_MODE_DESC')
 );
-$selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
-$formEmailDispatch->addSelectBox(
-    'mail_recipients_with_roles',
-    $gL10n->get('SYS_MULTIPLE_RECIPIENTS'),
-    $selectBoxEntries,
-    array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
-);
-$formEmailDispatch->addCheckbox(
-    'mail_into_to',
-    $gL10n->get('SYS_INTO_TO'),
-    (bool) $formValues['mail_into_to'],
-    array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
-);
-$formEmailDispatch->addInput(
-    'mail_number_recipients',
-    $gL10n->get('SYS_NUMBER_RECIPIENTS'),
-    $formValues['mail_number_recipients'],
-    array('type' => 'number', 'minNumber' => 0, 'maxNumber' => 9999, 'step' => 1, 'helpTextIdInline' => 'SYS_NUMBER_RECIPIENTS_DESC')
-);
+
+$sendingMode = $gSettingsManager->getInt('mail_sending_mode');
+
+// Only show this options if SendingMode = 0 / SYS_MAIL_BULK
+if($sendingMode == 0) {
+    $selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
+    $formEmailDispatch->addSelectBox(
+        'mail_recipients_with_roles',
+        $gL10n->get('SYS_MULTIPLE_RECIPIENTS'),
+        $selectBoxEntries,
+        array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
+    );
+    $formEmailDispatch->addCheckbox(
+        'mail_into_to',
+        $gL10n->get('SYS_INTO_TO'),
+        (bool) $formValues['mail_into_to'],
+        array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
+    );
+    $formEmailDispatch->addInput(
+        'mail_number_recipients',
+        $gL10n->get('SYS_NUMBER_RECIPIENTS'),
+        $formValues['mail_number_recipients'],
+        array('type' => 'number', 'minNumber' => 0, 'maxNumber' => 9999, 'step' => 1, 'helpTextIdInline' => 'SYS_NUMBER_RECIPIENTS_DESC')
+    );
+}
 $selectBoxEntries = array('iso-8859-1' => $gL10n->get('SYS_ISO_8859_1'), 'utf-8' => $gL10n->get('SYS_UTF8'));
 $formEmailDispatch->addSelectBox(
     'mail_character_encoding',

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -513,6 +513,19 @@ $formEmailDispatch->addInput(
     $formValues['mail_sendmail_name'],
     array('maxLength' => 50, 'helpTextIdInline' => 'SYS_SENDER_NAME_DESC')
 );
+$selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
+$formEmailDispatch->addSelectBox(
+    'mail_recipients_with_roles',
+    $gL10n->get('SYS_MULTIPLE_RECIPIENTS'),
+    $selectBoxEntries,
+    array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
+);
+$formEmailDispatch->addCheckbox(
+    'mail_into_to',
+    $gL10n->get('SYS_INTO_TO'),
+    (bool) $formValues['mail_into_to'],
+    array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
+);
 $formEmailDispatch->addInput(
     'mail_number_recipients',
     $gL10n->get('SYS_NUMBER_RECIPIENTS'),

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -513,6 +513,24 @@ $formEmailDispatch->addInput(
     $formValues['mail_sendmail_name'],
     array('maxLength' => 50, 'helpTextIdInline' => 'SYS_SENDER_NAME_DESC')
 );
+
+// Add js to show or hide mail options
+$page->addJavascript('
+    $(function(){
+        var fieldsToHideOnSingleMode = "#mail_recipients_with_roles_group, #mail_into_to_group, #mail_number_recipients_group";
+        if($("#mail_sending_mode").val() == 1) {
+            $(fieldsToHideOnSingleMode).hide();
+        }
+        $("#mail_sending_mode").on("change", function() {
+            if($("#mail_sending_mode").val() == 1) {
+                $(fieldsToHideOnSingleMode).hide();
+            } else {
+                $(fieldsToHideOnSingleMode).show();
+            }
+        });
+    });
+');
+
 $selectBoxEntries = array(0 => $gL10n->get('SYS_MAIL_BULK'), 1 => $gL10n->get('SYS_MAIL_SINGLE'));
 $formEmailDispatch->addSelectBox(
     'mail_sending_mode',
@@ -521,30 +539,26 @@ $formEmailDispatch->addSelectBox(
     array('defaultValue' => $formValues['mail_sending_mode'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MAIL_SENDING_MODE_DESC')
 );
 
-$sendingMode = $gSettingsManager->getInt('mail_sending_mode');
+$selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
+$formEmailDispatch->addSelectBox(
+    'mail_recipients_with_roles',
+    $gL10n->get('SYS_MULTIPLE_RECIPIENTS'),
+    $selectBoxEntries,
+    array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
+);
+$formEmailDispatch->addCheckbox(
+    'mail_into_to',
+    $gL10n->get('SYS_INTO_TO'),
+    (bool) $formValues['mail_into_to'],
+    array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
+);
+$formEmailDispatch->addInput(
+    'mail_number_recipients',
+    $gL10n->get('SYS_NUMBER_RECIPIENTS'),
+    $formValues['mail_number_recipients'],
+    array('type' => 'number', 'minNumber' => 0, 'maxNumber' => 9999, 'step' => 1, 'helpTextIdInline' => 'SYS_NUMBER_RECIPIENTS_DESC')
+);
 
-// Only show this options if SendingMode = 0 / SYS_MAIL_BULK
-if($sendingMode == 0) {
-    $selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
-    $formEmailDispatch->addSelectBox(
-        'mail_recipients_with_roles',
-        $gL10n->get('SYS_MULTIPLE_RECIPIENTS'),
-        $selectBoxEntries,
-        array('defaultValue' => $formValues['mail_recipients_with_roles'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MULTIPLE_RECIPIENTS_DESC')
-    );
-    $formEmailDispatch->addCheckbox(
-        'mail_into_to',
-        $gL10n->get('SYS_INTO_TO'),
-        (bool) $formValues['mail_into_to'],
-        array('helpTextIdInline' => 'SYS_INTO_TO_DESC')
-    );
-    $formEmailDispatch->addInput(
-        'mail_number_recipients',
-        $gL10n->get('SYS_NUMBER_RECIPIENTS'),
-        $formValues['mail_number_recipients'],
-        array('type' => 'number', 'minNumber' => 0, 'maxNumber' => 9999, 'step' => 1, 'helpTextIdInline' => 'SYS_NUMBER_RECIPIENTS_DESC')
-    );
-}
 $selectBoxEntries = array('iso-8859-1' => $gL10n->get('SYS_ISO_8859_1'), 'utf-8' => $gL10n->get('SYS_UTF8'));
 $formEmailDispatch->addSelectBox(
     'mail_character_encoding',

--- a/adm_program/modules/preferences/preferences.php
+++ b/adm_program/modules/preferences/preferences.php
@@ -513,6 +513,13 @@ $formEmailDispatch->addInput(
     $formValues['mail_sendmail_name'],
     array('maxLength' => 50, 'helpTextIdInline' => 'SYS_SENDER_NAME_DESC')
 );
+$selectBoxEntries = array(0 => $gL10n->get('SYS_MAIL_BULK'), 1 => $gL10n->get('SYS_MAIL_SINGLE'));
+$formEmailDispatch->addSelectBox(
+    'mail_sending_mode',
+    $gL10n->get('SYS_MAIL_SENDING_MODE'),
+    $selectBoxEntries,
+    array('defaultValue' => $formValues['mail_sending_mode'], 'showContextDependentFirstEntry' => false, 'helpTextIdInline' => 'SYS_MAIL_SENDING_MODE_DESC')
+);
 $selectBoxEntries = array(0 => $gL10n->get('SYS_HIDDEN'), 1 => $gL10n->get('SYS_SENDER'), 2 => $gL10n->get('SYS_ADMINISTRATOR'));
 $formEmailDispatch->addSelectBox(
     'mail_recipients_with_roles',

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -620,6 +620,7 @@ class Email extends PHPMailer
      * Method will send the email to all recipients. Therefore, the method will evaluate how to send the email.
      * If it's necessary all recipients will be added to BCC and also smaller packages of recipients will be
      * created. So maybe several emails will be send. Also a copy to the sender will be send if the preferences are set.
+     * If the Sending Mode is set to "SINGLE" every e-mail will be send on its own, so there will be send out a lot e-mails.
      * @return true|string
      */
     public function sendEmail()

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -157,22 +157,23 @@ class Email extends PHPMailer
      * in the recipients list. The decision if the recipient will be sent as TO or BCC will be done later
      * in the email send process.
      * @param string $address A valid email address to which the email should be sent.
-     * @param string $name    The name of the recipient that will be shown in the email header.
+     * @param string $firstName    The first name of the recipient that will be shown in the email header.
+     * @param string $lastName    The last name of the recipient that will be shown in the email header.
      * @param array $additionalFields    Additional fields to map in a Key Value like Array. Not used at all yet.
      * @return bool Returns **true** if the address was added to the recipients list.
      */
-    public function addRecipient($address, $firstName = '', $name = '', $additionalFields = array())
+    public function addRecipient($address, $firstName = '', $lastName = '', $additionalFields = array())
     {
         // Recipients must be Ascii-US formatted, so encode in MimeHeader
-        $asciiName = stripslashes($firstName  . ' ' . $name);
+        $asciiName = stripslashes($firstName  . ' ' . $lastName);
 
         // check if valid email address and if email not in the recipients array
         if (StringUtils::strValidCharacters($address, 'email')
         && array_search($address, array_column($this->emRecipientsArray, 'address')) === false) {
-            $recipient = array('name' => $asciiName, 'address' => $address, 'firstname' => $firstName, 'surname' => $name);
+            $recipient = array('name' => $asciiName, 'address' => $address, 'firstname' => $firstName, 'surname' => $lastName);
             $recipient = array_merge($recipient , $additionalFields);
             $this->emRecipientsArray[] = $recipient;
-            $this->emRecipientsNames[] = $firstName  . ' ' . $name;
+            $this->emRecipientsNames[] = $firstName  . ' ' . $lastName;
             
             return true;
         }
@@ -332,20 +333,20 @@ class Email extends PHPMailer
     /**
      * method adds CC recipients to mail
      * @param string $address
-     * @param string $name
+     * @param string $lastName
      * @return true|string
      */
-    public function addCopy($address, $firstName = '', $name = '')
+    public function addCopy($address, $firstName = '', $lastName = '')
     {
         try {
-            $this->addCC($address, $firstName .' '. $name);
+            $this->addCC($address, $firstName .' '. $lastName);
         } catch (Exception $e) {
             return $e->errorMessage();
         } catch (\Exception $e) {
             return $e->getMessage();
         }
 
-        $this->emRecipientsNames[] = $name;
+        $this->emRecipientsNames[] = $lastName;
 
         return true;
     }
@@ -354,13 +355,13 @@ class Email extends PHPMailer
      * method adds BCC recipients to mail
      * Bcc Empfänger werden ersteinmal gesammelt, damit später Päckchen verschickt werden können
      * @param string $address
-     * @param string $name
+     * @param string $lastName
      * @return bool
      * @deprecated 4.2.0:4.3.0 "addBlindCopy()" is deprecated, use "addRecipient()" instead.
      */
-    public function addBlindCopy($address, $firstName = '', $name = '')
+    public function addBlindCopy($address, $firstName = '', $lastName = '')
     {
-        return $this->addRecipient($address, $firstName, $name);
+        return $this->addRecipient($address, $firstName, $lastName);
     }
 
     /**
@@ -593,9 +594,7 @@ class Email extends PHPMailer
 
         // replace parameters in email template
         $replaces = array(
-            '#receiver_first_name#' => $firstName,
             '#receiver_firstname#'  => $firstName,
-            '#receiver_surname#'    => $surname,
             '#receiver_lastname#'   => $surname,
             '#receiver_email#'      => $email,
             '#receiver_name#'       => $name

--- a/adm_program/system/classes/Email.php
+++ b/adm_program/system/classes/Email.php
@@ -150,18 +150,22 @@ class Email extends PHPMailer
      * in the email send process.
      * @param string $address A valid email address to which the email should be sent.
      * @param string $name    The name of the recipient that will be shown in the email header.
+     * @param array $additionalFields    Additional fields to map in a Key Value like Array. Not used at all yet.
      * @return bool Returns **true** if the address was added to the recipients list.
      */
-    public function addRecipient($address, $name = '')
+    public function addRecipient($address, $firstName = '', $name = '', $additionalFields = array())
     {
         // Recipients must be Ascii-US formatted, so encode in MimeHeader
-        $asciiName = stripslashes($name);
+        $asciiName = stripslashes($firstName  . ' ' . $name);
 
         // check if valid email address and if email not in the recipients array
         if (StringUtils::strValidCharacters($address, 'email')
         && array_search($address, array_column($this->emRecipientsArray, 'address')) === false) {
-            $this->emRecipientsArray[] = array('name' => $asciiName, 'address' => $address);
-            $this->emRecipientsNames[] = $name;
+            $recipient = array('name' => $asciiName, 'address' => $address, 'firstname' => $firstName, 'surname' => $name);
+            $recipient = array_merge($recipient , $additionalFields);
+            $this->emRecipientsArray[] = $recipient;
+            $this->emRecipientsNames[] = $firstName  . ' ' . $name;
+            
             return true;
         }
         return false;
@@ -252,7 +256,7 @@ class Email extends PHPMailer
             // all email addresses will be attached as BCC
             while ($row = $statement->fetch()) {
                 if (StringUtils::strValidCharacters($row['email'], 'email')) {
-                    $this->addRecipient($row['email'], $row['firstname'] . ' ' . $row['lastname']);
+                    $this->addRecipient($row['email'], $row['firstname'], $row['lastname']);
                     ++$numberRecipientsAdded;
                 }
             }
@@ -306,7 +310,7 @@ class Email extends PHPMailer
             // all email addresses will be attached as BCC
             while ($row = $statement->fetch()) {
                 if (StringUtils::strValidCharacters($row['email'], 'email')) {
-                    $this->addRecipient($row['email'], $row['firstname'] . ' ' . $row['lastname']);
+                    $this->addRecipient($row['email'], $row['firstname'], $row['lastname']);
                     ++$numberRecipientsAdded;
                 }
             }
@@ -323,10 +327,10 @@ class Email extends PHPMailer
      * @param string $name
      * @return true|string
      */
-    public function addCopy($address, $name = '')
+    public function addCopy($address, $firstName = '', $name = '')
     {
         try {
-            $this->addCC($address, $name);
+            $this->addCC($address, $firstName .' '. $name);
         } catch (Exception $e) {
             return $e->errorMessage();
         } catch (\Exception $e) {
@@ -346,9 +350,9 @@ class Email extends PHPMailer
      * @return bool
      * @deprecated 4.2.0:4.3.0 "addBlindCopy()" is deprecated, use "addRecipient()" instead.
      */
-    public function addBlindCopy($address, $name = '')
+    public function addBlindCopy($address, $firstName = '', $name = '')
     {
-        return $this->addRecipient($address, $name);
+        return $this->addRecipient($address, $firstName, $name);
     }
 
     /**
@@ -565,6 +569,32 @@ class Email extends PHPMailer
         $this->emHtmlText = $emailHtmlText;
     }
 
+
+    /**
+     * Add the user specific template text to the email message and replace the plaeholders of the template.
+     * @param string $text        Email text that should be send
+     * @param string $firstname  Receiver firstname
+     * @param string $surname Receiver surname
+     * @param string $email  Receiver email address
+     * @param string $name  Receiver firstname and surname
+     */
+    public function setUserSpecificTemplateText($text, $firstName, $surname, $email, $name)
+    {
+        // replace all line feeds within the mailtext into simple breaks because only those are valid within mails
+        $text = str_replace("\r\n", "\n", $text);
+
+        // replace parameters in email template
+        $replaces = array(
+            '#receiver_first_name#' => $firstName,
+            '#receiver_firstname#'  => $firstName,
+            '#receiver_surname#'    => $surname,
+            '#receiver_lastname#'   => $surname,
+            '#receiver_email#'      => $email,
+            '#receiver_name#'       => $name
+        );
+        return StringUtils::strMultiReplace($text, $replaces);
+    }
+
     /**
      * Funktion um den Nachrichtentext an die Mail uebergeben
      * @param string $text
@@ -634,66 +664,96 @@ class Email extends PHPMailer
     {
         global $gSettingsManager, $gLogger, $gDebug, $gValidLogin, $gCurrentUser;
 
-        // add body to the email
-        if ($this->emSendAsHTML) {
-            $this->msgHTML($this->emHtmlText);
-        } else {
-            $this->Body = $this->emText;
-        }
-
         try {
             // if there is a limit of email recipients than split the recipients into smaller packages
             $recipientsArrays = array_chunk($this->emRecipientsArray, $gSettingsManager->getInt('mail_number_recipients'));
 
             foreach ($recipientsArrays as $recipientsArray) {
-                // if number of bcc recipients = 1 then send the mail directly to the user and not as bcc
-                if ($this->countRecipients() === 1) {
-                    // remove all current recipients from mail
-                    $this->clearAllRecipients();
+                try {
+                    // if number of bcc recipients = 1 then send the mail directly to the user and not as bcc
+                    if ($this->countRecipients() === 1) {
+                        // remove all current recipients from mail
+                        $this->clearAllRecipients();
 
-                    $this->addAddress($recipientsArray[0]['address'], $recipientsArray[0]['name']);
-                    if ($gDebug) {
-                        $gLogger->notice('Email send as TO to ' . $recipientsArray[0]['name'] . ' (' . $recipientsArray[0]['address'] . ')');
-                    }
-                } elseif ($gSettingsManager->getBool('mail_into_to')) {
-                    // remove all current recipients from mail
-                    $this->clearAllRecipients();
-
-                    // add all recipients as bcc to the mail
-                    foreach ($recipientsArray as $recipientTO) {
-                        $this->addAddress($recipientTO['address'], $recipientTO['name']);
+                        $this->addAddress($recipientsArray[0]['address'], $recipientsArray[0]['name']);
                         if ($gDebug) {
-                            $gLogger->notice('Email send as TO to ' . $recipientTO['name'] . ' (' . $recipientTO['address'] . ')');
+                            $gLogger->notice('Email send as TO to ' . $recipientsArray[0]['name'] . ' (' . $recipientsArray[0]['address'] . ')');
+                        }
+                        // add body to the email
+                        if ($this->emSendAsHTML) {
+                            $html = $this->setUserSpecificTemplateText($this->emHtmlText, $recipientsArray[0]['firstname'], $recipientsArray[0]['surname'], $recipientsArray[0]['address'], $recipientsArray[0]['name']);
+                            $this->msgHTML($html);
+                        } else {
+                            $txt = $this->setUserSpecificTemplateText($this->emText, $recipientsArray[0]['firstname'], $recipientsArray[0]['surname'], $recipientsArray[0]['address'], $recipientsArray[0]['name']);
+                            $this->Body = $txt;
+                        }
+                        
+                        // now send mail
+                        $this->send();
+                    } elseif ($gSettingsManager->getBool('mail_into_to')) {
+                    
+                        // add all recipients as bcc to the mail
+                        foreach ($recipientsArray as $recipientTO) {
+                            // remove all current recipients from mail
+                            $this->clearAllRecipients();
+
+                            $this->addAddress($recipientTO['address'], $recipientTO['name']);
+                            if ($gDebug) {
+                                $gLogger->notice('Email send as TO to ' . $recipientTO['name'] . ' (' . $recipientTO['address'] . ')');
+                            }
+
+                            // add body to the email
+                            if ($this->emSendAsHTML) {
+                                $html = $this->setUserSpecificTemplateText($this->emHtmlText, $recipientTO['firstname'], $recipientTO['surname'], $recipientTO['address'], $recipientTO['name']);
+                                $this->msgHTML($html);
+                            } else {
+                                $txt = $this->setUserSpecificTemplateText($this->emText, $recipientTO['firstname'], $recipientTO['surname'], $recipientTO['address'], $recipientTO['name']);
+                                $this->Body = $txt;
+                            }
+                            
+                            // now send mail
+                            $this->send();
+                        }
+                    } else {
+                        // normally we need no To-address and set "undisclosed recipients", but if
+                        // that won't work than the following address will be set
+                        if ($gValidLogin && (int) $gSettingsManager->get('mail_recipients_with_roles') === 1) {
+                            // fill recipient with sender address to prevent problems with provider
+                            $this->addAddress($gCurrentUser->getValue('EMAIL'), $gCurrentUser->getValue('FIRST_NAME').' '.$gCurrentUser->getValue('LAST_NAME'));
+                        } elseif ((int) $gSettingsManager->get('mail_recipients_with_roles') === 2
+                        || (!$gValidLogin && (int) $gSettingsManager->get('mail_recipients_with_roles') === 1)) {
+                            // fill recipient with administrators address to prevent problems with provider
+                            $this->addAddress($gSettingsManager->getString('email_administrator'), $gL10n->get('SYS_ADMINISTRATOR'));
+                        }
+
+                        // add all recipients as bcc to the mail
+                        foreach ($recipientsArray as $recipientBCC) {
+                            // remove only all BCC because to-address could be explicit set if undisclosed recipients won't work
+                            $this->clearBCCs();
+                            $this->addBCC($recipientBCC['address'], $recipientBCC['name']);
+                            if ($gDebug) {
+                                $gLogger->notice('Email send as BCC to ' . $recipientBCC['name'] . ' (' . $recipientBCC['address'] . ')');
+                            }
+
+                            // add body to the email
+                            if ($this->emSendAsHTML) {
+                                $html = $this->setUserSpecificTemplateText($this->emHtmlText, $recipientBCC['firstname'], $recipientBCC['surname'], $recipientBCC['address'], $recipientBCC['name']);
+                                $this->msgHTML($html);
+                            } else {
+                                $txt = $this->setUserSpecificTemplateText($this->emText, $recipientBCC['firstname'], $recipientBCC['surname'], $recipientBCC['address'], $recipientBCC['name']);
+                                $this->Body = $txt;
+                            }
+                            
+                            // now send mail
+                            $this->send();
                         }
                     }
-                } else {
-                    // remove only all BCC because to-address could be explicit set if undisclosed recipients won't work
-                    $this->clearBCCs();
-
-                    // normally we need no To-address and set "undisclosed recipients", but if
-                    // that won't work than the following address will be set
-                    if ($gValidLogin && (int) $gSettingsManager->get('mail_recipients_with_roles') === 1) {
-                        // fill recipient with sender address to prevent problems with provider
-                        $this->addAddress($gCurrentUser->getValue('EMAIL'), $gCurrentUser->getValue('FIRST_NAME').' '.$gCurrentUser->getValue('LAST_NAME'));
-                    } elseif ((int) $gSettingsManager->get('mail_recipients_with_roles') === 2
-                    || (!$gValidLogin && (int) $gSettingsManager->get('mail_recipients_with_roles') === 1)) {
-                        // fill recipient with administrators address to prevent problems with provider
-                        $this->addAddress($gSettingsManager->getString('email_administrator'), $gL10n->get('SYS_ADMINISTRATOR'));
-                    }
-
-                    // add all recipients as bcc to the mail
-                    foreach ($recipientsArray as $recipientBCC) {
-                        $this->addBCC($recipientBCC['address'], $recipientBCC['name']);
-                        if ($gDebug) {
-                            $gLogger->notice('Email send as BCC to ' . $recipientBCC['name'] . ' (' . $recipientBCC['address'] . ')');
-                        }
-                    }
+                } catch (Exception $e) {
+                    return $e->errorMessage();
+                } catch (\Exception $e) {
+                    return $e->getMessage();
                 }
-
-                // now send mail
-                $this->send();
             }
-
             // now send the email as a copy to the sender
             if ($this->emCopyToSender) {
                 $this->sendCopyMail();

--- a/adm_program/system/classes/UserRegistration.php
+++ b/adm_program/system/classes/UserRegistration.php
@@ -263,7 +263,7 @@ class UserRegistration extends User
                 while ($row = $emailStatement->fetch()) {
                     // send mail that a new registration is available
                     $sysmail = new SystemMail($this->db);
-                    $sysmail->addRecipient($row['email'], $row['first_name']. ' '. $row['last_name']);
+                    $sysmail->addRecipient($row['email'], $row['first_name'], $row['last_name']);
                     $sysmail->sendSystemMail('SYSMAIL_REGISTRATION_WEBMASTER', $this); // TODO Exception handling
                 }
             }


### PR DESCRIPTION
With this change you are able to use the following placeholders within the email wrapper.
'#receiver_first_name#'
'#receiver_firstname#'
'#receiver_surname#'
'#receiver_lastname#'
'#receiver_email#'
'#receiver_name#'

It is also prepared to add more fields