### PR TITLE
PHP 8.3: Fix  warnings: if a parameter has a default value of null, it must be declared as nullable

### DIFF
--- a/src/Changelog/Entity/LogChanges.php
+++ b/src/Changelog/Entity/LogChanges.php
@@ -193,7 +193,7 @@ class LogChanges extends Entity
      * @param string $objectname Human readable representation of the record (used in the log view)
      * @param string $action The cause of the log (CREATED, DELETED, MODIFY)
      */
-    protected function setLogBasevalues(string $table, int $id = 0, string $uuid = null, string $objectname = null, string $action = 'MODIFY') {
+    protected function setLogBasevalues(string $table, int $id = 0, ?string $uuid = null, ?string $objectname = null, string $action = 'MODIFY') {
         $this->objectTableName = $table;
         $this->setValue('log_table', $this->objectTableName);
         $this->setValue('log_record_id', $id);
@@ -210,7 +210,7 @@ class LogChanges extends Entity
      * @param int $id The record ID of the inserted record
      * @param string $objectname Human readable representation of the record (used in the log view)
      */
-    public function setLogCreation(string $table, int $id = 0, string $uuid = null, string $objectname = null)
+    public function setLogCreation(string $table, int $id = 0, ?string $uuid = null, ?string $objectname = null)
     {
         $this->setLogBasevalues($table, $id, $uuid, $objectname, 'CREATED');
     }
@@ -222,7 +222,7 @@ class LogChanges extends Entity
      * @param int $id The record ID of the inserted record
      * @param string $objectname Human readable representation of the record (used in the log view)
      */
-    public function setLogDeletion(string $table, int $id = 0, string $uuid = null, string $objectname = null) 
+    public function setLogDeletion(string $table, int $id = 0, ?string $uuid = null, ?string $objectname = null) 
     {
         $this->setLogBasevalues($table, $id, $uuid, $objectname, 'DELETED');
     }
@@ -234,7 +234,7 @@ class LogChanges extends Entity
      * @param int $id The record ID of the inserted record
      * @param string $objectname Human readable representation of the record (used in the log view)
      */
-    public function setLogModification(string $table, int $id, string $uuid = null, string $objectname = null, string $field, string $fieldName = null, string $oldValue = null, string $newValue = null)
+    public function setLogModification(string $table, int $id, ?string $uuid = null, ?string $objectname = null, ?string $field = null, ?string $fieldName = null, ?string $oldValue = null, ?string $newValue = null)
     {
         $this->setLogBasevalues($table, $id, $uuid, $objectname, 'MODIFY');
 

--- a/src/Changelog/Service/ChangelogService.php
+++ b/src/Changelog/Service/ChangelogService.php
@@ -1084,7 +1084,7 @@ class ChangelogService {
      * @return bool Returns true if the database table (or at least one, of multiple are given) is logged
      * @throws Exception
      */
-    public static function hasLogViewPermission(string|array $table, User $user = null) : bool {
+    public static function hasLogViewPermission(string|array $table, ?User $user = null) : bool {
         global $gSettingsManager, $gCurrentUser;
         if (empty($user)) {
             $user = $gCurrentUser;

--- a/src/Infrastructure/ChangeNotification.php
+++ b/src/Infrastructure/ChangeNotification.php
@@ -104,7 +104,7 @@ class ChangeNotification
      * @param User|null $user Optional the user object of the changed user could be set.
      * @throws Exception
      */
-    public function prepareUserChanges(int $userID, User $user = null)
+    public function prepareUserChanges(int $userID, ?User $user = null)
     {
         global $gDb, $gProfileFields;
         if (!isset($this->changes[$userID])) {
@@ -146,7 +146,7 @@ class ChangeNotification
      * @param string $new_value_db The new value of the field after the change as stored in the database
      * @throws Exception
      */
-    public function logProfileChange(int $userID, int $fieldId, string $fieldName, string $old_value = null, string $new_value = null, string $old_value_db = '', string $new_value_db = '', string $reason = "MODIFIED", $user = null)
+    public function logProfileChange(int $userID, int $fieldId, string $fieldName, ?string $old_value = null, ?string $new_value = null, string $old_value_db = '', string $new_value_db = '', string $reason = "MODIFIED", $user = null)
     {
         // Store the change to send out one change notification mail (after all modifications are done)
         $this->prepareUserChanges($userID, $user);
@@ -168,7 +168,7 @@ class ChangeNotification
      * @param User|null $user Optional the object of the changed user.
      * @throws Exception
      */
-    public function logUserChange(int $userID, string $fieldName, string $old_value = null, string $new_value = null, string $action = "MODIFIED", User $user = null)
+    public function logUserChange(int $userID, string $fieldName, ?string $old_value = null, ?string $new_value = null, string $action = "MODIFIED", ?User $user = null)
     {
         global $gSettingsManager, $gL10n, $gDb;
 
@@ -221,7 +221,7 @@ class ChangeNotification
      * @param string $old_value The previous value of the field before the change
      * @param string $new_value The new value of the field after the change
      */
-    public function logRoleChange(Membership $membership, string $fieldName, string $old_value = null, string $new_value = null)
+    public function logRoleChange(Membership $membership, string $fieldName, ?string $old_value = null, ?string $new_value = null)
     {
         global $gSettingsManager, $gL10n;
         $userID = $membership->getValue("mem_usr_id");
@@ -266,7 +266,7 @@ class ChangeNotification
      * @param User|null $user (optional) The User object of the newly created user
      * @throws Exception
      */
-    public function logUserCreation(int $userID, User $user = null)
+    public function logUserCreation(int $userID, ?User $user = null)
     {
         global $gProfileFields, $gDb, $gSettingsManager;
 
@@ -315,7 +315,7 @@ class ChangeNotification
      * @param User|null $user (optional) The User object of the user to be deleted
      * @throws Exception
      */
-    public function logUserDeletion(int $userID, User $user = null)
+    public function logUserDeletion(int $userID, ?User $user = null)
     {
         global $gProfileFields, $gL10n, $gDb, $gSettingsManager;
 

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -799,7 +799,7 @@ class Entity
                             $queryParams[] = $value;
                         }
                     }
-                    // Ignore the usr_id_create and timestamp_create (and *_change) columns in the change log...
+                    // Ignore the usr_id_create and timestamp_crearte (and *_change) columns in the change log...
                     if (!in_array($key, $this->getIgnoredLogColumns())) {
                         $logChanges[$key] = array('oldValue' => $this->columnsInfos[$key]['previousValue'], 'newValue' => $value); 
                     }

--- a/src/Session/Entity/Session.php
+++ b/src/Session/Entity/Session.php
@@ -503,7 +503,7 @@ class Session extends Entity
         int    $expire = 0,
         string $path = '',
         string $domain = '',
-        bool   $secure = null,
+        ?bool   $secure = null,
         bool   $httpOnly = true
     ): bool
     {
@@ -554,7 +554,7 @@ class Session extends Entity
      *                             Set to "false" to allow access for JavaScript. (Possible XSS security leak)
      * @throws \RuntimeException
      */
-    public static function start(string $cookiePrefix, int $limit = 0, string $path = '', string $domain = '', bool $secure = null, bool $httpOnly = true)
+    public static function start(string $cookiePrefix, int $limit = 0, string $path = '', string $domain = '', ?bool $secure = null, bool $httpOnly = true)
     {
         global $gLogger, $gSetCookieForDomain;
 

--- a/src/UI/Presenter/FormPresenter.php
+++ b/src/UI/Presenter/FormPresenter.php
@@ -131,7 +131,7 @@ class FormPresenter
      *                             is set as default and need not set with this parameter.
      * @throws Exception
      */
-    public function __construct(string $id, string $template, string $action = '', PagePresenter $htmlPage = null, array $options = array())
+    public function __construct(string $id, string $template, string $action = '', ?PagePresenter $htmlPage = null, array $options = array())
     {
         // create array with all options
         $optionsDefault = array(

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -113,7 +113,7 @@ class User extends Entity
      *                                  object with no specific user is created.
      * @throws Exception
      */
-    public function __construct(Database $database, ProfileFields $userFields = null, int $userId = 0)
+    public function __construct(Database $database, ?ProfileFields $userFields = null, int $userId = 0)
     {
         $this->changeNotificationEnabled = true;
 
@@ -242,7 +242,7 @@ class User extends Entity
      * @return bool Return true if a special right should be checked and the user has this right.
      * @throws Exception
      */
-    public function checkRolesRight(string $right = null): bool
+    public function checkRolesRight(?string $right = null): bool
     {
         $sqlFetchedRows = array();
 
@@ -421,7 +421,7 @@ class User extends Entity
      *                                       SYS_LOGIN_USERNAME_PASSWORD_INCORRECT
      *                                       SYS_SECURITY_CODE_INVALID
      */
-    public function checkLogin(string $password, bool $setAutoLogin = false, bool $updateSessionCookies = true, bool $updateHash = true, bool $isAdministrator = false, string $totpCode = null): bool
+    public function checkLogin(string $password, bool $setAutoLogin = false, bool $updateSessionCookies = true, bool $updateHash = true, bool $isAdministrator = false, ?string $totpCode = null): bool
     {
         if ($this->checkPassword($password) && $this->checkMembership($isAdministrator) && $this->checkTotp($totpCode)) {
             $this->updateSession($setAutoLogin, $updateSessionCookies);

--- a/src/Users/Entity/UserData.php
+++ b/src/Users/Entity/UserData.php
@@ -50,7 +50,7 @@ class UserData extends Entity
      * @param string $newval new value after the change (can be null)
      * @return true returns **true** if no error occurred
      */
-    protected function logUserfieldChange(string $oldval = null, string $newval = null) : bool {
+    protected function logUserfieldChange(?string $oldval = null, ?string $newval = null) : bool {
         if ($oldval === $newval) {
             // No change, nothing to log
             return true;


### PR DESCRIPTION

e.g. if a function has signature funcname(string $param = null), php8.3 will throw a warning, because the type of $param is string. If null is also allowed, one must explicitly declare the type as nullable, either via ?string or string|null.