### PR TITLE
Category Report: Make column definitions movable / deletable

### DIFF
--- a/modules/category-report/preferences_function.php
+++ b/modules/category-report/preferences_function.php
@@ -42,21 +42,11 @@ try {
                 $values['number_col'] = isset($_POST['number_col' . $conf]) ? 1 : 0;
                 $values['default_conf'] = (bool)$_POST['default_conf' . $conf];
 
-                $allColumnsEmpty = true;
-
-                $fields = '';
-                for ($number = 0; isset($_POST['column' . $conf . '_' . $number]); $number++) {
-                    if (strlen($_POST['column' . $conf . '_' . $number]) > 0) {
-                        $allColumnsEmpty = false;
-                        $fields .= $_POST['column' . $conf . '_' . $number] . ',';
-                    }
-                }
-
-                if ($allColumnsEmpty) {
+                if (empty($_POST['columns' . $conf])) {
                     throw new Exception('SYS_FIELD_EMPTY', array('SYS_COLUMN'));
                 }
-
-                $values['col_fields'] = substr($fields, 0, -1);
+                
+                $values['col_fields'] = implode(',', $_POST['columns' . $conf]);
                 $config[] = $values;
             }
 

--- a/themes/simple/templates/modules/category-report.config.tpl
+++ b/themes/simple/templates/modules/category-report.config.tpl
@@ -18,17 +18,20 @@
                     </label>
                     <div class="col-sm-9">
                         <div class="table-responsive">
-                            <table class="table table-condensed" id="mylist_fields_table">
+                            <table class="table table-condensed catreport-columns-table" id="mylist_fields_table{$categoryReport.key}">
                                 <thead>
                                 <tr>
-                                    <th style="width: 20%;">{$l10n->get('SYS_ABR_NO')}</th>
-                                    <th style="width: 37%;">{$l10n->get('SYS_CONTENT')}</th>
+                                    <th style="width: 30%;">{$l10n->get('SYS_ABR_NO')}</th>
+                                    <th style="width: 60%;">{$l10n->get('SYS_CONTENT')}</th>
+                                    <th style="width: !60px;"></th>
                                 </tr>
                                 </thead>
                                 <tbody id="mylist_fields_tbody{$categoryReport.key}">
+                                </tbody>
+                                <tfoot>
                                 <tr id="table_row_button">
-                                    <td colspan="2">
-                                        <a class="icon-text-link" href="javascript:addColumn{$categoryReport.key}()"><i class="bi bi-plus-circle-fill"></i> {$l10n->get('SYS_ADD_COLUMN')}</a>
+                                    <td colspan="3">
+                                        <a class="icon-text-link" href="javascript:addColumnToConfiguration({$categoryReport.key})"><i class="bi bi-plus-circle-fill"></i> {$l10n->get('SYS_ADD_COLUMN')}</a>
                                     </td>
                                 </tr>
                                 </tbody>


### PR DESCRIPTION
Simplify the category report configuration:
  * Allow re-ordering the columns (using jQuery sortable)
  * Allow deleting individual columns
  * Dynamically number the columns using JS rather than hardcoding
  * Use name="columns0[]" to set all columns in one http array rather than numbering each select control individually (which breaks when sorting)