### PR TITLE
fix: revert wrong placed file/foldernames

### DIFF
--- a/modules/category-report/category_report.php
+++ b/modules/category-report/category_report.php
@@ -453,7 +453,7 @@ try {
 
 // Settings for export file
     if ($getMode === 'csv' || $getMode === 'pdf') {
-        $filename = FileSystemUtils::getSanitizedPathEntry($filename) . 'category-report' . $getMode;
+        $filename = FileSystemUtils::getSanitizedPathEntry($filename) . '.' . $getMode;
 
         header('Content-Disposition: attachment; filename="' . $filename . '"');
 

--- a/modules/contacts/contacts_function.php
+++ b/modules/contacts/contacts_function.php
@@ -116,7 +116,7 @@ try {
             $role->stopMembership($row['mem_usr_id']);
         }
 
-        echo json_encode(array('status' => 'success', 'message' => $gL10n->get('SYS_END_MEMBERSHIP_OF_USER_OK', array($user->getValue('FIRST_NAME') . ' contacts_function.php' . $user->getValue('LAST_NAME'), $gCurrentOrganization->getValue('org_longname')))));
+        echo json_encode(array('status' => 'success', 'message' => $gL10n->get('SYS_END_MEMBERSHIP_OF_USER_OK', array($user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME'), $gCurrentOrganization->getValue('org_longname')))));
         exit();
     } elseif ($getMode === 'delete') {
         // User must not be in any other organization

--- a/modules/events/events_function.php
+++ b/modules/events/events_function.php
@@ -128,7 +128,7 @@ try {
             if (!$startDateTime) {
                 throw new Exception('SYS_DATE_INVALID', array('SYS_START', 'YYYY-MM-DD'));
             } else {
-                throw new Exception('SYS_TIME_INVALID', array($gL10n->get('SYS_TIME') . ' events_function.php' . $gL10n->get('SYS_START'), 'HH:ii'));
+                throw new Exception('SYS_TIME_INVALID', array($gL10n->get('SYS_TIME') . ' ' . $gL10n->get('SYS_START'), 'HH:ii'));
             }
         } else {
             // now write date and time with database format to date object
@@ -152,7 +152,7 @@ try {
             if (!$endDateTime) {
                 throw new Exception('SYS_DATE_INVALID', array('SYS_END', 'YYYY-MM-DD'));
             } else {
-                throw new Exception('SYS_TIME_INVALID', array($gL10n->get('SYS_TIME') . ' events_function.php' . $gL10n->get('SYS_END'), 'HH:ii'));
+                throw new Exception('SYS_TIME_INVALID', array($gL10n->get('SYS_TIME') . ' ' . $gL10n->get('SYS_END'), 'HH:ii'));
             }
         } else {
             // now write date and time with database format to date object
@@ -273,7 +273,7 @@ try {
                 // if the data of the role must be changed
                 $role = new Role($gDb, (int)$event->getValue('dat_rol_id'));
 
-                $role->setValue('rol_name', $event->getDateTimePeriod(false) . ' events_function.php' . $event->getValue('dat_headline'));
+                $role->setValue('rol_name', $event->getDateTimePeriod(false) . ' ' . $event->getValue('dat_headline'));
                 $role->setValue('rol_description', substr($event->getValue('dat_description'), 0, 3999));
                 // role members are allowed to view lists
                 $role->setValue('rol_view_memberships', ($formValues['event_right_list_view']) ? Role::VIEW_ROLE_MEMBERS : Role::ROLE_LEADER_MEMBERS_ASSIGN_EDIT);
@@ -316,7 +316,7 @@ try {
                     $role->setValue('rol_max_members', (int)$formValues['dat_max_members']);
                 }
 
-                $role->setValue('rol_name', $event->getDateTimePeriod(false) . ' events_function.php' . $event->getValue('dat_headline', 'database'));
+                $role->setValue('rol_name', $event->getDateTimePeriod(false) . ' ' . $event->getValue('dat_headline', 'database'));
                 $role->setValue('rol_description', substr($event->getValue('dat_description', 'database'), 0, 3999));
 
                 $role->save();

--- a/modules/events/events_new.php
+++ b/modules/events/events_new.php
@@ -256,13 +256,13 @@ try {
     $form->addInput(
         'event_from',
         $gL10n->get('SYS_START'),
-        $event->getValue('dat_begin', $gSettingsManager->getString('system_date') . ' events_new.php' . $gSettingsManager->getString('system_time')),
+        $event->getValue('dat_begin', $gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time')),
         array('type' => 'datetime', 'property' => FormPresenter::FIELD_REQUIRED)
     );
     $form->addInput(
         'event_to',
         $gL10n->get('SYS_END'),
-        $event->getValue('dat_end', $gSettingsManager->getString('system_date') . ' events_new.php' . $gSettingsManager->getString('system_time')),
+        $event->getValue('dat_end', $gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time')),
         array('type' => 'datetime', 'property' => FormPresenter::FIELD_REQUIRED)
     );
     $form->addSelectBoxForCategories(
@@ -336,7 +336,7 @@ try {
     $form->addInput(
         'event_deadline',
         $gL10n->get('SYS_DEADLINE'),
-        $event->getValue('dat_deadline', $gSettingsManager->getString('system_date') . ' events_new.php' . $gSettingsManager->getString('system_time')),
+        $event->getValue('dat_deadline', $gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time')),
         array('type' => 'datetime', 'helpTextId' => 'SYS_EVENT_DEADLINE_DESC')
     );
     $form->addCheckbox('event_right_list_view', $gL10n->get('SYS_RIGHT_VIEW_PARTICIPANTS'), $flagDateRightListView);

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -686,7 +686,7 @@ try {
             $filename .= '-' . str_replace('.', '', $list->getValue('lst_name'));
         }
 
-        $filename = FileSystemUtils::getSanitizedPathEntry($filename) . 'groups-roles' . $getMode;
+        $filename = FileSystemUtils::getSanitizedPathEntry($filename) . '.' . $getMode;
         $file = ADMIDIO_PATH . FOLDER_TEMP_DATA . '/' . $filename;
 
         header('Content-Type: application/pdf');
@@ -743,7 +743,7 @@ try {
                 // Appointment
                 $value = '';
                 if ($role->getValue('rol_weekday') > 0) {
-                    $value = RolesService::getWeekdays($role->getValue('rol_weekday')) . ' lists_show.php';
+                    $value = RolesService::getWeekdays($role->getValue('rol_weekday')) . ' ';
                 }
                 if ((string)$role->getValue('rol_start_time') !== '') {
                     $value = $gL10n->get('SYS_FROM_TO', array($role->getValue('rol_start_time', $gSettingsManager->getString('system_time')), $role->getValue('rol_end_time', $gSettingsManager->getString('system_time'))));
@@ -759,7 +759,7 @@ try {
 
                 // Member Fee
                 if ((string)$role->getValue('rol_cost') !== '') {
-                    $roleProperties[] = array('label' => $gL10n->get('SYS_CONTRIBUTIONv'), 'value' => $role->getValue('rol_cost') . ' lists_show.php' . $gSettingsManager->getString('system_currency'));
+                    $roleProperties[] = array('label' => $gL10n->get('SYS_CONTRIBUTIONv'), 'value' => $role->getValue('rol_cost') . ' ' . $gSettingsManager->getString('system_currency'));
                 }
 
                 // Fee period

--- a/modules/messages/messages_send.php
+++ b/modules/messages/messages_send.php
@@ -93,7 +93,7 @@ try {
 
         // if user is logged in then show sender name and email
         if ($gCurrentUserId > 0) {
-            $formValues['namefrom'] = $gCurrentUser->getValue('FIRST_NAME') . ' messages_send.php' . $gCurrentUser->getValue('LAST_NAME');
+            $formValues['namefrom'] = $gCurrentUser->getValue('FIRST_NAME') . ' ' . $gCurrentUser->getValue('LAST_NAME');
             if (!isset($formValues['mailfrom']) || !StringUtils::strValidCharacters((string) $formValues['mailfrom'], 'email')) {
                 $formValues['mailfrom'] = $gCurrentUser->getValue('EMAIL');
             }
@@ -163,7 +163,7 @@ try {
                     // only send email to user if current user is allowed to view this user, and he has a valid email address
                     if ($gCurrentUser->hasRightViewProfile($user)) {
                         // add user to the message object
-                        $message->addUser($user->getValue('usr_id'), $user->getValue('FIRST_NAME') . ' messages_send.php' . $user->getValue('LAST_NAME'));
+                        $message->addUser($user->getValue('usr_id'), $user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME'));
 
                         // add user as recipients to the email
                         $email->addRecipientsByUser($user->getValue('usr_uuid'));
@@ -325,7 +325,7 @@ try {
 
         // message if sending was OK
         if ($getMsgType === Message::MESSAGE_TYPE_PM) {
-            $successMessage = $gL10n->get('SYS_PRIVATE_MESSAGE_SEND', array($user->getValue('FIRST_NAME') . ' messages_send.php' . $user->getValue('LAST_NAME')));
+            $successMessage = $gL10n->get('SYS_PRIVATE_MESSAGE_SEND', array($user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME')));
         } else {
             $successMessage = $gL10n->get('SYS_EMAIL_SEND');
         }
@@ -333,7 +333,7 @@ try {
         exit();
     } else {
         if ($getMsgType === Message::MESSAGE_TYPE_PM) {
-            throw new Exception('SYS_PRIVATE_MESSAGE_NOT_SEND', array($user->getValue('FIRST_NAME') . ' messages_send.php' . $user->getValue('LAST_NAME'), $sendResult));
+            throw new Exception('SYS_PRIVATE_MESSAGE_NOT_SEND', array($user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME'), $sendResult));
         } else {
             throw new Exception('SYS_EMAIL_NOT_SEND', array('SYS_RECIPIENT', $sendResult));
         }

--- a/modules/messages/messages_write.php
+++ b/modules/messages/messages_write.php
@@ -265,7 +265,7 @@ try {
         if ($getUserUuid !== '') {
             // check if the user has email address for receiving an email
             if (!$user->hasEmail()) {
-                throw new Exception('SYS_USER_NO_EMAIL', array($user->getValue('FIRST_NAME') . ' messages_write.php' . $user->getValue('LAST_NAME')));
+                throw new Exception('SYS_USER_NO_EMAIL', array($user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME')));
             }
         } elseif ($getRoleUuid !== '') {
             // if a certain role is called, then check if the rights for it are available
@@ -477,7 +477,7 @@ try {
             $form->addInput(
                 'namefrom',
                 $gL10n->get('SYS_YOUR_NAME'),
-                $gCurrentUser->getValue('FIRST_NAME') . ' messages_write.php' . $gCurrentUser->getValue('LAST_NAME'),
+                $gCurrentUser->getValue('FIRST_NAME') . ' ' . $gCurrentUser->getValue('LAST_NAME'),
                 array('maxLength' => 50, 'property' => FormPresenter::FIELD_DISABLED)
             );
 
@@ -602,9 +602,9 @@ try {
 
             if ($getMsgType === Message::MESSAGE_TYPE_PM) {
                 if ($messageContent->getValue('msc_usr_id') === $gCurrentUserId) {
-                    $sentUser = $gCurrentUser->getValue('FIRST_NAME') . ' messages_write.php' . $gCurrentUser->getValue('LAST_NAME');
+                    $sentUser = $gCurrentUser->getValue('FIRST_NAME') . ' ' . $gCurrentUser->getValue('LAST_NAME');
                 } else {
-                    $sentUser = $user->getValue('FIRST_NAME') . ' messages_write.php' . $user->getValue('LAST_NAME');
+                    $sentUser = $user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME');
                 }
 
                 $messageHeader = $gL10n->get('SYS_USERNAME_WITH_TIMESTAMP', array($sentUser,
@@ -613,7 +613,7 @@ try {
                 ));
                 $messageIcon = 'bi-chat-left-fill';
             } else {
-                $messageHeader = $messageContent->getValue('msc_timestamp', $gSettingsManager->getString('system_date') . ' messages_write.php' . $gSettingsManager->getString('system_time')) . '<br />' . $gL10n->get('SYS_TO') . ': ' . $message->getRecipientsNamesString();
+                $messageHeader = $messageContent->getValue('msc_timestamp', $gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time')) . '<br />' . $gL10n->get('SYS_TO') . ': ' . $message->getRecipientsNamesString();
                 $messageIcon = 'bi-envelope-fill';
                 $attachments = $message->getAttachmentsInformations();
 

--- a/modules/photos/ecard_send.php
+++ b/modules/photos/ecard_send.php
@@ -53,7 +53,7 @@ try {
         throw new Exception('SYS_CURRENT_USER_NO_EMAIL', array('<a href="' . ADMIDIO_URL . FOLDER_MODULES . '/profile/profile.php">', '</a>'));
     }
 
-    $senderName  = $gCurrentUser->getValue('FIRST_NAME') . ' ecard_send.php' . $gCurrentUser->getValue('LAST_NAME');
+    $senderName  = $gCurrentUser->getValue('FIRST_NAME') . ' ' . $gCurrentUser->getValue('LAST_NAME');
     $senderEmail = $gCurrentUser->getValue('EMAIL');
 
     // check form field input and sanitized it from malicious content

--- a/modules/profile/profile_function.php
+++ b/modules/profile/profile_function.php
@@ -53,7 +53,7 @@ try {
             throw new Exception('SYS_NO_RIGHTS');
         }
 
-        $filename = $user->getValue('FIRST_NAME') . ' profile_function.php' . $user->getValue('LAST_NAME');
+        $filename = $user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME');
 
         $filename = FileSystemUtils::getSanitizedPathEntry($filename) . '.vcf';
 

--- a/modules/profile/profile_new.php
+++ b/modules/profile/profile_new.php
@@ -86,7 +86,7 @@ try {
             // if we want to copy the user than set id = 0
             $user->setValue('usr_id', 0);
             $getUserUuid = '';
-            $headline = $gL10n->get('SYS_COPY_VAR', array($user->getValue('FIRST_NAME') . ' profile_new.php' . $user->getValue('LAST_NAME')));
+            $headline = $gL10n->get('SYS_COPY_VAR', array($user->getValue('FIRST_NAME') . ' ' . $user->getValue('LAST_NAME')));
         } elseif ($getUserUuid === '' && $gValidLogin) {
             $headline = $gL10n->get('SYS_CREATE_MEMBER');
         } elseif ($getUserUuid === '' && !$gValidLogin) {

--- a/src/UI/Presenter/GroupsRolesPresenter.php
+++ b/src/UI/Presenter/GroupsRolesPresenter.php
@@ -169,7 +169,7 @@ class GroupsRolesPresenter extends PagePresenter
 
                 if ($role->getValue('rol_weekday') > 0 || !empty($role->getValue('rol_start_time'))) {
                     if ($role->getValue('rol_weekday') > 0) {
-                        $html .= RolesService::getWeekdays($role->getValue('rol_weekday')) . ' GroupsRolesPresenter.php';
+                        $html .= RolesService::getWeekdays($role->getValue('rol_weekday')) . ' ';
                     }
                     if (!empty($role->getValue('rol_start_time'))) {
                         $html .= $gL10n->get('SYS_FROM_TO', array($role->getValue('rol_start_time', $gSettingsManager->getString('system_time')), $role->getValue('rol_end_time', $gSettingsManager->getString('system_time'))));


### PR DESCRIPTION
I hope i get rid of all occurrences mentioned in #1805.

The following bash-codes where used to check the code for further occurrences of wrong placed file and foldernames:
``` bash
# -------------------------------------------------------------------
#  For every tracked *.php file, print lines where the file’s 
#  name appears inside ' … '  or  " … ",
#  with nothing but whitespace before/after the name.
# -------------------------------------------------------------------

git ls-files -z -- '*.php' |
while IFS= read -r -d '' file; do
    name=$(basename "$file")
    safe=$(printf '%s\n' "$name" | sed 's/[][\/.^$*+?(){}|]/\\&/g')
    pat="'\\s*${safe}\\s*'|\"\\s*${safe}\\s*\""

    git grep -n -P "$pat" -- "$file" || true
done
```
``` bash
# -------------------------------------------------------------------
#  For every tracked *.php file, print lines where the file’s own
#  parent-folder name appears inside ' … '  or  " … ",
#  with nothing but whitespace before/after the name.
# -------------------------------------------------------------------

git ls-files -z -- '*.php' |
while IFS= read -r -d '' file; do
    folder=$(basename "$(dirname "$file")")
    safe=$(printf '%s\n' "$folder" | sed 's/[][\/.^$*+?(){}|]/\\&/g')
    pat="'\\s*${safe}\\s*'|\"\\s*${safe}\\s*\""

    git grep -n -P "$pat" -- "$file" || true
done
```
---
closes #1805 