### PR TITLE
Fix HtmlDataTable instance naming to avoid conflicts when adding multiple table instances on one page

### DIFF
--- a/adm_program/system/classes/HtmlDataTables.php
+++ b/adm_program/system/classes/HtmlDataTables.php
@@ -155,11 +155,11 @@ class HtmlDataTables
             $javascriptGroupFunction = '
                 // Order by the grouping
                 $("#' . $this->id . ' tbody").on("click", "tr.admidio-group-heading", function() {
-                    const currentOrder = admidioTable.order()[0];
+                    const currentOrder = admidioTable_'. $this->id . '.order()[0];
                     if (currentOrder[0] === ' . $this->groupedColumn . ' && currentOrder[1] === "asc") {
-                        admidioTable.order([' . $this->groupedColumn . ', "desc"]).draw();
+                        admidioTable_'. $this->id . '.order([' . $this->groupedColumn . ', "desc"]).draw();
                     } else {
-                        admidioTable.order([' . $this->groupedColumn . ', "asc"]).draw();
+                        admidioTable_'. $this->id . '.order([' . $this->groupedColumn . ', "asc"]).draw();
                     }
                 });';
         }
@@ -180,7 +180,7 @@ class HtmlDataTables
         }
         $this->htmlPage->addJavascript(
             '
-            const admidioTable = $("#' . $this->id . '").DataTable({' .
+            const admidioTable_'. $this->id . ' = $("#' . $this->id . '").DataTable({' .
             implode(',', $this->datatablesInitParameters) .
             $javascriptGroup . '
             });


### PR DESCRIPTION
When trying to add multiple HTMLDataTables to a single HTMLPage the following JavaScript error occurs:
`Uncaught SyntaxError: redeclaration of const admidioTable`

To fix this the `id` of each HTMLDataTable to be added to the page should be included in the constant name.