### PR TITLE
More work on the changelog

### DIFF
--- a/adm_program/modules/changelog.php
+++ b/adm_program/modules/changelog.php
@@ -383,9 +383,9 @@ try {
             if ($row['table_name'] == 'list_columns') {
                 // The related item is either a user field or a column name mem_ or usr_ -> in the latter case, convert it to a translatable string and translate
                 if (!empty($relatedName) && (str_starts_with($relatedName, 'mem_') || str_starts_with($relatedName, 'usr_'))) {
-                    $relatedName = $fieldString[$relatedName];
+                    $relatedName = $fieldString[$relatedName]??$relatedName;
                     if (is_array($relatedName)) {
-                        $relatedName = $relatedName['name'];
+                        $relatedName = $relatedName['name']??'-';
                     }
                     if (!empty($relatedName)) {
                         $relatedName = Language::translateIfTranslationStrId($relatedName);

--- a/adm_program/modules/changelog.php
+++ b/adm_program/modules/changelog.php
@@ -380,6 +380,9 @@ try {
             if ($row['table_name'] == 'roles_rights_data') {
                 $relatedTable = 'roles';
             }
+            if ($row['table_name'] == 'roles_dependencies') {
+                $relatedTable = 'roles';
+            }
             if ($row['table_name'] == 'list_columns') {
                 // The related item is either a user field or a column name mem_ or usr_ -> in the latter case, convert it to a translatable string and translate
                 if (!empty($relatedName) && (str_starts_with($relatedName, 'mem_') || str_starts_with($relatedName, 'usr_'))) {

--- a/adm_program/modules/contacts/contacts_data.php
+++ b/adm_program/modules/contacts/contacts_data.php
@@ -321,7 +321,7 @@ try {
                     // User is not member of any organization -> ask if delete completely
                     $userAdministration .= '
                         <a class="admidio-icon-link admidio-messagebox" href="javascript:void(0);" data-buttons="yes-no"
-                            data-message="' . $gL10n->get('SYS_USER_DELETE_DESC', array($row['FIRST_NAME'] . ' ' . $row['LAST_NAME'])) . '"
+                            data-message="' . $gL10n->get('SYS_USER_DELETE_DESC', array($row['first_name'] . ' ' . $row['last_name'])) . '"
                             data-href="callUrlHideElement(\'row_members_' . $row['usr_uuid'] . '\', \'' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/contacts/contacts_function.php', array('mode' => 'delete', 'user_uuid' => $row['usr_uuid'])) . '\', \'' . $gCurrentSession->getCsrfToken() . '\')">
                             <i class="bi bi-trash" data-bs-toggle="tooltip" title="' . $gL10n->get('SYS_REMOVE_CONTACT') . '"></i>
                         </a>';
@@ -330,7 +330,7 @@ try {
                 // User could only be removed from this organization -> ask so
                 $userAdministration .= '
                     <a class="admidio-icon-link admidio-messagebox" href="javascript:void(0);" data-buttons="yes-no"
-                        data-message="' . $gL10n->get('SYS_END_MEMBERSHIP_OF_USER', array($row['FIRST_NAME'] . ' ' . $row['LAST_NAME'], $gCurrentOrganization->getValue('org_longname'))) . '"
+                        data-message="' . $gL10n->get('SYS_END_MEMBERSHIP_OF_USER', array($row['first_name'] . ' ' . $row['last_name'], $gCurrentOrganization->getValue('org_longname'))) . '"
                         data-href="callUrlHideElement(\'row_members_' . $row['usr_uuid'] . '\', \'' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/contacts/contacts_function.php', array('mode' => 'remove', 'user_uuid' => $row['usr_uuid'])) . '\', \'' . $gCurrentSession->getCsrfToken() . '\')">
                         <i class="bi bi-trash" data-bs-toggle="tooltip" title="' . $gL10n->get('SYS_REMOVE_CONTACT') . '"></i>
                     </a>';

--- a/adm_program/modules/photos/photo_album_function.php
+++ b/adm_program/modules/photos/photo_album_function.php
@@ -19,6 +19,7 @@
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 use Admidio\Photos\Entity\Album;
+use Admidio\Infrastructure\Utils\SecurityUtils;
 
 require_once(__DIR__ . '/../../system/common.php');
 require(__DIR__ . '/../../system/login_valid.php');

--- a/src/Changelog/Entity/LogChanges.php
+++ b/src/Changelog/Entity/LogChanges.php
@@ -243,7 +243,7 @@ class LogChanges extends Entity
      * @param int $id The record ID of the inserted record
      * @param string $objectname Human readable representation of the record (used in the log view)
      */
-    public function setLogDeletion(string $table, int $id, string $uuid = null, string $objectname = null) 
+    public function setLogDeletion(string $table, int $id = 0, string $uuid = null, string $objectname = null) 
     {
         $this->setLogBasevalues($table, $id, $uuid, $objectname, 'DELETED');
     }

--- a/src/Changelog/Service/ChangelogService.php
+++ b/src/Changelog/Service/ChangelogService.php
@@ -1,6 +1,7 @@
 <?php
 namespace Admidio\Changelog\Service;
 
+use Admidio\Roles\Entity\RolesDependencies;
 use HtmlPage;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Language;
@@ -183,8 +184,8 @@ class ChangelogService {
                 //return new RolesRights($gDb, '', 0);
             case 'roles_rights_data':
                 return new RolesRightsData($gDb);
-            //case 'role_dependencies':
-                // Does not use an Entity-derived class; so far, changes are NOT logged
+            case 'role_dependencies':
+                return new RolesDependencies($gDb);
             case 'rooms':
                 return new Room($gDb);
             case 'texts':
@@ -520,7 +521,7 @@ class ChangelogService {
             case 'roles':
                 $url = SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/groups-roles/lists_show.php', array('role_list' => $uuid)); break;
             case 'roles_rights':
-                $url = SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/groups-roles/groups_roles_new.php', array('role_uuid' => $uuid)); break;
+                $url = SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/groups-roles/groups_roles.php', array('mode' => 'edit', 'role_uuid' => $uuid)); break;
             case 'roles_rights_data':
                 // The log_record_linkid contains the table and the uuid encoded as 'table':'UUID' => split and call Create linke with the new table!
                 if (strpos($id, ':') !== false) {
@@ -531,7 +532,7 @@ class ChangelogService {
                 }
                 return self::createLink($text, $table, $id, $id); 
             case 'role_dependencies':
-                $url = SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/groups-roles/groups_roles_new.php', array('role_uuid' => $uuid)); break;
+                $url = SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/groups-roles/groups_roles.php', array('mode' => 'edit', 'role_uuid' => $uuid)); break;
             case 'rooms':
                 $url = SecurityUtils::encodeUrl(ADMIDIO_URL.FOLDER_MODULES.'/rooms/rooms_new.php', array('room_uuid' => $uuid)); break;
             // case 'texts': // Texts can be modified in the preferences, but there is no direct link to the notifications sections, where the texts are located at the end!

--- a/src/Changelog/Service/ChangelogService.php
+++ b/src/Changelog/Service/ChangelogService.php
@@ -34,6 +34,7 @@ use Admidio\Users\Entity\UserRegistration;
 use Admidio\Users\Entity\UserRelation;
 use Admidio\Users\Entity\UserRelationType;
 use Admidio\Weblinks\Entity\Weblink;
+use ModuleEvents;
 
 use Admidio\Roles\Service\RoleService;
 
@@ -236,11 +237,30 @@ class ChangelogService {
             'URL' => $gL10n->get('SYS_URL')
         );
 
+        $memApprovedValues = array(
+            ModuleEvents::MEMBER_APPROVAL_STATE_INVITED => array(
+                'text' => 'SYS_EVENT_PARTICIPATION_INVITED',
+                'icon' => 'calendar2-check-fill'
+            ),
+            ModuleEvents::MEMBER_APPROVAL_STATE_ATTEND => array(
+                'text' => 'SYS_EVENT_PARTICIPATION_ATTEND',
+                'icon' => 'check-circle-fill'
+            ),
+            ModuleEvents::MEMBER_APPROVAL_STATE_TENTATIVE => array(
+                'text' => 'SYS_EVENT_PARTICIPATION_TENTATIVE',
+                'icon' => 'question-circle-fill'
+            ),
+            ModuleEvents::MEMBER_APPROVAL_STATE_REFUSED => array(
+                'text' => 'SYS_EVENT_PARTICIPATION_CANCELED',
+                'icon' => 'x-circle-fill'
+            )
+        );
+
         return array(
             'mem_begin' =>                 'SYS_MEMBERSHIP_START',
             'mem_end' =>                   'SYS_MEMBERSHIP_END',
             'mem_leader' =>                array('name' => 'SYS_LEADER', 'type' => 'BOOL'),
-            'mem_approved' =>              array('name' => 'SYS_MEMBERSHIP_APPROVED', 'type' => 'BOOL'),
+            'mem_approved' =>              array('name' => 'SYS_MEMBERSHIP_APPROVED', 'type' => 'CUSTOM_LIST', 'entries' => $memApprovedValues),
             'mem_count_guests' =>          'SYS_SEAT_AMOUNT',
             'mem_timestamp_change' =>      'SYS_CHANGED_AT',
             'mem_usr_id_change' =>         'SYS_CHANGED_BY',
@@ -663,7 +683,21 @@ class ChangelogService {
                     $htmlValue = $obj->readableName();
                     break;
                 case 'CUSTOM_LIST':
-                    $htmlValue = $entries[$value]??$value;
+                    $value = $entries[$value]??$value;
+                    $htmlValue = '';
+                    if (is_array($value)) {
+                        if (isset($value['icon'])) {
+                            $htmlValue .= '<div class="bi bi-'.$value['icon'].'"> ';
+                        }
+                        if (isset($value['text'])) {
+                            $htmlValue .=  $gL10n-> get($value['text']);
+                        }
+                        if (isset($value['icon'])) {
+                            $htmlValue .= '</div>';
+                        }
+                    } else {
+                        $htmlValue = $value;
+                    }
                     break;
 
 

--- a/src/Documents/Entity/File.php
+++ b/src/Documents/Entity/File.php
@@ -285,13 +285,21 @@ class File extends Entity
      * to log changes to these columns.
      * The folder table also contains fol_usr_id and fol_timestamp. We also don't want to log
      * download counter increases...
+     * When a file is created, we also don't need to log some columns, because they are already 
+     * in the creation log record.
      *
      * @return true Returns the list of database columns to be ignored for logging.
      */
     public function getIgnoredLogColumns(): array
     {
-        return array_merge(parent::getIgnoredLogColumns(), ['fil_counter', 'fil_usr_id', 'fil_timestamp']);
+        $ignored = parent::getIgnoredLogColumns();
+        $ignored = array_merge($ignored, ['fil_counter', 'fil_usr_id', 'fil_timestamp']);
+        if ($this->insertRecord) {
+            $ignored = array_merge($ignored, ['fil_fol_id', 'fil_name']);
+        }
+        return $ignored;
     }
+    
     /**
      * Adjust the changelog entry for this db record: Add the parent fold as a related object
      * 

--- a/src/Documents/Entity/Folder.php
+++ b/src/Documents/Entity/Folder.php
@@ -206,25 +206,19 @@ class Folder extends Entity
      * Deletes the selected record of the table and all references in other tables.
      * Also, all files, subfolders and the selected folder will be deleted in the file system.
      * After that the class will be initialized.
-     * @param int $folderId
      * @return bool **true** if no error occurred
      * @throws Exception
      */
-    public function delete(int $folderId = 0): bool
+    public function delete(): bool
     {
         global $gLogger;
 
-        $folId = (int)$this->getValue('fol_id');
-        $folderPath = '';
-
-        if ($folderId === 0) {
-            if ($this->getValue('fol_name') === '') {
-                return false;
-            }
-
-            $folderId = (int)$this->getValue('fol_id');
-            $folderPath = $this->getFullFolderPath();
+        if ($this->getValue('fol_name') === '') {
+            return false;
         }
+
+        $folderId = (int)$this->getValue('fol_id');
+        $folderPath = $this->getFullFolderPath();
 
         $this->db->startTransaction();
 
@@ -232,29 +226,19 @@ class Folder extends Entity
 
         while ($rowFolId = (int)$subfoldersStatement->fetchColumn()) {
             // rekursiver Aufruf mit jedem einzelnen Unterordner
-            $this->delete($rowFolId);
+            $subfol = new Folder($this->db, $rowFolId);
+            $subfol->delete();
         }
 
-        // In the database delete the files of the current folder_id
-        $sqlDeleteFiles = 'DELETE FROM ' . TBL_FILES . '
-                            WHERE fil_fol_id = ? -- $folderId';
-        $this->db->queryPrepared($sqlDeleteFiles, array($folderId));
+        $files = $this->getFilesWithProperties();
+        foreach ($files as $f) {
+            $fl = new File($this->db, $f['fil_id']);
+            $fl->delete();
+        }
 
         // delete all roles assignments that have the right to view this folder
-        if ($folderId === $folId) {
-            $this->folderViewRolesObject->delete();
-            $this->folderUploadRolesObject->delete();
-        } else {
-            $folderViewRoles = new RolesRights($this->db, 'folder_view', $folderId);
-            $folderViewRoles->delete();
-            $folderUploadRoles = new RolesRights($this->db, 'folder_upload', $folderId);
-            $folderUploadRoles->delete();
-        }
-
-        // Delete the entry of the folder itself in the database
-        $sqlDeleteFolder = 'DELETE FROM ' . TBL_FOLDERS . '
-                             WHERE fol_id = ? -- $folderId';
-        $this->db->queryPrepared($sqlDeleteFolder, array($folderId));
+        $this->folderViewRolesObject->delete();
+        $this->folderUploadRolesObject->delete();
 
         // physically delete the directory from the disk
         if ($folderPath !== '') {
@@ -266,12 +250,8 @@ class Folder extends Entity
             }
         }
 
-        $returnCode = true;
-
         // Even if the physical deletion fails, everything is deleted in the DB...
-        if ($folderId === $folId) {
-            $returnCode = parent::delete();
-        }
+        $returnCode = parent::delete();
 
         $this->db->endTransaction();
 
@@ -323,27 +303,20 @@ class Folder extends Entity
     /**
      * Set the public flag to a folder and all sub-folders.
      * @param bool $publicFlag If set to **1** then all users could see this folder.
-     * @param int $folderId The id of the folder where the public flag should be set.
      * @throws Exception
      */
-    public function editPublicFlagOnFolder(bool $publicFlag, int $folderId = 0)
+    public function editPublicFlagOnFolder(bool $publicFlag)
     {
-        if ($folderId === 0) {
-            $folderId = (int)$this->getValue('fol_id');
-            $this->setValue('fol_public', (int)$publicFlag);
-        }
+        $folderId = (int)$this->getValue('fol_id');
+        $this->setValue('fol_public', (int)$publicFlag);
 
         $subfoldersStatement = $this->getSubfolderStatement($folderId);
 
         while ($folId = (int)$subfoldersStatement->fetchColumn()) {
-            // recursive call with every single subfolder
-            $this->editPublicFlagOnFolder($publicFlag, $folId);
+            $subfol = new Folder($this->db, $folId);
+            $subfol->editPublicFlagOnFolder($publicFlag);
+            $subfol->save();
         }
-
-        $sqlUpdate = 'UPDATE ' . TBL_FOLDERS . '
-                         SET fol_public = ? -- $publicFlag
-                       WHERE fol_id = ? -- $folderId';
-        $this->db->queryPrepared($sqlUpdate, array((int)$publicFlag, $folderId));
     }
 
     /**
@@ -744,30 +717,23 @@ class Folder extends Entity
      * Benennt eine Ordnerinstanz um und sorgt dafür das bei allen Unterordnern der Pfad angepasst wird
      * @param string $newName
      * @param string $newPath
-     * @param int $folderId
      * @throws Exception
      */
-    public function rename(string $newName, string $newPath, int $folderId = 0)
+    public function rename(string $newName, string $newPath)
     {
-        if ($folderId === 0) {
-            $folderId = (int)$this->getValue('fol_id');
-            $this->setValue('fol_name', $newName);
-            $this->save();
-        }
+        $folderId = (int)$this->getValue('fol_id');
+        $this->setValue('fol_name', $newName);
+        $this->setValue('fol_path', newValue: $newPath);
+        $this->save();
 
         $this->db->startTransaction();
-
-        // Set new path in database for folderId
-        $sqlUpdate = 'UPDATE ' . TBL_FOLDERS . '
-                         SET fol_path = ? -- $newPath
-                       WHERE fol_id = ? -- $folderId';
-        $this->db->queryPrepared($sqlUpdate, array($newPath, $folderId));
 
         $subfoldersStatement = $this->getSubfolderStatement($folderId, array('fol_id', 'fol_name'));
 
         while ($rowSubfolders = $subfoldersStatement->fetch()) {
             // recursive call with every subfolder
-            $this->rename($rowSubfolders['fol_name'], $newPath . '/' . $newName, $rowSubfolders['fol_id']);
+            $subfol = new Folder($this->db, $rowSubfolders['fol_id']);
+            $subfol->rename($rowSubfolders['fol_name'], $newPath . '/' . $newName);
         }
 
         $this->db->endTransaction();
@@ -799,15 +765,23 @@ class Folder extends Entity
      * Some tables contain columns _usr_id_create, timestamp_create, etc. We do not want
      * to log changes to these columns.
      * The folder table also contains fol_usr_id and fol_timestamp. Also, for now fol_type will always be DOCUMENTS.
+     * When a folder is created, we also don't need to log some columns, because they are already 
+     * in the creation log record.
      *
      * @return true Returns the list of database columns to be ignored for logging.
      */
     public function getIgnoredLogColumns(): array
     {
-        return array_merge(parent::getIgnoredLogColumns(), ['fol_type', 'fol_usr_id', 'fol_timestamp']);
+        $ignored = parent::getIgnoredLogColumns();
+        $ignored = array_merge($ignored, ['fol_type', 'fol_usr_id', 'fol_timestamp']);
+        if ($this->insertRecord) {
+            $ignored = array_merge($ignored, ['fol_org_id', 'fol_fol_id_parent', 'fol_name', 'fol_public']);
+        }
+        return $ignored;
     }
+
     /**
-     * Adjust the changelog entry for this db record: Add the parent folder as a related object
+    * Adjust the changelog entry for this db record: Add the parent folder as a related object
      * 
      * @param LogChanges $logEntry The log entry to adjust
      * 

--- a/src/Documents/Entity/Folder.php
+++ b/src/Documents/Entity/Folder.php
@@ -781,7 +781,7 @@ class Folder extends Entity
     }
 
     /**
-    * Adjust the changelog entry for this db record: Add the parent folder as a related object
+     * Adjust the changelog entry for this db record: Add the parent folder as a related object
      * 
      * @param LogChanges $logEntry The log entry to adjust
      * 

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -52,7 +52,7 @@ class Entity
     /**
      * @var string Name of the unique autoincrement index column of the database table
      */
-    protected string $keyColumnName;
+    protected string $keyColumnName = '';
     /**
      * @var Database An object of the class Database for communication with the database
      */
@@ -913,10 +913,7 @@ class Entity
                 if (str_starts_with($columnName, $this->columnPrefix . '_')) {
                     $this->dbColumns[$columnName] = '';
 
-                    // Set the first column as key column automatically as fall-back. A later 
-                    // auto-increment column will override anyway, but tables without an auto-
-                    // increment column also need some value for the keyColumName.
-                    if ($property['serial'] || !isset($this->keyColumnName)) {
+                    if ($property['serial']) {
                         $this->keyColumnName = $columnName;
                     }
                 }

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -810,12 +810,12 @@ class Entity
                     VALUES ('.Database::getQmForValues($sqlFieldArray).')';
             if ($this->db->queryPrepared($sql, $queryParams) !== false) {
                 $returnCode = true;
-                $this->insertRecord = false;
                 if ($this->keyColumnName !== '') {
                     $this->dbColumns[$this->keyColumnName] = $this->db->lastInsertId();
                     $this->logCreation();
                     $this->logModifications($logChanges);
                 }
+                $this->insertRecord = false;
             }
         } else {
             $sql = 'UPDATE '.$this->tableName.'

--- a/src/Preferences/ValueObject/SettingsManager.php
+++ b/src/Preferences/ValueObject/SettingsManager.php
@@ -2,6 +2,7 @@
 namespace Admidio\Preferences\ValueObject;
 
 use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Entity\Entity;
 use Admidio\Infrastructure\Exception;
 
 /**
@@ -313,10 +314,11 @@ class SettingsManager
      */
     private function insert(string $name, string $value)
     {
-        $sql = 'INSERT INTO '.TBL_PREFERENCES.'
-                       (prf_org_id, prf_name, prf_value)
-                VALUES (?, ?, ?) -- $orgId, $name, $value';
-        $this->db->queryPrepared($sql, array($this->orgId, $name, $value));
+        $prf = new Entity($this->db, TBL_PREFERENCES, 'prf');
+        $prf->setValue('prf_org_id', $this->orgId);
+        $prf->setValue('prf_name', $name);
+        $prf->setValue('prf_value', $value);
+        $prf->save();
     }
 
     /**
@@ -393,11 +395,13 @@ class SettingsManager
      */
     private function update(string $name, string $value)
     {
-        $sql = 'UPDATE '.TBL_PREFERENCES.'
-                   SET prf_value  = ? -- $value
-                 WHERE prf_org_id = ? -- $orgId
-                   AND prf_name   = ? -- $name';
-        $this->db->queryPrepared($sql, array($value, $this->orgId, $name));
+        $prf = new Entity($this->db, TBL_PREFERENCES, 'prf');
+        $found = $prf->readDataByColumns(array('prf_org_id' => $this->orgId, 'prf_name' => $name));
+
+        if ($found) {
+            $prf->setValue('prf_value', $value);
+            $prf->save();
+        }
     }
 
     /**

--- a/src/ProfileFields/Entity/ProfileField.php
+++ b/src/ProfileFields/Entity/ProfileField.php
@@ -102,12 +102,7 @@ class ProfileField extends Entity
             $this->db->queryPrepared($sql, array($rowLst['lsc_lst_id'], $rowLst['lsc_number']));
         }
 
-        // delete all dependencies in other tables
-        // TODO_RK: Shall we delete log entries pertaining to the given user and field?
-        // $sql = 'DELETE FROM '.TBL_USER_LOG.'
-                //  WHERE usl_usf_id = ? -- $usfId';
-        // $this->db->queryPrepared($sql, array($usfId));
-
+        // delete all dependencies in other tables, except for the changelog (which needs to be audit proof)
         $sql = 'DELETE FROM ' . TBL_USER_DATA . '
                  WHERE usd_usf_id = ? -- $usfId';
         $this->db->queryPrepared($sql, array($usfId));

--- a/src/Roles/Entity/ListConfiguration.php
+++ b/src/Roles/Entity/ListConfiguration.php
@@ -319,9 +319,15 @@ class ListConfiguration extends Entity
         $this->db->startTransaction();
 
         // Delete all columns of the list
-        $sql = 'DELETE FROM '.TBL_LIST_COLUMNS.'
-                      WHERE lsc_lst_id = ? -- $lstId';
-        $this->db->queryPrepared($sql, array($lstId));
+        $sql = 'SELECT lsc_id
+                  FROM '.TBL_LIST_COLUMNS.'
+                 WHERE lsc_lst_id = ? -- $lstId';
+        $listColumnsStatement = $this->db->queryPrepared($sql, array($lstId));
+
+        while ($lscId = $listColumnsStatement->fetchColumn()) {
+            $listColumn = new ListColumns($this->db, $lscId);
+            $listColumn->delete();
+        }
 
         $return = parent::delete();
 

--- a/src/Roles/Entity/Role.php
+++ b/src/Roles/Entity/Role.php
@@ -263,6 +263,7 @@ class Role extends Entity
 
         $this->db->startTransaction();
 
+        // TODO_RK
         $sql = 'DELETE FROM ' . TBL_ROLE_DEPENDENCIES . '
                  WHERE rld_rol_id_parent = ? -- $rolId
                     OR rld_rol_id_child  = ? -- $rolId';

--- a/src/Roles/Entity/RolesDependencies.php
+++ b/src/Roles/Entity/RolesDependencies.php
@@ -18,21 +18,6 @@ use Admidio\Changelog\Entity\LogChanges;
 class RolesDependencies extends Entity
 {
     /**
-     * Constructor that will create an object of a recordset of the table adm_roles_dependencies.
-     * If the id is set than the specific category will be loaded.
-     * @param Database $database Object of the class Database. This should be the default global object **$gDb**.
-     * @param int $objectId ID of the object of which the roles should be loaded.
-     * @throws Exception
-     */
-    public function __construct(Database $database)
-    {
-        parent::__construct($database, TBL_ROLE_DEPENDENCIES, 'rld');
-        // The DB table does not have an auto-increment key, so use the first column instead (most things won't
-        // work, but dependencies should never be loaded individually by ID anyway)
-        $this->keyColumnName = '';
-    }
-
-    /**
      * Deletes the selected record of the table and initializes the class
      * Since the role_dependencies table does not have a single auto-increment 
      * key, but two columne (parent-child), we have to override the parent't 
@@ -59,7 +44,7 @@ class RolesDependencies extends Entity
     }
 
     /**
-     * Retrieve the list of database fields that are ignored for the changelog.
+     * List of database fields that are ignored for the changelog.
      * Some tables contain columns _usr_id_create, timestamp_create, etc. We do not want
      * to log changes to these columns. Subclasses can also add further fields 
      * (e.g. the users table stores and auto-increments the login count, which 

--- a/src/Roles/Entity/RolesDependencies.php
+++ b/src/Roles/Entity/RolesDependencies.php
@@ -1,0 +1,96 @@
+<?php
+namespace Admidio\Roles\Entity;
+
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Exception;
+use Admidio\Changelog\Entity\LogChanges;
+
+
+/**
+ * Manages the dependencies of roles
+ *
+ * ```
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+class RolesDependencies extends Entity
+{
+    /**
+     * Constructor that will create an object of a recordset of the table adm_roles_dependencies.
+     * If the id is set than the specific category will be loaded.
+     * @param Database $database Object of the class Database. This should be the default global object **$gDb**.
+     * @param int $objectId ID of the object of which the roles should be loaded.
+     * @throws Exception
+     */
+    public function __construct(Database $database)
+    {
+        parent::__construct($database, TBL_ROLE_DEPENDENCIES, 'rld');
+        // The DB table does not have an auto-increment key, so use the first column instead (most things won't
+        // work, but dependencies should never be loaded individually by ID anyway)
+        $this->keyColumnName = '';
+    }
+
+    /**
+     * Deletes the selected record of the table and initializes the class
+     * Since the role_dependencies table does not have a single auto-increment 
+     * key, but two columne (parent-child), we have to override the parent't 
+     * method.
+     * 
+     * @return true Returns **true** if no error occurred
+     * @throws Exception
+     */
+    public function delete(): bool
+    {
+        if (array_key_exists('rld_rol_id_parent', $this->dbColumns) && $this->dbColumns['rld_rol_id_parent'] !== '' &&
+            array_key_exists('rld_rol_id_child', $this->dbColumns) && $this->dbColumns['rld_rol_id_child'] !== ''
+        ) {
+            // Log record deletion, then delete
+            $this->logDeletion();
+            $sql = 'DELETE FROM '.$this->tableName.'
+                     WHERE rld_rol_id_parent = ? -- $this->dbColumns[\'rld_rol_id_parent\']
+                     AND rld_rol_id_child = ? -- $this->dbColumns[\'rld_rol_id_child\']';
+            $this->db->queryPrepared($sql, array($this->dbColumns['rld_rol_id_parent'], $this->dbColumns['rld_rol_id_child']));
+        }
+
+        $this->clear();
+        return true;
+    }
+
+    /**
+     * Retrieve the list of database fields that are ignored for the changelog.
+     * Some tables contain columns _usr_id_create, timestamp_create, etc. We do not want
+     * to log changes to these columns. Subclasses can also add further fields 
+     * (e.g. the users table stores and auto-increments the login count, which 
+     * we do not want to log)
+     * 
+     * @return true Returns the list of database columns to be ignored for logging.
+     */
+    public function getIgnoredLogColumns(): array
+    {
+        $ignored = parent::getIgnoredLogColumns();
+        return array_merge($ignored, ['rld_rol_id_parent', 'rld_rol_id_child']);
+    }
+
+    /**
+     * Adjust the changelog entry for this db record. Since we don't have any id in the table,
+     * insert the child as record and the parent as relatd.
+     * 
+     * @param LogChanges $logEntry The log entry to adjust
+     * 
+     * @return void
+     */
+    protected function adjustLogEntry(LogChanges $logEntry) {
+        $parent_role = new Role($this->db, $this->getValue('rld_rol_id_parent'));
+        $child_role = new Role($this->db, $this->getValue('rld_rol_id_child'));
+
+        $logEntry->setValue('log_record_id', $child_role->getValue('rol_id'));
+        $logEntry->setValue('log_record_uuid', $child_role->getValue('rol_uuid'));
+        $logEntry->setValue('log_record_name', $child_role->readableName());
+        
+        $logEntry->setLogRelated($parent_role->getValue('rol_uuid'), $parent_role->readableName());
+    }
+
+
+}

--- a/src/Roles/ValueObject/RoleDependency.php
+++ b/src/Roles/ValueObject/RoleDependency.php
@@ -4,9 +4,15 @@ namespace Admidio\Roles\ValueObject;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Exception;
 use Admidio\Roles\Entity\Role;
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Roles\Entity\RolesDependencies;
 
 /**
  * @brief Class to manage dependencies between different roles.
+ * 
+ * The RoleDependency DB record differs from all other records, since
+ * there is no auto-increment ID, but a primary key consisting of parent and child role.
+ * 
  *
  * @copyright The Admidio Team
  * @see https://www.admidio.org/
@@ -81,11 +87,11 @@ class RoleDependency
      */
     public function delete()
     {
-        $sql = 'DELETE FROM '.TBL_ROLE_DEPENDENCIES.'
-                 WHERE rld_rol_id_child  = ? -- $this->roleIdChildOrig
-                   AND rld_rol_id_parent = ? -- $this->roleIdParentOrig';
-        $this->db->queryPrepared($sql, array($this->roleIdChildOrig, $this->roleIdParentOrig));
-
+        $dep = new RolesDependencies($this->db);
+        $found = $dep->readDataByColumns(['rld_rol_id_parent' => $this->roleIdParentOrig, 'rld_rol_id_child' => $this->roleIdChildOrig]);
+        if ($found) {
+            $dep->delete();
+        }
         $this->clear();
     }
 
@@ -195,11 +201,13 @@ class RoleDependency
     public function insert(int $loginUserId): bool
     {
         if ($loginUserId > 0 && !$this->isEmpty()) {
-            $sql = 'INSERT INTO '.TBL_ROLE_DEPENDENCIES.'
-                           (rld_rol_id_parent, rld_rol_id_child, rld_comment, rld_usr_id, rld_timestamp)
-                    VALUES (?, ?, ?, ?, ?) -- $this->roleIdParent, $this->roleIdChild, $this->comment, $loginUserId, DATETIME_NOW';
-            $queryParams = array($this->roleIdParent, $this->roleIdChild, $this->comment, $loginUserId, DATETIME_NOW);
-            $this->db->queryPrepared($sql, $queryParams);
+            $dep = new RolesDependencies($this->db);
+            $dep->setValue('rld_rol_id_parent', $this->roleIdParent);
+            $dep->setValue('rld_rol_id_child', $this->roleIdChild);
+            $dep->setValue('rld_comment', $this->comment);
+            $dep->setValue('rld_usr_id', $loginUserId);
+            $dep->setValue('rld_timestamp', DATETIME_NOW);
+            $dep->save();
             $this->persisted = true;
 
             return true;
@@ -217,10 +225,14 @@ class RoleDependency
     public static function removeChildRoles(Database $database, int $parentId): bool
     {
         if ($parentId > 0) {
-            $sql = 'DELETE FROM '.TBL_ROLE_DEPENDENCIES.'
-                     WHERE rld_rol_id_parent = ? -- $parentId';
-            $database->queryPrepared($sql, array($parentId));
-
+            $children = self::getChildRoles($database, $parentId);
+            foreach ($children as $child) {
+                $dep = new RolesDependencies($database);
+                $found = $dep->readDataByColumns(['rld_rol_id_parent' => $parentId, 'rld_rol_id_child' => $child]);
+                if ($found) {
+                    $dep->delete();
+                }
+            }
             return true;
         }
 
@@ -268,6 +280,7 @@ class RoleDependency
     public function update(int $loginUserId): bool
     {
         if ($loginUserId > 0 && !$this->isEmpty()) {
+            // TODO_RK
             $sql = 'UPDATE '.TBL_ROLE_DEPENDENCIES.'
                        SET rld_rol_id_parent = ? -- $this->roleIdParent
                          , rld_rol_id_child  = ? -- $this->roleIdChild

--- a/src/UI/View/ProfileFields.php
+++ b/src/UI/View/ProfileFields.php
@@ -6,6 +6,7 @@ use Admidio\ProfileFields\Entity\ProfileField;
 use Admidio\UI\Component\Form;
 use HtmlPage;
 use Admidio\Infrastructure\Utils\SecurityUtils;
+use Admidio\Changelog\Service\ChangelogService;
 
 /**
  * @brief Class with methods to display the module pages.

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -597,10 +597,6 @@ class User extends Entity
                             SET rld_usr_id = NULL
                           WHERE rld_usr_id = ' . $usrId;
 
-        $sqlQueries[] = 'UPDATE ' . TBL_USER_LOG . '
-                          SET usl_usr_id_create = NULL
-                          WHERE usl_usr_id_create = ' . $usrId;
-                          
         $sqlQueries[] = 'UPDATE ' . TBL_USERS . '
                             SET usr_usr_id_create = NULL
                             WHERE usr_usr_id_create = ' . $usrId;
@@ -661,7 +657,7 @@ class User extends Entity
                           WHERE NOT EXISTS (SELECT 1 FROM ' . TBL_MESSAGES_RECIPIENTS . '
                           WHERE msr_msg_id = msc_msg_id)';
 
-                          $sqlQueries[] = 'DELETE FROM ' . TBL_MESSAGES . '
+        $sqlQueries[] = 'DELETE FROM ' . TBL_MESSAGES . '
                           WHERE NOT EXISTS (SELECT 1 FROM ' . TBL_MESSAGES_RECIPIENTS . '
                           WHERE msr_msg_id = msg_id)';
                           
@@ -673,10 +669,6 @@ class User extends Entity
 
         $sqlQueries[] = 'DELETE FROM ' . TBL_SESSIONS . '
                           WHERE ses_usr_id = ' . $usrId;
-
-        // TODO_RK: Shall we delete all log-entries pertaining to the given user??? That's not audit-proof!
-        // $sqlQueries[] = 'DELETE FROM ' . TBL_LOG . '
-        //                   WHERE usl_usr_id = ' . $usrId;
 
         $sqlQueries[] = 'DELETE FROM ' . TBL_USER_DATA . '
                           WHERE usd_usr_id = ' . $usrId;


### PR DESCRIPTION
Most direct DB access is converted to Entity-based DB access, so these changes are logged automatically.

- Preferences converted to use Entity rather than direct DB access -> Changes are logged. The preference name is not translated into human-readable form, as there is no function for this and there are hundreds of preferences, which I don't want to hardcode.
- Folder and album deletions and renamings use Entity-based DB access; REmoved logging of duplicate information (parent folder and file/folder name is already included in the creation log entry!)
  - Instead of one folder object looping through all child folders and act on other folders, I now create a separate Folder object for each subfolder and tell it to delete itself (and its children). That's more in line with object-oriented programming and also removes some duplicate code.
- List_Columns deletion uses Entity-based DB access and is now logged
- Role_dependencies now also use an Entity-based class to store changes in the DB. Unfortunatel, the table has no auto-increment key (Entity assumes one in keyColumnName!), so some parts are a little more complicated than with other tables.

- Event participation status display improved in the changelog page
- Don't remove log entries when a user is deleted

AFAICS, there is no relevant direct DB access any more for changes that should be logged.

The other issues of the changelog are still open, though. I still don't like the massive code duplication to get nice names for the affected DB columns / tables. Both the translation of the column and table names as well as the display of the values have code duplicated from the preferences module or other core modules, where the human-readable texts are "hardcoded" into the forms....


### What is still missing

- [ ] Write Documentation how to implement/customize proper logging for core and third-party modules -> Should be added to the DokuWiki
- [ ] Multi-organization setup -> Creating/deleting organizations is logged, but the changelog page (and the changelog table!) does not distinguish to which org a record belongs!
- [ ] Access permissions taking into account Organization ID
- [ ] "Delete History" button in the changelog page (nice-to-have)
- [ ] On the Changelog page, provide a table selection filter, potentially add more filters, e.g. by name or old/new value
- [ ] Performance: The changelog page currently loads and formats all changelog entries in the requested time frame. For large installations, this might overwhelm the browser and/or network. Maybe the changelog should be switched to dynamic page loading (like the contact list)?

### Open/Known Bugs (in my changelog code or in admidio in general)

- [ ] Folder rights (table role_rights, internal_name) are not tanslated / user-readable
- [ ] Deleting a folder also logs removal of each role permission
- [ ] Moving a folder removes and re-adds all role permissions
- [ ] Category administration: Type is not used / stored in changelog (EVT, ANN, …) -> Changelog shows all categories, even when not relevant (e.g. calendars are shown for role categories)
- [ ] 	A lot of Code Duplication in ChangelogService: Translating tables, column names and values to human-readable labels -> no generic function, translations are scattered all over the codebase, whenever a form control is created...
  - [ ] DB column -> readable string conversion from individual record editing pages 
  - [ ] Hardcode the html links to the different kinds of tables
  - [ ] Hardcoded code to generate Entity-derived object for a given DB tble (e.g. new User for 'adm_users' table)
  - [ ] Function formatValue contains a lot of duplicate code from user fields -> Write one generic function that formats values, including links to various forms of objects?
  - [ ] $userFieldText to convert user field types to readable strings