### PR TITLE
fix: '-' in Html(Data)Table Ids prevent using modal windows

### DIFF
--- a/adm_program/system/classes/HtmlDataTables.php
+++ b/adm_program/system/classes/HtmlDataTables.php
@@ -172,11 +172,11 @@ class HtmlDataTables
             $javascriptGroupFunction = '
                 // Order by the grouping
                 $("#' . $this->id . ' tbody").on("click", "tr.admidio-group-heading", function() {
-                    const currentOrder = admidioTable_'. $this->id . '.order()[0];
+                    const currentOrder = admidioTable_' . $this->id . '.order()[0];
                     if (currentOrder[0] === ' . $this->groupedColumn . ' && currentOrder[1] === "asc") {
-                        admidioTable_'. $this->id . '.order([' . $this->groupedColumn . ', "desc"]).draw();
+                        admidioTable_' . $this->id . '.order([' . $this->groupedColumn . ', "desc"]).draw();
                     } else {
-                        admidioTable_'. $this->id . '.order([' . $this->groupedColumn . ', "asc"]).draw();
+                        admidioTable_' . $this->id . '.order([' . $this->groupedColumn . ', "asc"]).draw();
                     }
                 });';
         }
@@ -197,7 +197,7 @@ class HtmlDataTables
         }
         $this->htmlPage->addJavascript(
             '
-            const admidioTable_'. $this->id . ' = $("#' . $this->id . '").DataTable({' .
+            const admidioTable_' . $this->id . ' = $("#' . $this->id . '").DataTable({' .
             implode(',', $this->datatablesInitParameters) .
             $javascriptGroup . '
             });

--- a/adm_program/system/classes/ModuleDocumentsFiles.php
+++ b/adm_program/system/classes/ModuleDocumentsFiles.php
@@ -153,7 +153,7 @@ class ModuleDocumentsFiles extends HtmlPage
         }
 
         // initialize and set the parameter for DataTables
-        $dataTables = new HtmlDataTables($this, 'documents-files-table');
+        $dataTables = new HtmlDataTables($this, 'documents_files_table');
         $dataTables->disableDatatablesColumnsSort(array(1, 6));
         $dataTables->setDatatablesColumnsNotHideResponsive(array(6));
         $dataTables->createJavascript(count($this->data), 6);

--- a/adm_program/system/classes/ModuleDocumentsFiles.php
+++ b/adm_program/system/classes/ModuleDocumentsFiles.php
@@ -153,7 +153,7 @@ class ModuleDocumentsFiles extends HtmlPage
         }
 
         // initialize and set the parameter for DataTables
-        $dataTables = new HtmlDataTables($this, 'documents_files_table');
+        $dataTables = new HtmlDataTables($this, 'adm_documents_files_table');
         $dataTables->disableDatatablesColumnsSort(array(1, 6));
         $dataTables->setDatatablesColumnsNotHideResponsive(array(6));
         $dataTables->createJavascript(count($this->data), 6);

--- a/adm_program/system/classes/ModuleGroupsRoles.php
+++ b/adm_program/system/classes/ModuleGroupsRoles.php
@@ -376,7 +376,7 @@ class ModuleGroupsRoles extends HtmlPage
         }
 
         // initialize and set the parameter for DataTables
-        $dataTables = new HtmlDataTables($this, 'role-permissions-table');
+        $dataTables = new HtmlDataTables($this, 'role_permissions_table');
         $dataTables->setDatatablesGroupColumn(1);
         $dataTables->disableDatatablesColumnsSort(array(3, 8));
         $dataTables->setDatatablesColumnsNotHideResponsive(array(8));

--- a/adm_program/system/classes/ModuleGroupsRoles.php
+++ b/adm_program/system/classes/ModuleGroupsRoles.php
@@ -376,7 +376,7 @@ class ModuleGroupsRoles extends HtmlPage
         }
 
         // initialize and set the parameter for DataTables
-        $dataTables = new HtmlDataTables($this, 'role_permissions_table');
+        $dataTables = new HtmlDataTables($this, 'adm_role_permissions_table');
         $dataTables->setDatatablesGroupColumn(1);
         $dataTables->disableDatatablesColumnsSort(array(3, 8));
         $dataTables->setDatatablesColumnsNotHideResponsive(array(8));


### PR DESCRIPTION
fixes #1741: _couldn't use modal windows in HtmlDataTables_ 

***

I also checked all HtmlTable initializations so hopefully I found all occurrences (only 2?).
@Fasse: Maybe you can check again?