### PR TITLE
fix: debug and import mode globals not defined

### DIFF
--- a/src/UI/View/Preferences.php
+++ b/src/UI/View/Preferences.php
@@ -1823,7 +1823,7 @@ class Preferences extends HtmlPage
      */
     public function createSystemInformationForm(): string
     {
-        global $gL10n, $gDb, $gLogger;
+        global $gL10n, $gDb, $gLogger, $gDebug, $gImportDemoData;
 
         $this->assignSmartyVariable('operatingSystemName', SystemInfoUtils::getOS());
         $this->assignSmartyVariable('operatingSystemUserName', SystemInfoUtils::getUname());


### PR DESCRIPTION
[`src/UI/View/Preferences.php`](diffhunk://#diff-acbd850cafebbf7d42e6be7546c3b5c2344d45ddfa04f30a595d34f726d05d5dL1826-R1826): Modified the `createSystemInformationForm` method to include the global variables `$gDebug` and `$gImportDemoData`.