### PR TITLE
Improve DB Installation Check (#1537)

### DIFF
--- a/adm_program/installation/index.php
+++ b/adm_program/installation/index.php
@@ -9,8 +9,24 @@
  ***********************************************************************************************
  */
 
+
+$rootPath = dirname(__DIR__, 2);
+
 // check if installation is necessary
-if (is_file('../../adm_my_files/config.php')) {
+if (is_file($rootPath . '/adm_my_files/config.php')) {
+    // load config and init bootstrapping
+    require_once($rootPath . '/adm_my_files/config.php');
+
+    // check for empty db and redirect to installation wizard
+    try {
+        $gDb = Database::createDatabaseInstance();
+        $gDb->getTableColumns($g_adm_db . '.' . $g_tbl_praefix . '_sessions');
+    } catch (\Throwable $t) {
+        $page = 'installation.php';
+        header('Location: ' . $page);
+        exit();
+    }
+
     $page = 'update.php';
 } else {
     $page = 'installation.php';

--- a/adm_program/system/common.php
+++ b/adm_program/system/common.php
@@ -38,6 +38,15 @@ try {
     // => EXIT
 }
 
+// check for empty db and redirect to installation wizard
+try {
+    $gDb->getTableColumns($g_adm_db . '.' . $g_tbl_praefix . '_sessions');
+} catch (\Throwable $t) {
+    header('Location: adm_program/installation/index.php');
+    exit();
+}
+
+
 /*********************************************************************************
  Create and validate sessions, check auto login, read session variables
 /********************************************************************************/

--- a/dockerscripts/startup.sh
+++ b/dockerscripts/startup.sh
@@ -61,122 +61,112 @@ mailq
 # generate admidio config.php
 ADMIDIO_CONFIG_TEMPLATE="/opt/app-root/src/provisioning/adm_my_files/config_example.php"
 ADMIDIO_CONFIG="/opt/app-root/src/adm_my_files/config.php"
-ADMIDIO_FIRSTRUN="/opt/app-root/src/adm_my_files/.admidio_installed"
 ADMIDIO_IMAGE_VERSION="/opt/app-root/src/.admidio_image_version"
 ADMIDIO_INSTALLED_VERSION="/opt/app-root/src/adm_my_files/.admidio_installed_version"
 
 
-if [ -f "${ADMIDIO_FIRSTRUN}" ]; then
-    # if nessary environment variables exist, copy config template to config file
-    if ! ( [ -z "${ADMIDIO_DB_HOST}" ] || ( [ -z "${ADMIDIO_DB_PORT}" ] && [ -z "${ADMIDIO_DB_HOST##*:}" ] ) || [ -z "${ADMIDIO_DB_NAME}" ] || [ -z "${ADMIDIO_DB_USER}" ] || [ -z "${ADMIDIO_DB_PASSWORD}" ] ) ; then
-        echo "[INFO ] generate admidio config.php file"
-        cp --preserve=mode,ownership,timestamps "${ADMIDIO_CONFIG_TEMPLATE}" "${ADMIDIO_CONFIG}"
-    fi
-    # chown default.root "${ADMIDIO_CONFIG}"
-    # chmod 664 "${ADMIDIO_CONFIG}"
-
-    if [ -f "${ADMIDIO_CONFIG}" ]; then
-        echo "[INFO ] configure admidio config.php file"
-
-        # Select your database system for example 'mysql' or 'pgsql'
-        # $gDbType = 'mysql';
-        sed -i "s/^\$gDbType.*/\$gDbType = '${ADMIDIO_DB_TYPE:-mysql}';/g" "${ADMIDIO_CONFIG}"
-
-        # // Table prefix for Admidio-Tables in database
-        # // Example: 'adm'
-        # $g_tbl_praefix = 'adm';
-        sed -i "s/^\$g_tbl_praefix.*/\$g_tbl_praefix = '${ADMIDIO_DB_TABLE_PRAEFIX:-adm}';/g" "${ADMIDIO_CONFIG}"
-        #
-        # // Access to the database of the MySQL-Server
-        # $g_adm_srv  = 'URL_to_your_MySQL-Server';    // Server
-        if [ "${ADMIDIO_DB_HOST}" != "" ]; then
-            sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = '${ADMIDIO_DB_HOST%%:*}';/g" "${ADMIDIO_CONFIG}"
-        else
-            sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = 'localhost';/g" "${ADMIDIO_CONFIG}"
-        fi
-
-        # $g_adm_port = null;                          // Port
-        if [ "${ADMIDIO_DB_PORT}" != "" ]; then
-            sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_PORT};/g" "${ADMIDIO_CONFIG}"
-        elif [ "${ADMIDIO_DB_HOST}" != "" ]; then
-            sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_HOST##*:};/g" "${ADMIDIO_CONFIG}"
-        else
-            sed -i "s/^\$g_adm_port.*/\$g_adm_port = null;/g" "${ADMIDIO_CONFIG}"
-        fi
-        # $g_adm_db   = 'Databasename';                // Database
-        sed -i "s/^\$g_adm_db.*/\$g_adm_db = '${ADMIDIO_DB_NAME:-admidio}';/g" "${ADMIDIO_CONFIG}"
-        # $g_adm_usr  = 'Username';                    // User
-        sed -i "s/^\$g_adm_usr.*/\$g_adm_usr = '${ADMIDIO_DB_USER:-admidio}';/g" "${ADMIDIO_CONFIG}"
-        # $g_adm_pw   = 'Password';                    // Password
-        sed -i "s/^\$g_adm_pw.*/\$g_adm_pw = '${ADMIDIO_DB_PASSWORD:-admidio}';/g" "${ADMIDIO_CONFIG}"
-
-        # // URL to this Admidio installation
-        # // Example: 'https://www.admidio.org/example'
-        # $g_root_path = 'https://www.your-website.de/admidio';
-        if [ "${ADMIDIO_ROOT_PATH}" != "" ]; then
-            sed -i "s#^\$g_root_path.*#\$g_root_path = '${ADMIDIO_ROOT_PATH}';#g" "${ADMIDIO_CONFIG}"
-        fi
-
-        if [ "${ADMIDIO_ORGANISATION}" != "" ]; then
-            if [ "$(egrep '^\$g_organization' ${ADMIDIO_CONFIG})" != "" ]; then
-                sed -i "s/^\$g_organization.*/\$g_organization = '${ADMIDIO_ORGANISATION}';/g" "${ADMIDIO_CONFIG}"
-            else
-                echo "" >> "${ADMIDIO_CONFIG}"
-                echo "# // Short description of the organization that is running Admidio" >> "${ADMIDIO_CONFIG}"
-                echo "# // This short description must correspond to your input in the installation wizard !!!" >> "${ADMIDIO_CONFIG}"
-                echo "# // Example: 'ADMIDIO'" >> "${ADMIDIO_CONFIG}"
-                echo "# // Maximum of 10 characters !!!" >> "${ADMIDIO_CONFIG}"
-                echo "\$g_organization = '${ADMIDIO_ORGANISATION}';" >> "${ADMIDIO_CONFIG}"
-                echo "" >> "${ADMIDIO_CONFIG}"
-            fi
-        fi
-
-        # // The name of the timezone in which your organization is located.
-        # // This must be one of the strings that are defined here https://www.php.net/manual/en/timezones.php
-        # // Example: 'Europe/Berlin'
-        # $gTimezone = 'Europe/Berlin';
-        if [ "${TZ}" != "" ]; then
-            sed -i "s#^\$gTimezone.*#\$gTimezone = '${TZ}';#g" "${ADMIDIO_CONFIG}"
-        fi
-
-        # // If this flag is set = 1 then you must enter your loginname and password
-        # // for an update of the Admidio database to a new version of Admidio.
-        # // For a more comfortable and easy update you can set this preference = 0.
-        # $gLoginForUpdate = 1;
-        sed -i "s/^\$gLoginForUpdate.*/\$gLoginForUpdate = ${ADMIDIO_LOGIN_FOR_UPDATE:-1};/g" "${ADMIDIO_CONFIG}"
-
-        # // Set the preferred password hashing algorithm.
-        # // Possible values are: 'DEFAULT', 'ARGON2ID', 'ARGON2I', 'BCRYPT', 'SHA512'
-        # $gPasswordHashAlgorithm = 'DEFAULT';
-        sed -i "s/^\$gPasswordHashAlgorithm.*/\$gPasswordHashAlgorithm = '${ADMIDIO_PASSWORD_HASH_ALGORITHM:-DEFAULT}';/g" "${ADMIDIO_CONFIG}"
-    else
-        echo "[WARNING] admidio config.php file does not exist."
-    fi
-
-    if [ "$(cat ${ADMIDIO_INSTALLED_VERSION} 2>/dev/null)" != "$(cat ${ADMIDIO_IMAGE_VERSION} 2>/dev/null)" ]; then
-        echo "[INFO ] update admidio installation to image version ($(cat ${ADMIDIO_IMAGE_VERSION} 2>/dev/null)) ..."
-        echo "[DEBUG] rsync -a --delete provisioning/adm_program/ adm_program/"
-        rsync -a --delete provisioning/adm_program/ adm_program/
-        echo "[DEBUG] rsync -a provisioning/adm_plugins/ adm_plugins/"
-        rsync -a provisioning/adm_plugins/ adm_plugins/
-        echo "[DEBUG] rsync -a provisioning/adm_themes/ adm_themes/"
-        rsync -a provisioning/adm_themes/ adm_themes/
-        echo "[DEBUG] rsync -a --delete provisioning/adm_themes/simple/ adm_themes/simple/"
-        rsync -a --delete provisioning/adm_themes/simple/ adm_themes/simple/
-        echo "[DEBUG] rsync -a --exclude=/config.php --exclude=/.admidio_installed --exclude=/.admidio_installed_version provisioning/adm_my_files/ adm_my_files/"
-        rsync -a --exclude="/config.php" --exclude="/.admidio_installed" --exclude="/.admidio_installed_version" provisioning/adm_my_files/ adm_my_files/
-        rm -f "${ADMIDIO_INSTALLED_VERSION}"
-    fi
+# if nessary environment variables exist, copy config template to config file
+if ! ( [ -z "${ADMIDIO_DB_HOST}" ] || ( [ -z "${ADMIDIO_DB_PORT}" ] && [ -z "${ADMIDIO_DB_HOST##*:}" ] ) || [ -z "${ADMIDIO_DB_NAME}" ] || [ -z "${ADMIDIO_DB_USER}" ] || [ -z "${ADMIDIO_DB_PASSWORD}" ] ) ; then
+    echo "[INFO ] generate admidio config.php file"
+    cp --preserve=mode,ownership,timestamps "${ADMIDIO_CONFIG_TEMPLATE}" "${ADMIDIO_CONFIG}"
 fi
 
-if [ ! -f "${ADMIDIO_FIRSTRUN}" ]; then
-    echo "[INFO ] create .admidio_installed file (${ADMIDIO_FIRSTRUN})"
-    touch "${ADMIDIO_FIRSTRUN}"
+if [ -f "${ADMIDIO_CONFIG}" ]; then
+    echo "[INFO ] configure admidio config.php file"
+
+    # Select your database system for example 'mysql' or 'pgsql'
+    # $gDbType = 'mysql';
+    sed -i "s/^\$gDbType.*/\$gDbType = '${ADMIDIO_DB_TYPE:-mysql}';/g" "${ADMIDIO_CONFIG}"
+
+    # // Table prefix for Admidio-Tables in database
+    # // Example: 'adm'
+    # $g_tbl_praefix = 'adm';
+    sed -i "s/^\$g_tbl_praefix.*/\$g_tbl_praefix = '${ADMIDIO_DB_TABLE_PRAEFIX:-adm}';/g" "${ADMIDIO_CONFIG}"
+    #
+    # // Access to the database of the MySQL-Server
+    # $g_adm_srv  = 'URL_to_your_MySQL-Server';    // Server
+    if [ "${ADMIDIO_DB_HOST}" != "" ]; then
+        sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = '${ADMIDIO_DB_HOST%%:*}';/g" "${ADMIDIO_CONFIG}"
+    else
+        sed -i "s/^\$g_adm_srv.*/\$g_adm_srv = 'localhost';/g" "${ADMIDIO_CONFIG}"
+    fi
+
+    # $g_adm_port = null;                          // Port
+    if [ "${ADMIDIO_DB_PORT}" != "" ]; then
+        sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_PORT};/g" "${ADMIDIO_CONFIG}"
+    elif [ "${ADMIDIO_DB_HOST}" != "" ]; then
+        sed -i "s/^\$g_adm_port.*/\$g_adm_port = ${ADMIDIO_DB_HOST##*:};/g" "${ADMIDIO_CONFIG}"
+    else
+        sed -i "s/^\$g_adm_port.*/\$g_adm_port = null;/g" "${ADMIDIO_CONFIG}"
+    fi
+    # $g_adm_db   = 'Databasename';                // Database
+    sed -i "s/^\$g_adm_db.*/\$g_adm_db = '${ADMIDIO_DB_NAME:-admidio}';/g" "${ADMIDIO_CONFIG}"
+    # $g_adm_usr  = 'Username';                    // User
+    sed -i "s/^\$g_adm_usr.*/\$g_adm_usr = '${ADMIDIO_DB_USER:-admidio}';/g" "${ADMIDIO_CONFIG}"
+    # $g_adm_pw   = 'Password';                    // Password
+    sed -i "s/^\$g_adm_pw.*/\$g_adm_pw = '${ADMIDIO_DB_PASSWORD:-admidio}';/g" "${ADMIDIO_CONFIG}"
+
+    # // URL to this Admidio installation
+    # // Example: 'https://www.admidio.org/example'
+    # $g_root_path = 'https://www.your-website.de/admidio';
+    if [ "${ADMIDIO_ROOT_PATH}" != "" ]; then
+        sed -i "s#^\$g_root_path.*#\$g_root_path = '${ADMIDIO_ROOT_PATH}';#g" "${ADMIDIO_CONFIG}"
+    fi
+
+    if [ "${ADMIDIO_ORGANISATION}" != "" ]; then
+        if [ "$(egrep '^\$g_organization' ${ADMIDIO_CONFIG})" != "" ]; then
+            sed -i "s/^\$g_organization.*/\$g_organization = '${ADMIDIO_ORGANISATION}';/g" "${ADMIDIO_CONFIG}"
+        else
+            echo "" >> "${ADMIDIO_CONFIG}"
+            echo "# // Short description of the organization that is running Admidio" >> "${ADMIDIO_CONFIG}"
+            echo "# // This short description must correspond to your input in the installation wizard !!!" >> "${ADMIDIO_CONFIG}"
+            echo "# // Example: 'ADMIDIO'" >> "${ADMIDIO_CONFIG}"
+            echo "# // Maximum of 10 characters !!!" >> "${ADMIDIO_CONFIG}"
+            echo "\$g_organization = '${ADMIDIO_ORGANISATION}';" >> "${ADMIDIO_CONFIG}"
+            echo "" >> "${ADMIDIO_CONFIG}"
+        fi
+    fi
+
+    # // The name of the timezone in which your organization is located.
+    # // This must be one of the strings that are defined here https://www.php.net/manual/en/timezones.php
+    # // Example: 'Europe/Berlin'
+    # $gTimezone = 'Europe/Berlin';
+    if [ "${TZ}" != "" ]; then
+        sed -i "s#^\$gTimezone.*#\$gTimezone = '${TZ}';#g" "${ADMIDIO_CONFIG}"
+    fi
+
+    # // If this flag is set = 1 then you must enter your loginname and password
+    # // for an update of the Admidio database to a new version of Admidio.
+    # // For a more comfortable and easy update you can set this preference = 0.
+    # $gLoginForUpdate = 1;
+    sed -i "s/^\$gLoginForUpdate.*/\$gLoginForUpdate = ${ADMIDIO_LOGIN_FOR_UPDATE:-1};/g" "${ADMIDIO_CONFIG}"
+
+    # // Set the preferred password hashing algorithm.
+    # // Possible values are: 'DEFAULT', 'ARGON2ID', 'ARGON2I', 'BCRYPT', 'SHA512'
+    # $gPasswordHashAlgorithm = 'DEFAULT';
+    sed -i "s/^\$gPasswordHashAlgorithm.*/\$gPasswordHashAlgorithm = '${ADMIDIO_PASSWORD_HASH_ALGORITHM:-DEFAULT}';/g" "${ADMIDIO_CONFIG}"
+else
+    echo "[WARNING] admidio config.php file does not exist."
 fi
 
 if [ ! -f "${ADMIDIO_INSTALLED_VERSION}" ]; then
     echo "[INFO ] create ADMIDIO_INSTALLED_VERSION file (${ADMIDIO_INSTALLED_VERSION}) with admidio version ($(cat ${ADMIDIO_IMAGE_VERSION} 2>/dev/null))"
     echo -n "$(cat ${ADMIDIO_IMAGE_VERSION} 2>/dev/null)" > "${ADMIDIO_INSTALLED_VERSION}"
+fi
+
+if [ "$(cat ${ADMIDIO_INSTALLED_VERSION} 2>/dev/null)" != "$(cat ${ADMIDIO_IMAGE_VERSION} 2>/dev/null)" ]; then
+    echo "[INFO ] update admidio installation to image version ($(cat ${ADMIDIO_IMAGE_VERSION} 2>/dev/null)) ..."
+    echo "[DEBUG] rsync -a --delete provisioning/adm_program/ adm_program/"
+    rsync -a --delete provisioning/adm_program/ adm_program/
+    echo "[DEBUG] rsync -a provisioning/adm_plugins/ adm_plugins/"
+    rsync -a provisioning/adm_plugins/ adm_plugins/
+    echo "[DEBUG] rsync -a provisioning/adm_themes/ adm_themes/"
+    rsync -a provisioning/adm_themes/ adm_themes/
+    echo "[DEBUG] rsync -a --delete provisioning/adm_themes/simple/ adm_themes/simple/"
+    rsync -a --delete provisioning/adm_themes/simple/ adm_themes/simple/
+    echo "[DEBUG] rsync -a --exclude=/config.php --exclude=/.admidio_installed --exclude=/.admidio_installed_version provisioning/adm_my_files/ adm_my_files/"
+    rsync -a --exclude="/config.php" --exclude="/.admidio_installed" --exclude="/.admidio_installed_version" provisioning/adm_my_files/ adm_my_files/
+    rm -f "${ADMIDIO_INSTALLED_VERSION}"
 fi
 
 # run apache with php enabled as user default


### PR DESCRIPTION
We have problems with the database check from time to time. Currently it is assumed that the database has already been initialized as soon as a config.php exists.

In most cases, the following error occurs:
```
PHP Fatal error:  Uncaught Error: Call to a member function fetchAll() on bool in /opt/app-root/src/adm_program/system/classes/Database.php:516
Stack trace:
#0 /opt/app-root/src/adm_program/system/classes/Database.php(442): Database->loadTableColumnsProperties()
#1 /opt/app-root/src/adm_program/system/classes/TableAccess.php(654): Database->getTableColumnsProperties()
#2 /opt/app-root/src/adm_program/system/classes/TableAccess.php(147): TableAccess->setColumnsInfos()
#3 /opt/app-root/src/adm_program/system/classes/TableAccess.php(109): TableAccess->clear()
#4 /opt/app-root/src/adm_program/system/classes/Session.php(62): TableAccess->__construct()
#5 /opt/app-root/src/adm_program/system/common.php(91): Session->__construct()
#6 /opt/app-root/src/adm_program/overview.php(18): require_once('...')
#7 {main}\n  thrown in /opt/app-root/src/adm_program/system/classes/Database.php on line 516
  127.0.0.1 "GET /adm_program/overview.php HTTP/1.1" 500 -
```

Therefore, the check should take place directly in the database and, if necessary, redirect to the installation page.

With the new check, the installation in the container can be significantly simplified, as most of the values are already available via the container configuration.

@Fasse: Can you please review the pull request (changes in `adm_program`) and test with a normal installation?
