### PR TITLE
fix: remove Message.php from recipient string

### DIFF
--- a/src/Messages/Entity/Message.php
+++ b/src/Messages/Entity/Message.php
@@ -409,7 +409,7 @@ class Message extends Entity
                 $recipientsString = $recipients[0]['name'];
             } else {
                 $user = new User($this->db, $gProfileFields, $this->getValue('msg_usr_id_sender'));
-                $recipientsString = $user->getValue('FIRST_NAME') . ' Message.php' . $user->getValue('LAST_NAME');
+                $recipientsString = $user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME');
             }
         } else {
             // email receivers are all stored in the recipients array


### PR DESCRIPTION
gerade in den Demo Daten gesehen: 
"[Raum reservieren]	Eric Message.phpVorsitzender"
![Screenshot 2025-03-02 at 19 02 28](https://github.com/user-attachments/assets/b0fafeb2-19e6-4658-b490-b6f92ac68b77)
