### PR TITLE
Generalize RolesRightsData to use Entity sub-classes

### DIFF
--- a/src/Changelog/Service/ChangelogService.php
+++ b/src/Changelog/Service/ChangelogService.php
@@ -227,6 +227,10 @@ class ChangelogService {
      */
     public static function getObjectForTable(string $module): Entity | null {
         global $gDb, $gProfileFields;
+
+        if (str_starts_with($module, TABLE_PREFIX . '_')) {
+            $module = substr($module, strlen(TABLE_PREFIX) + 1);
+        }
         // HANDLE REGISTERED CALLBACKS, THEN DEFAULT PROCESSING
         // First process callbacks defined for the given module:
         if (!empty($module) && array_key_exists($module, self::$customCallbacks['getObjectForTable'])) {
@@ -298,7 +302,7 @@ class ChangelogService {
                 return new Topic($gDb);
             case 'saml_clients':
                 return new SAMLClient($gDb);
-            case 'ssos_keys':
+            case 'sso_keys':
                 return new Key($gDb);
             default:
                 return null;

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -181,6 +181,30 @@ class Entity
     }
 
     /**
+     * Get the name of the underlying database table. This can be used to construct sql queries  without hardcoding the table.
+     * @return string The name of the underlying database table
+     */
+    public function getTableName(): string {
+        return $this->tableName;
+    }
+
+    /**
+     * Get the column prefix of the underlying table. This can be used to construct column names without hardcoding the prefix.
+     * @return string The column prefix used for the underlying database table
+     */
+    public function getColumnPrefix(): string {
+        return $this->columnPrefix;
+    }
+
+    /**
+     * Get the key column of the underlying database table. This can be used to construct sql queries names without hardcoding the column name.
+     * @return string The key column name used for the underlying database table
+     */
+    public function getKeyColumnName(): string {
+        return $this->keyColumnName;
+    }
+
+    /**
      * Reads the number of all records of this table
      * @return int Number of records of this table
      * @throws Exception
@@ -799,7 +823,7 @@ class Entity
                             $queryParams[] = $value;
                         }
                     }
-                    // Ignore the usr_id_create and timestamp_create (and *_change) columns in the change log...
+                    // Ignore the usr_id_create and timestamp_crearte (and *_change) columns in the change log...
                     if (!in_array($key, $this->getIgnoredLogColumns())) {
                         $logChanges[$key] = array('oldValue' => $this->columnsInfos[$key]['previousValue'], 'newValue' => $value); 
                     }

--- a/src/Roles/Entity/RolesRightsData.php
+++ b/src/Roles/Entity/RolesRightsData.php
@@ -1,6 +1,7 @@
 <?php
 namespace Admidio\Roles\Entity;
 
+use Admidio\Changelog\Service\ChangelogService;
 use Admidio\Infrastructure\Database;
 use Admidio\Roles\Entity\RolesRights;
 use Admidio\Infrastructure\Entity\Entity;
@@ -81,7 +82,11 @@ class RolesRightsData extends Entity
                 $obj = new MenuEntry($this->db, $objID);
                 break;
             default:
-                $obj = new Entity($this->db, $objTable, $objID);
+                $obj = ChangelogService::getObjectForTable($objTable);
+                if (!is_null($obj)) {
+                    $obj->readDataById($objID);
+                }
+                // $obj = new Entity($this->db, $objTable, $objID);
         }
         $objUuid = $obj->getValue($obj->columnPrefix . '_uuid'); 
         $objTableclean = str_replace(TABLE_PREFIX . '_', '', $objTable);


### PR DESCRIPTION
Currently, RolesRightesData will create an Entity object for all classes that are not explicitly listed. In the future, more classes might get roles rights support. If the dedicated Entity-sub-class is not used, the changelog implementation for that table is not applied.

On the other hand, ChangelogService::getObjectForTable already provides the functionality to create an (empty) object for a given DB table... Using that method solves the problem.