### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN yum update -y --allowerasing --skip-broken --nobest --setopt=tsflags=nodocs 
     yum remove -y nodejs nodejs-docs npm && \
     yum autoremove -y && \
     rm -rf /usr/lib/node_modules && \
-    yum -y clean all --enablerepo='*'
+    yum -y clean all --enablerepo='*' && rm -rf /var/cache/yum
 
 COPY . .
 RUN mkdir provisioning && cp -a adm_plugins adm_themes adm_my_files provisioning/ && rm -rf adm_plugins adm_themes adm_my_files
@@ -53,7 +53,7 @@ RUN set -euf -o pipefail ; \
       trivy filesystem --exit-code 1 --severity CRITICAL --no-progress / && \
       echo "scan image with trivy (trivy filesystem --exit-code 1 --severity MEDIUM,HIGH --no-progress /)" && \
       trivy filesystem --exit-code 0 --severity MEDIUM,HIGH --no-progress / && \
-      rm -rf /opt/app-root/src/.cache/trivy ; \
+      rm -rf /opt/app-root/src/.cache/trivy; \
     fi
 
 


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile. I added `--no-cache-dir` to the `pip install` command and it reduces the image size by 145.02 MB (6%) without affecting the image.

Impact on the image size:
* Image size before repair: 2.36 GB
* Image size after repair: 2.22 GB
* Difference: 145.02 MB (6%)

I hope that you will find these changes useful to you. :smile: Let me know if you have any questions or concerns.

