### PR TITLE
queryPrepared() returns the wrong state if in silent mode

### DIFF
--- a/adm_program/system/classes/Database.php
+++ b/adm_program/system/classes/Database.php
@@ -779,7 +779,12 @@ class Database
             $this->pdoStatement = $this->pdo->prepare($sql);
 
             if ($this->pdoStatement !== false) {
-                $this->pdoStatement->execute($params);
+                $success = $this->pdoStatement->execute($params);
+
+                // When executing PostgreSQL statements, at least if there is a table missing, no exception is thrown. But the PDOStatement.execute() returns false.
+                if (!$success) {
+                    return false;
+                }
 
                 if (StringUtils::strStartsWith($sql, 'SELECT', false)) {
                     $gLogger->info('SQL: Found rows: ' . $this->pdoStatement->rowCount());


### PR DESCRIPTION
Solves #1728 for 4.3.X