### PR TITLE
Various smaller fixes for the v4.3 branch

### DIFF
--- a/adm_program/installation/db_scripts/update_4_3.xml
+++ b/adm_program/installation/db_scripts/update_4_3.xml
@@ -124,5 +124,6 @@
     <step id="1230" database="pgsql">UPDATE %PREFIX%_preferences SET prf_value = '24' WHERE prf_name = 'photo_thumbs_page' AND prf_value::int = 16</step>
     <step id="1240">UPDATE %PREFIX%_categories SET cat_type = 'EVT' WHERE cat_type = 'DAT'</step>
     <step id="1250">UPDATE %PREFIX%_categories SET cat_org_id = 1 WHERE cat_org_id IS NULL AND cat_name_intern = 'EVENTS'</step>
+    <step id="1255">UPDATE %PREFIX%_roles_rights SET ror_table = '%PREFIX%_events' WHERE ror_table = '%PREFIX%_dates'</step>
     <step>stop</step>
 </update>

--- a/adm_program/installation/install_steps/start_installation.php
+++ b/adm_program/installation/install_steps/start_installation.php
@@ -212,8 +212,10 @@ $gCurrentOrganization->setValue('org_homepage', ADMIDIO_URL);
 $gCurrentOrganization->save();
 $gCurrentOrgId = $gCurrentOrganization->getValue('org_id');
 
+$gProfileFields = new ProfileFields($db, $gCurrentOrgId);
+
 // create administrator and assign roles
-$administrator = new User($db);
+$administrator = new User($db, $gProfileFields);
 $administrator->setValue('usr_login_name', $_SESSION['user_login']);
 $administrator->setPassword($_SESSION['user_password']);
 $administrator->setValue('usr_usr_id_create', $gCurrentUserId);

--- a/adm_program/installation/installation.php
+++ b/adm_program/installation/installation.php
@@ -147,6 +147,8 @@ if (is_file($configPath)) {
     }
 }
 
