### PR TITLE
Improve check for changed values in Entity

### DIFF
--- a/src/Infrastructure/ChangeNotification.php
+++ b/src/Infrastructure/ChangeNotification.php
@@ -66,8 +66,7 @@ class ChangeNotification
     public function __construct()
     {
         global $gSettingsManager;
-
-        $gSettingsManager->disableExceptions();
+ 
         $this->format = $gSettingsManager->getBool('mail_html_registered_users') ? 'html' : 'text';
 
         // Register a shutdown function, which will be called when the whole PHP


### PR DESCRIPTION
### Don't disable all exceptions in the ChangeNotification constructor
This is a global setting applying to all code execution afterward, that is not expected to happen. In particular, it prevents inserting new preference entries into the database, because that relies on an exception when the prf_name cannot be found. With exceptions disabled, the preferences managet will always try to update and never insert a new setting.

### Improve change detection of database column values, using the column type
Since loading from the database converts to the actual data types,
but setting uses strings, some datatypes need special-casing:
  * Boolean false are read as null, but set as 0
        -> null and 0 must be considered as false.
  * Similarily, loading a (date)time will include seconds, but
    setting will not include seconds in the string value
        -> try to convert to DateTime and compare them.