### PR TITLE
Login redirect: Allow redirecting to a POST URL after successful login

### DIFF
--- a/src/SSO/Service/SSOService.php
+++ b/src/SSO/Service/SSOService.php
@@ -195,6 +195,10 @@ class SSOService {
 
         if (!isset($_SESSION['login_forward_url'])) {
             $_SESSION['login_forward_url'] = CURRENT_URL;
+            // GET variables are included in the current URL, but POST variables need to be added
+            if (!empty($_POST)) {
+                $_SESSION['login_forward_url_post'] = $_POST;
+            }
         }
         $headline = $gL10n->get('SYS_LOGIN_TO', array($client->readableName()));
 

--- a/system/js/common_functions.js
+++ b/system/js/common_functions.js
@@ -283,6 +283,33 @@ function messageBox(message, title, type, buttons, href) {
 }
 
 /**
+ * This function will redirect the user's browser to the given URL. If post data is provided,
+ * a hidden form is submitted to achieve a html POST, otherwise self.location.href is set to load the URL.
+ */
+function redirectToURL(url, args = null) {
+    if (!args) {
+        self.location.href = url;
+    } else {
+        // Simulate a POST redirect
+        const form = document.createElement("form");
+        form.method = "POST";
+        form.action = url;
+        form.style.display = "none";
+
+        for (const key in args) {
+            if (Object.hasOwn(args, key)) {
+                const input = document.createElement("input");
+                input.type = "hidden";
+                input.name = key;
+                input.value = args[key];
+                form.appendChild(input);
+            }
+        }
+        document.body.appendChild(form);
+        form.submit();
+    }
+}
+/**
  * The function will override the submitting of a form. It will call the action url and handle the response
  * of that url. Therefore, a json with status and message key is expected. Also a url key must be provided to
  * which the user will be guided if the form was successfully processed.
@@ -308,15 +335,9 @@ function formSubmit(event) {
             try {
                 var returnData = JSON.parse(data);
                 var returnStatus = returnData.status;
-                var returnMessage = "";
-                var forwardUrl = "";
-
-                if (typeof returnData.message !== "undefined") {
-                    returnMessage = returnData.message;
-                }
-                if (typeof returnData.url !== "undefined") {
-                    forwardUrl = returnData.url;
-                }
+                var returnMessage = returnData.message || "";
+                var forwardUrl = returnData.url || "";
+                var forwardPost = returnData.url_post || null;
             } catch (e) {
                 if (typeof $(".modal-body") !== "undefined") {
                     $(".modal-body").html(data);
@@ -333,7 +354,7 @@ function formSubmit(event) {
                     formAlert.fadeIn("slow");
                     if (forwardUrl !== "") {
                         setTimeout(function () {
-                            self.location.href = forwardUrl;
+                            redirectToURL(forwardUrl, forwardPost);
                         }, 2500);
                     } else {
                         $("#" + submitButtonID).attr("disabled", false);
@@ -344,7 +365,7 @@ function formSubmit(event) {
                         }, 2500);
                     }
                 } else {
-                    self.location.href = forwardUrl;
+                    redirectToURL(forwardUrl, forwardPost);
                 }
             } else {
                 if ($("#adm_captcha").length > 0) {

--- a/system/login.php
+++ b/system/login.php
@@ -63,10 +63,16 @@ try {
 
         unset($_SESSION['login_forward_url']);
 
-        echo json_encode(array(
+        $payload = array(
             'status' => 'success',
             'url' => $forwardUrl
-        ));
+        );
+        if (array_key_exists('login_forward_url_post', $_SESSION)) {
+            $payload['url_post'] = $_SESSION['login_forward_url_post'];
+            unset($_SESSION['login_forward_url_post']);
+        }
+
+        echo json_encode($payload);
         exit();
     }
 } catch (Exception $e) {


### PR DESCRIPTION
The login form so far (optionally) stores the current URL and redirects to the URL after a successful login. However, for SSO, some clients use a POST request to the SSO endpoints, so after successful login the POST request needs to be repeated.

This is implemented via three steps:

1. Before the login form is shown, the $_POST array is stored in the session ($_SESSION['login_forward_url_post']), alongside the login_forward_url 
2. When the login form is processed, the session is checked for the login_forward_url_post entry. If it exists, it is added to the returned JSON 
3. The JS code handling the login response uses either self.location.href to switch to the URL if no post arguments are given, or creates a hidden form, adds the post variables as hidden inputs and submits the form, resulting in the proper POST request being sent to the URL.


This is fully implemented, and also used in the SAML 2.0 SSO code, as Keycloak sends the SSO request as POST (most other clients use GET).