+$gDb = $db; // Make the database object globally available to all classes, just like after installation
+
 switch ($step) {
     case 'welcome': // (Default) Welcome to installation
         $gLogger->info('INSTALLATION: Welcome to installation');

--- a/adm_program/languages/de-DE.xml
+++ b/adm_program/languages/de-DE.xml
@@ -473,9 +473,9 @@
   <string name="SYS_DATABASE">Datenbank</string>
   <string name="SYS_DATABASE_BACKUP">Datenbank-Backup</string>
   <string name="SYS_DATABASE_BACKUP_DESC">Datenbanksicherungen der Admidio-Tabellen können hier erstellt und heruntergeladen werden.</string>
-  <string name="SYS_DATABASE_DOESNOT_NEED_UPDATED">Eine Aktualisierung der Datenbank ist nicht erforderlich</string>
+  <string name="SYS_DATABASE_DOESNOT_NEED_UPDATED">Eine Aktualisierung der Datenbank ist nicht erforderlich.</string>
   <string name="SYS_DATABASE_ERROR">Datenbankfehler</string>
-  <string name="SYS_DATABASE_IS_UP_TO_DATE">Die Admidio-Datenbank ist aktuell</string>
+  <string name="SYS_DATABASE_IS_UP_TO_DATE">Die Admidio-Datenbank ist aktuell.</string>
   <string name="SYS_DATABASE_NO_LOGIN">Es konnte keine Verbindung zur Datenbank erstellt werden!\n\nFolgender Fehler ist aufgetreten:\n#VAR1#.</string>
   <string name="SYS_DATABASE_NO_LOGIN_CONFIG_FILE">Es konnte keine Verbindung zur Datenbank erstellt werden!\n\nBitte prüfen Sie die Zugangsdaten in der Datei config.php im Order adm_my_files. Sollte die Datei noch von einer anderen Installation stammen, so entfernen Sie die config.php bitte aus dem Ordner, da über den Installationsassistenten eine neue Datei erzeugt wird. Danach kann die Installation fortgesetzt werden.\n\nFolgender Fehler ist aufgetreten:\n#VAR1#.</string>
   <string name="SYS_DATABASE_VERSION">Datenbank-Version</string>
@@ -697,7 +697,7 @@
   <string name="SYS_FILE_RENAME_ERROR">Beim Umbenennen der Datei #VAR1# ist ein Fehler aufgetreten.</string>
   <string name="SYS_FILE_TO_LARGE_SERVER">Die hochgeladene Datei übersteigt die vom Server zugelassene Dateigröße von #VAR1# MB.</string>
   <string name="SYS_FILE_TYPE">Dateityp</string>
-  <string name="SYS_FILE_UPLOADED">Die Datei #VAR1_BOLD# wurde hochgeladen</string>
+  <string name="SYS_FILE_UPLOADED">Die Datei #VAR1_BOLD# wurde hochgeladen.</string>
   <string name="SYS_FILE_UPLOADS">Dateiuploads</string>
   <string name="SYS_FILES_UPLOAD_SUCCESSFUL">Alle Dateien wurden erfolgreich hochgeladen.</string>
   <string name="SYS_FILES_UPLOAD_NOT_SUCCESSFUL">Es wurden nicht alle Dateien erfolgreich hochgeladen.</string>
@@ -753,7 +753,7 @@
   <string name="SYS_HEADLINE">Überschrift</string>
   <string name="SYS_HELP">Hilfe</string>
   <string name="SYS_HIDE">Ausblenden</string>
-  <string name="SYS_HIDDEN">Versteckt </string>
+  <string name="SYS_HIDDEN">Versteckt</string>
   <string name="SYS_HIGHLIGHT_EVENT">Veranstaltung optisch hervorheben</string>
   <string name="SYS_HOMEPAGE">Startseite</string>
   <string name="SYS_HOST">Host</string>
@@ -870,7 +870,7 @@
   <string name="SYS_MAX_PHOTO_SIZE_HEIGHT">Maximale Bildhöhe</string>
   <string name="SYS_MAX_PHOTO_SIZE_WIDTH">Maximale Bildbreite</string>
   <string name="SYS_MAX_PROCESSABLE_IMAGE_SIZE">max. bearbeitbare Bildgröße</string>
-  <string name="SYS_MAX_RECEIVER">Maximale Empfänger:innen für E-Mails</string>
+  <string name="SYS_MAX_RECEIVER">Maximale Anzahl Empfänger:innen für E-Mails</string>
   <string name="SYS_MAX_RECEIVER_DESC">Dieser Wert gibt an, wie viele Empfänger:innen man für ein E-Mail auswählen kann. Eine Rolle wird als ein einzelner Empfänger verstanden.</string>
   <string name="SYS_MAXIMUM_FILE_SIZE">Maximale Dateigröße</string>
   <string name="SYS_MAXIMUM_FILE_SIZE_DESC">Benutzer:innen können nur Dateien hochladen, bei denen die Dateigröße kleiner als der hier angegebene Wert ist. Steht hier 0, so ist der Upload deaktiviert. (Voreinstellung: 3MB)</string>
@@ -1038,7 +1038,7 @@
   <string name="SYS_PASSWORDS_NOT_EQUAL">Das eingegebene Passwort stimmt nicht mit der Wiederholung überein.</string>
   <string name="SYS_PATH_SEPARATOR">Pfad Trenner</string>
   <string name="SYS_PERIOD">Zeitraum</string>
-  <string name="SYS_PERIOD_FROM_TO">Zeitraum vom #VAR1# bis #VAR2# </string>
+  <string name="SYS_PERIOD_FROM_TO">Zeitraum vom #VAR1# bis #VAR2#</string>
   <string name="SYS_PERMISSIONS">Berechtigungen</string>
   <string name="SYS_PDF">PDF</string>
   <string name="SYS_PHONE">Telefon</string>

--- a/adm_program/languages/de.xml
+++ b/adm_program/languages/de.xml
@@ -504,7 +504,7 @@
   <string name="SYS_DEFAULT_CONFIGURATION_CAT_REP_DESC">Eine der hier vorgegebenen Konfigurationen kann zur Standardkonfiguration für den Kategorienreport dieser Organisation gemacht werden. Die gewählte Konfiguration wird beim Aufruf des Reports direkt angezeigt.</string>
   <string name="SYS_DEFAULT_CONFIGURATION_LISTS_DESC">Eine der hier vorgegebenen Konfigurationen kann zur Standardkonfiguration für Listen dieser Organisation gemacht werden. Mitgliederlisten von Rollen, die keine Listenkonfiguration hinterlegt haben, werden mit dieser Konfiguration angezeigt.</string>
   <string name="SYS_DEFAULT_COUNTRY">Standard-Land</string>
-  <string name="SYS_DEFAULT_COUNTRY_DESC">Angabe eines Landes in dessem Umfeld die Organisation hauptsächlich arbeitet. Dieses wird z.B. bei der Registrierung oder beim Anlegen neuer Benutzer:innen vorausgewählt. Es soll die Eingabe erleichtern und kann aber auch von der Benutzerin oder dem Benutzer beliebig geändert werden. (Voreinstellung: Deutschland)</string>
+  <string name="SYS_DEFAULT_COUNTRY_DESC">Angabe eines Landes in dessen Umfeld die Organisation hauptsächlich arbeitet. Dieses wird z.B. bei der Registrierung oder beim Anlegen neuer Benutzer:innen vorausgewählt. Es soll die Eingabe erleichtern und kann aber auch von der Benutzerin oder dem Benutzer beliebig geändert werden. (Voreinstellung: Deutschland)</string>
   <string name="SYS_DEFAULT_ENCODING_UTF8">Standardkodierung (UTF-8)</string>
   <string name="SYS_DEFAULT_LIST">Standardliste</string>
   <string name="SYS_DEFAULT_LIST_DESC">Soll eine Mitgliederliste zu dieser Rolle angezeigt werden und wird keine Listenkonfiguration vorgegeben, so wird die Liste in der systemweit eingestellten Standardlistenkonfiguration dargestellt. Über dieses Feld kann für die einzelne Rolle eine andere Listenkonfiguration ausgewählt werden, die angezeigt wird, wenn keine Listenkonfiguration vorgegeben ist.</string>
@@ -864,7 +864,7 @@
   <string name="SYS_MASTODON">Mastodon</string>
   <string name="SYS_MAX_ATTACHMENT_SIZE">Du kannst so viele Anhänge hinzufügen, wie du möchtest. Die Dateigröße aller Anhänge zusammen darf #VAR1# MB nicht überschreiten.</string>
   <string name="SYS_MAX_PARTICIPANTS">Max. Teilnehmende</string>
-  <string name="SYS_MAX_PARTICIPANTS_OF_ROLE">#VAR1# von max. #VAR2# Teilnehmende</string>
+  <string name="SYS_MAX_PARTICIPANTS_OF_ROLE">#VAR1# von max. #VAR2# Teilnehmenden</string>
   <string name="SYS_MAX_PATH_LENGTH">Max Pfadlänge</string>
   <string name="SYS_MAX_PHOTO_SIZE_DESC">Die angegebenen Werte bestimmen die maximale Größe, die ein Bild in der Breite bzw. Höhe haben darf. Die Fotos werden beim Hochladen auf diese Größe skaliert. Bei einem Modalen-Fenster oder Popup-Fenster wird das Fenster automatisch in die Größe des Foto angepasst. (Voreinstellung: #VAR1# x #VAR2# Pixel)</string>
   <string name="SYS_MAX_PHOTO_SIZE_HEIGHT">Maximale Bildhöhe</string>
@@ -966,7 +966,7 @@
   <string name="SYS_NO_ROLES_AND_USERS">Es sind keine Rollen oder Benutzer:innen freigegeben, an die du Nachrichten schicken kannst.</string>
   <string name="SYS_NO_ROLES_VISIBLE">Es wurden keine Rollen gefunden. Ggf. fehlen dir die Rechte bestimmte Rollen zu sehen.</string>
   <string name="SYS_NO_TEMPLATE">Keine Vorlage</string>
-  <string name="SYS_NO_USER_FOUND">Es wurde kein Benutzer:in gefunden, der den gewählten Kriterien entspricht.</string>
+  <string name="SYS_NO_USER_FOUND">Es wurde kein:e Benutzer:in gefunden, der den gewählten Kriterien entspricht.</string>
   <string name="SYS_NO_VALID_RECIPIENTS">Die ausgewählten Rollen und Benutzer:innen besitzen keine gültigen E-Mail-Adressen. Aus diesem Grund kann die E-Mail nicht versendet werden.</string>
   <string name="SYS_NOBODY">Niemand</string>
   <string name="SYS_NONE">Keiner</string>
@@ -1102,7 +1102,7 @@
   <string name="SYS_QUARTERLY">Vierteljährlich</string>
   <string name="SYS_QUOTE">Einfaches Anführungszeichen (\')</string>
   <string name="SYS_RADIO_BUTTON">Optionsfeld</string>
-  <string name="SYS_RECENT_ALBUMS_OF_ORGA">Neuesten Fotoalben der Organisation #VAR1#</string>
+  <string name="SYS_RECENT_ALBUMS_OF_ORGA">Neueste Fotoalben der Organisation #VAR1#</string>
   <string name="SYS_RECENT_ANNOUNCEMENTS_OF_ORGA">Neueste Ankündigungen der Organisation #VAR1#</string>
   <string name="SYS_RECIPIENT">Empfänger:in</string>
   <string name="SYS_RECIPIENT_EMAIL">Empfänger:in E-Mail</string>

--- a/adm_program/modules/links/links_function.php
+++ b/adm_program/modules/links/links_function.php
@@ -61,6 +61,7 @@ if ($getLinkUuid !== '') {
 
 if ($getMode === 1) {
     $_SESSION['links_request'] = $_POST;
+    $weblinkIsNew = $link->isNewRecord();
 
     if (strlen(StringUtils::strStripTags($_POST['lnk_name'])) === 0) {
         $gMessage->show($gL10n->get('SYS_FIELD_EMPTY', array($gL10n->get('SYS_LINK_NAME'))));
@@ -87,7 +88,7 @@ if ($getMode === 1) {
         }
 
         // Set link counter to 0
-        if ($weblinkIsNew) {
+        if ($weblinkIsNew) { 
             $link->setValue('lnk_counter', 0);
         }
 

--- a/adm_program/modules/profile-fields/profile_fields_new.php
+++ b/adm_program/modules/profile-fields/profile_fields_new.php
@@ -57,7 +57,7 @@ $gNavigation->addUrl(CURRENT_URL, $headline);
 
 if (isset($_SESSION['fields_request'])) {
     // hidden must be 0, if the flag should be set
-    if ($_SESSION['fields_request']['usf_hidden'] == 1) {
+    if (isset($_SESSION['fields_request']['usf_hidden']) && $_SESSION['fields_request']['usf_hidden'] == 1) {
         $_SESSION['fields_request']['usf_hidden'] = 0;
     } else {
         $_SESSION['fields_request']['usf_hidden'] = 1;

--- a/adm_program/system/classes/ChangeNotification.php
+++ b/adm_program/system/classes/ChangeNotification.php
@@ -16,7 +16,7 @@
  * system notifications for profile field changes are enabled in the configuration of Admidio
  *
  * On startup, a global (singleton) object $gChangeNotifications is created
- * that is automatically used the User and TableMembers classes to log
+ * that is automatically used by the User and TableMembers classes to log
  * changes.
  *
  *

--- a/adm_program/system/classes/ModuleGroupsRoles.php
+++ b/adm_program/system/classes/ModuleGroupsRoles.php
@@ -328,7 +328,7 @@ class ModuleGroupsRoles extends HtmlPage
                     $templateRow['viewMembersProfiles'] = $gL10n->get('ORG_REGISTERED_USERS');
                     break;
                 case 3:
-                    $templateRow['viewMembership'] = $gL10n->get('SYS_LEADERS');
+                    $templateRow['viewMembersProfiles'] = $gL10n->get('SYS_LEADERS');
                     break;
             }
 

--- a/adm_program/system/classes/ProfileFields.php
+++ b/adm_program/system/classes/ProfileFields.php
@@ -772,8 +772,20 @@ class ProfileFields
                 }
             }
 
-            if($this->mProfileFields[$fieldNameIntern]->getValue('usf_regex') !== ''
-            && preg_match('/'.$this->mProfileFields[$fieldNameIntern]->getValue('usf_regex').'/', $fieldValue) === 0) {
+            // RegEx handling. If the regex contains a forward slash /, it needs to be escaped!
+            $regex = $this->mProfileFields[$fieldNameIntern]->getValue('usf_regex');
+            $delimiters = '/+#äüö@§%&=°µ|<>';
+            while (strlen($delimiters) > 0 && str_contains($regex, $delimiters[0])) {
+                $delimiters = substr($delimiters, 1);
+            }
+            if (strlen($delimiters) == 0) {
+                $delimiter = '/';
+            } else {
+                $delimiter = $delimiters[0];
+            }
+
+            if($regex !== ''
+            && preg_match($delimiter.$regex.$delimiter, $fieldValue) === 0) {
                 throw new AdmException('SYS_FIELD_INVALID_REGEX', array($this->mProfileFields[$fieldNameIntern]->getValue('usf_name')));
             }
         }

--- a/adm_program/system/classes/TableAccess.php
+++ b/adm_program/system/classes/TableAccess.php
@@ -158,11 +158,11 @@ class TableAccess
      *
      * **Code example**
      * ```
-     * // Constructor of adm_dates object where the category (calendar) is connected
+     * // Constructor of adm_events object where the category (calendar) is connected
      * public function __construct($database, $datId = 0)
      * {
      *     $this->connectAdditionalTable(TBL_CATEGORIES, 'cat_id', 'dat_cat_id');
-     *     parent::__construct($db, TBL_DATES, 'dat', $datId);
+     *     parent::__construct($db, TBL_EVENTS, 'dat', $datId);
      * }
      * ```
      */

--- a/adm_program/system/classes/TableAccess.php
+++ b/adm_program/system/classes/TableAccess.php
@@ -485,7 +485,7 @@ class TableAccess
      * If the table has columns for creator or editor than these column with their timestamp will be updated.
      * For a new record if there is an uuid column a new uuid will be created and stored.
      * @param bool $updateFingerPrint Default **true**. Will update the creator or editor of the recordset
-     *                                if table has columns like **usr_id_create** or **usr_id_changed**
+     *                                if table has columns like **usr_id_create** or **usr_id_change**
      * @return bool If an update or insert into the database was done then return true, otherwise false.
      * @throws AdmException
      * @throws Exception
@@ -754,7 +754,7 @@ class TableAccess
 
             // now mark all other columns with values of this object as changed
             foreach ($this->dbColumns as $column => $value) {
-                if (strlen((string) $value) > 0) {
+                if ((is_array($value) && count($value)>0) || (strlen((string) $value) > 0)) {
                     $this->columnsInfos[$column]['changed'] = true;
                 }
             }

--- a/adm_program/system/classes/TableEvent.php
+++ b/adm_program/system/classes/TableEvent.php
@@ -10,7 +10,7 @@
 /**
  * Creates an event object from the database table adm_events
  *
- * With the given id an event object is created from the data in the database table **adm_dates**.
+ * With the given id an event object is created from the data in the database table **adm_events**.
  * The class will handle the communication with the database and give easy access to the data. New
  * event could be created or existing event could be edited. Special properties of
  * data like save urls, checks for evil code or timestamps of last changes will be handled within this class.
@@ -43,7 +43,7 @@ class TableEvent extends TableAccess
     private $mParticipants;
 
     /**
-     * Constructor that will create an object of a recordset of the table adm_dates.
+     * Constructor that will create an object of a recordset of the table adm_events.
      * If the id is set than the specific event will be loaded.
      * @param Database $database Object of the class Database. This should be the default global object **$gDb**.
      * @param int      $datId    The recordset of the event with this id will be loaded. If id isn't set than an empty object of the table is created.

--- a/adm_program/system/classes/TableUserRelationType.php
+++ b/adm_program/system/classes/TableUserRelationType.php
@@ -34,6 +34,9 @@ class TableUserRelationType extends TableAccess
      */
     public function getInverse(): ?TableUserRelationType
     {
+        if (empty($this->getValue('urt_id_inverse'))) {
+            return null;
+        }
         $inverse = new self($this->db, $this->getValue('urt_id_inverse'));
 
         if ($inverse->isNewRecord()) {

--- a/adm_program/system/classes/User.php
+++ b/adm_program/system/classes/User.php
@@ -93,6 +93,9 @@ class User extends TableAccess
 
         if ($userFields !== null) {
             $this->mProfileFieldsData = clone $userFields; // create explicit a copy of the object (param is in PHP5 a reference)
+        } else {
+            global $gProfileFields;
+            $this->mProfileFieldsData = clone $gProfileFields; // create explicit a copy of the object (param is in PHP5 a reference)
         }
 
         $this->organizationId = $GLOBALS['gCurrentOrgId'];


### PR DESCRIPTION
Various smaller fixes

* Typos in the German translation
* missing adjustments due to table renaming adm_dates -> adm_events
* Better handling of regexp and delimiter-detection
* During installation make global variables like $gDb, $gProfileFields, etc. available.
* In the links module, weblinkIsNew was lost in previous commits, leading to unknown variable errors.
* Typos in comments
* Copy&Paste error in array key
* Checking whether a vaiable is empty by converting it to a string does not work for array, so we need to special-case this.
* In TableUserRelationType we need an urt_id_inverse, otherwise we cannot retrieve the inverse.
* In User, when no profile fields are passed, make a clone of the global profile fields object