### PR TITLE
Some improvements to master: Use Entity::setValue/::save to activate/deactivate a role, remove spurious filename in user-visible output, allow leaving out the type param in the category edit page

### DIFF
--- a/adm_program/modules/guestbook/guestbook_comment_new.php
+++ b/adm_program/modules/guestbook/guestbook_comment_new.php
@@ -37,7 +37,7 @@ try {
     }
 
     // set create or edit mode
-    if ($getGboUuid !== '') {
+    if ($getGbcUuid !== '') {
         $mode = 'edit_comment';
         $headline = $gL10n->get('GBO_CREATE_COMMENT');
     } else {
@@ -127,6 +127,12 @@ try {
             $gL10n->get('SYS_NAME'),
             $gbComment->getValue('gbc_name'),
             array('maxLength' => 60, 'property' => HtmlForm::FIELD_DISABLED)
+        );
+        $form->addInput(
+            'gbc_name',
+            $gL10n->get('SYS_NAME'),
+            $gbComment->getValue('gbc_name'),
+            array('maxLength' => 60, 'property' => HtmlForm::FIELD_HIDDEN)
         );
     } else {
         $form->addInput(

--- a/adm_program/modules/guestbook/guestbook_new.php
+++ b/adm_program/modules/guestbook/guestbook_new.php
@@ -116,6 +116,12 @@ try {
             $guestbook->getValue('gbo_name'),
             array('maxLength' => 60, 'property' => HtmlForm::FIELD_DISABLED)
         );
+        $form->addInput(
+            'gbo_name',
+            $gL10n->get('SYS_NAME'),
+            $guestbook->getValue('gbo_name'),
+            array('maxLength' => 60, 'property' => HtmlForm::FIELD_HIDDEN)
+        );    
     } else {
         $form->addInput(
             'gbo_name',

--- a/adm_program/modules/photos/photo_album_function.php
+++ b/adm_program/modules/photos/photo_album_function.php
@@ -85,7 +85,7 @@ try {
         // set parent photo id
         $photoAlbumParent = new Album($gDb);
         $photoAlbumParent->readDataByUuid($_POST['parent_album_uuid']);
-        $_POST['pho_pho_id_parent'] = $photoAlbumParent->getValue('pho_id');
+        $formValues['pho_pho_id_parent'] = $photoAlbumParent->getValue('pho_id');
 
         // write form values in photos object
         foreach ($formValues as $key => $value) {

--- a/src/ProfileFields/Entity/ProfileField.php
+++ b/src/ProfileFields/Entity/ProfileField.php
@@ -222,7 +222,7 @@ class ProfileField extends Entity
                                     $listValueText = Language::translateIfTranslationStrId($listValueText);
 
                                     if ($format === 'html') {
-                                        $listValue = Image::getIconHtml($listValueImage, $listValueText) . ' ProfileField.php' . $listValueText;
+                                        $listValue = Image::getIconHtml($listValueImage, $listValueText) . ' ' . $listValueText;
                                     } else {
                                         // if no image is wanted then return the text part or only the position of the entry
                                         if (str_contains($listValue, '|')) {

--- a/src/Roles/Entity/Role.php
+++ b/src/Roles/Entity/Role.php
@@ -841,10 +841,8 @@ class Role extends Entity
 
         // system roles are always active and could therefore not be toggled
         if ((int)$this->getValue('rol_system') === 0) {
-            $sql = 'UPDATE ' . TBL_ROLES . '
-                       SET rol_valid = ? -- $status
-                     WHERE rol_id = ? -- $this->getValue(\'rol_id\')';
-            $this->db->queryPrepared($sql, array($status, (int)$this->getValue('rol_id')));
+            $this->setValue('rol_valid', $status);
+            $this->save();
 
             // all active users must renew their user data because maybe their
             // rights have been changed if they were members of this role

--- a/src/UI/View/Categories.php
+++ b/src/UI/View/Categories.php
@@ -42,6 +42,20 @@ class Categories extends HtmlPage
         $roleEditSet = array(0);
         $addButtonText = $gL10n->get('SYS_CATEGORY');
 
+        // create category object
+        $category = new Category($gDb);
+
+        if ($categoryUUID !== '') {
+            $category->readDataByUuid($categoryUUID);
+        }
+        // If no type was passed as param, try to read it from the DB. If unsuccessfull, thrown an error.
+        if (empty($type)) {
+            $type = $category->getValue('cat_type');
+        }
+        if (empty($type)) {
+            throw new Exception('SYS_INVALID_PAGE_VIEW');
+        }
+
         // set headline of the script
         if ($categoryUUID !== '') {
             if ($type === 'EVT') {
@@ -114,11 +128,7 @@ class Categories extends HtmlPage
             throw new Exception('SYS_INVALID_PAGE_VIEW');
         }
 
-        // create category object
-        $category = new Category($gDb);
-
         if ($categoryUUID !== '') {
-            $category->readDataByUuid($categoryUUID);
             $catId = (int)$category->getValue('cat_id');
 
             // get assigned roles of this category


### PR DESCRIPTION
- Activating/Deactivating a role should also use the Entity::save method to write to the database (otherwise the change will not be logged in the changelog)
- Categories view needs a type param. If only a UUID is given, read the type from the category in the DB -> type param is optional in the category edit page (making it easier to link to)
- ProfileField: Remove spurious ProfileFields.php filename inside a user-visible string (for male/female/diverse)
- Fix setting parent albums
- Fix editing guestbook entries and comments