### PR TITLE
Issue 1607 - Export Fix

### DIFF
--- a/adm_program/system/classes/ListData.php
+++ b/adm_program/system/classes/ListData.php
@@ -264,7 +264,9 @@ class ListData
         header('Content-Disposition: attachment; filename="' . $filename . '"');
         header('Cache-Control: max-age=0');
         header('Content-Length: ' . filesize($tempFileFolderName));
-        ob_clean();
+        if(ob_get_length() > 0) { // Issue 1607 Fix
+            ob_clean();
+        }
         flush();
         $writer->save('php://output');
         unlink($tempFileFolderName);


### PR DESCRIPTION
https://github.com/Admidio/admidio/issues/1607

Resolves the following error message from showing up in all exports (.csv and broke .xlsx)

<br /> <b>Notice</b>:  ob_clean(): failed to delete buffer. No buffer to delete in <b>/admidio/adm_program/system/classes/ListData.php</b> on line <b>266</b><br />