### PR TITLE
Fix demo data sql file so that event registration works on the demo org

### DIFF
--- a/demo_data/data.sql
+++ b/demo_data/data.sql
@@ -551,12 +551,12 @@ INSERT INTO %PREFIX%_roles (rol_id, rol_uuid, rol_cat_id, rol_name, rol_descript
 --
 
 INSERT INTO %PREFIX%_roles_rights (ror_id, ror_name_intern, ror_table, ror_ror_id_parent) VALUES
-(1, 'folder_view', 'adm_folders', null),
-(2, 'folder_upload', 'adm_folders', null),
-(3, 'category_view', 'adm_categories', null),
-(4, 'category_edit', 'adm_categories', 3),
-(5, 'event_participation', 'adm_dates', null),
-(6, 'menu_view', 'adm_menu', null);
+(1, 'folder_view', '%PREFIX%_folders', null),
+(2, 'folder_upload', '%PREFIX%_folders', null),
+(3, 'category_view', '%PREFIX%_categories', null),
+(4, 'category_edit', '%PREFIX%_categories', 3),
+(5, 'event_participation', '%PREFIX%_dates', null),
+(6, 'menu_view', '%PREFIX%_menu', null);
 
 --
 -- Data for table adm_roles_rights_data


### PR DESCRIPTION
Enabling registration for an event in the demo organisation fails with 

```
S Q L - E R R O R

SQLSTATE[42S02]: Base table or view not found: 1146 Table 'adm.adm_dates' doesn't exist

CODE: 42S02
```

because the prefix is not used correctly in the demo data creation.