### PR TITLE
Feature contacts and groups-roles-lists redesign

### DIFF
--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -1017,6 +1017,7 @@
   <string name="SYS_OPTIONAL">Optional</string>
   <string name="SYS_ORDER">Reihenfolge</string>
   <string name="SYS_ORGANIZATION">Organisation</string>
+  <string name="SYS_ORGANIZATION_AFFILIATION">Organisationszugehörigkeit</string>
   <string name="SYS_ORGANIZATION_DESC">Name und Kontaktangaben der aktuellen Organisation mit der Möglichkeit, Unterorganisationen zu erstellen und anzuzeigen.</string>
   <string name="SYS_OTHER_TABLES">Andere Tabellen (Module von Drittanbietern; nur für Administratoren sichtbar)</string>
   <string name="SYS_OVERHANG">Überhang</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -708,6 +708,8 @@
   <string name="SYS_FORMAT">Format</string>
   <string name="SYS_FORMER">Ehemaliger</string>
   <string name="SYS_FORMER_CONTACTS">Ehemalige Kontakte</string>
+  <string name="SYS_FORMER_MEMBER">Ehemaliges Mitglied</string>
+  <string name="SYS_FORMER_MEMBER_OF_GROUP">Ehemaliges Mitglied der Gruppe #VAR1#</string>
   <string name="SYS_FORMER_MEMBERS">Ehemalige Mitglieder</string>
   <string name="SYS_FORMER_PL">Ehemalige</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Ehemalige Rollenmitgliedschaften</string>
@@ -879,6 +881,7 @@
   <string name="SYS_MEGAPIXEL">Megapixel</string>
   <string name="SYS_MEMBER">Mitglied</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Mitgliederzuordnung</string>
+  <string name="SYS_MEMBER_OF_GROUP">Mitglied der Gruppe #VAR1#</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Mitglied der Organisation #VAR1#</string>
   <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Mitglieder zwischen #VAR1# und #VAR2#</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -683,7 +683,7 @@
   <string name="SYS_FILENAME_INVALID">Der ausgewählte Dateiname #VAR1_BOLD# enthält ungültige Zeichen. Bitte prüfen Sie den Dateinamen.\n\n Die folgenden Sonderzeichen sind nicht erlaubt: ? * ~ ; : \" | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">Die Datenbankversion #VAR1# ist höher als die Version der Admidio-Scripte #VAR2#.\n\nAktualisieren Sie bitte Ihre Admidio-Dateien auf dem FTP-Server #VAR3#mit der aktuelleren Admidio-Version#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
-  <string name="SYS_FILTER_MEMBERS">Mitglieder filtern</string>
+  <string name="SYS_FILTER_MEMBERS">Mitglieder</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter zum Exportieren</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">Erste Zeile beinhaltet die Spaltenbezeichnungen</string>
   <string name="SYS_FIRSTNAME">Vorname</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -202,6 +202,7 @@
   <string name="SYS_A_TO_Z">A bis Z</string>
   <string name="SYS_ABORT">Abbrechen</string>
   <string name="SYS_ABR_NO" description="Abbreviation for Number">Nr.</string>
+  <string name="SYS_ACTIVE_CONTACTS">Aktive Kontakte</string>
   <string name="SYS_ACTIVE_FORMER_MEMBERS">Aktive und ehemalige Mitglieder</string>
   <string name="SYS_ACTIVE_FORMER_MEMBERS_SHORT">Aktive und ehemalige</string>
   <string name="SYS_ACTIVE_MEMBERS">Aktive Mitglieder</string>
@@ -237,6 +238,7 @@
   <string name="SYS_ALBUM_FOLDER_NOT_FOUND">Der zugehörige Ordner wurde nicht gefunden. Sollte er bewusst über FTP gelöscht worden sein oder nicht mehr die Möglichkeit bestehen ihn wieder herzustellen, dann bitte den Ordner über die Oberfläche löschen.\nBesucher:innen der Webseite ohne Fotoverwaltungsrecht, wird dieses Album nicht mehr angezeigt.</string>
   <string name="SYS_ALBUM_NOT_APPROVED">Das Album ist momentan gesperrt und wird Gästen und Mitgliedern aus diesem Grund nicht angezeigt.</string>
   <string name="SYS_ALL">Alle</string>
+  <string name="SYS_ALL_CONTACTS">Alle Kontakte</string>
   <string name="SYS_ALL_DAY">Ganztägig</string>
   <string name="SYS_ALL_MEMBERS">Alle Mitglieder</string>
   <string name="SYS_ALL_ORGANIZATIONS">Alle Organisationen</string>
@@ -376,6 +378,8 @@
   <string name="SYS_CONTACT_NOT_FOUND_CREATE_NEW">Kann der neue Kontakt keinem existierenden Kontakt mit einem ähnlichen Namen zugeordnet werden, so können Sie einen neuen Kontakt anlegen und diesem die entsprechenden Rollen zuweisen.</string>
   <string name="SYS_CONTACT_SIMILAR_NAME">Es wurde ein Kontakt mit einem ähnlichen Namen gefunden.</string>
   <string name="SYS_CONTACTS">Kontakte</string>
+  <string name="SYS_CONTACTS_DESC">Hier können alle aktiven und ehemaligen Mitglieder angezeigt und organisiert werden. Neue Kontakte können importiert oder erstellt werden.</string>
+  <string name="SYS_CONTACTS_PER_PAGE">Anzahl der Kontakte pro Seite</string>
   <string name="SYS_CONTENT">Inhalt</string>
   <string name="SYS_CONTENTS">Inhalt</string>
   <string name="SYS_CONTRIBUTION">Beitrag</string>
@@ -426,8 +430,10 @@
   <string name="SYS_CURRENT_DATABASE_VERSION">Aktuelle Datenbankversion</string>
   <string name="SYS_CURRENT_EVENTS_OF_ORGA">Aktuelle Veranstaltungen der Organisation #VAR1#</string>
   <string name="SYS_CURRENT_MEMBER">Aktuelles Mitglied</string>
+  <string name="SYS_CURRENT_ORGANIZATION">Aktuelle Organisation</string>
   <string name="SYS_CURRENT_PASSWORD">Aktuelles Passwort</string>
   <string name="SYS_CURRENT_PROFILE_PICTURE">Aktuelles Profilfoto</string>
+  <string name="SYS_CURRENT_ROLE_MEMBERSHIP">Aktuelle Rollenmitgliedschaften</string>
   <string name="SYS_CURRENT_USER_NO_EMAIL" description="Var1 und Var2 erzeugen den Profil-Link">Sie haben keine gültige E-Mail-Adresse hinterlegt!\n\nTragen Sie bitte in Ihrem #VAR1#Profil#VAR2# eine E-Mail-Adresse ein.</string>
   <string name="SYS_DATA_CATEGORY_GLOBAL">Ist diese Option aktiviert, so sind die Objekte (Veranstaltungen, Ankündigungen, Weblinks ...) dieser Kategorie auch auf den Webseiten folgender Organisationen sichtbar:\n#VAR1_BOLD#</string>
   <string name="SYS_DATA_MULTI_ORGA">Daten für mehrere Organisationen sichtbar</string>
@@ -683,7 +689,6 @@
   <string name="SYS_FILENAME_INVALID">Der ausgewählte Dateiname #VAR1_BOLD# enthält ungültige Zeichen. Bitte prüfen Sie den Dateinamen.\n\n Die folgenden Sonderzeichen sind nicht erlaubt: ? * ~ ; : \" | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">Die Datenbankversion #VAR1# ist höher als die Version der Admidio-Scripte #VAR2#.\n\nAktualisieren Sie bitte Ihre Admidio-Dateien auf dem FTP-Server #VAR3#mit der aktuelleren Admidio-Version#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
-  <string name="SYS_FILTER_MEMBERS">Mitglieder</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter zum Exportieren</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">Erste Zeile beinhaltet die Spaltenbezeichnungen</string>
   <string name="SYS_FIRSTNAME">Vorname</string>
@@ -702,6 +707,7 @@
   <string name="SYS_FONT">Schriftart</string>
   <string name="SYS_FORMAT">Format</string>
   <string name="SYS_FORMER">Ehemaliger</string>
+  <string name="SYS_FORMER_CONTACTS">Ehemalige Kontakte</string>
   <string name="SYS_FORMER_MEMBERS">Ehemalige Mitglieder</string>
   <string name="SYS_FORMER_PL">Ehemalige</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Ehemalige Rollenmitgliedschaften</string>
@@ -874,10 +880,9 @@
   <string name="SYS_MEMBER">Mitglied</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Mitgliederzuordnung</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Mitglied der Organisation #VAR1#</string>
+  <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Mitglieder zwischen #VAR1# und #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Mitgliederverwaltung genutzt werden. Es werden anschließend in der Mitgliederverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>
-  <string name="SYS_CONTACTS_DESC">Hier können alle aktiven und ehemaligen Mitglieder angezeigt und organisiert werden. Neue Kontakte können importiert oder erstellt werden.</string>
-  <string name="SYS_CURRENT_ROLE_MEMBERSHIP">Aktuelle Rollenmitgliedschaften</string>
   <string name="SYS_MEMBERS_PER_PAGE">Anzahl Teilnehmende pro Seite</string>
   <string name="SYS_MEMBERS_PER_PAGE_DESC">Anzahl der Mitglieder, die in der HTML-Ansicht dargestellt werden. Weitere Mitglieder können durch das Weiterblättern erreicht werden. Die Druckvorschau und der Export sind von diesem Wert nicht betroffen. (Voreinstellung: 25)</string>
   <string name="SYS_MEMBERS_SIMILAR_NAME">Es wurden #VAR1# Mitglieder mit einem ähnlichen Namen gefunden.</string>
@@ -1600,7 +1605,6 @@
   <string name="SYS_USERNAME_DESCRIPTION">Mit diesem Namen kannst du dich anschließend im System anmelden.\nDer Name muss im System eindeutig sein. Ist dein Wunschname bereits vergeben, dann versuche es mit Kombinationen, wie zum Beispiel Andi78 oder StefanT.</string>
   <string name="SYS_USERNAME_OR_EMAIL">Anmeldename oder E-Mail</string>
   <string name="SYS_USERNAME_WITH_TIMESTAMP">#VAR1# am #VAR2# um #VAR3#</string>
-  <string name="SYS_CONTACTS_PER_PAGE">Anzahl der Kontakte pro Seite</string>
   <string name="SYS_USING_CURRENT_VERSION">Sie benutzen eine aktuelle #VAR1#Version von Admidio!</string>
   <string name="SYS_UTF8">UTF-8</string>
   <string name="SYS_UTF16BE">UTF-16BE</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -709,7 +709,7 @@
   <string name="SYS_FORMER">Ehemaliger</string>
   <string name="SYS_FORMER_CONTACTS">Ehemalige Kontakte</string>
   <string name="SYS_FORMER_MEMBER">Ehemaliges Mitglied</string>
-  <string name="SYS_FORMER_MEMBER_OF_GROUP">Ehemaliges Mitglied der Gruppe #VAR1#</string>
+  <string name="SYS_FORMER_MEMBER_OF_ROLE_GROUP">Ehemaliges Mitglied der Rolle/Gruppe #VAR1#</string>
   <string name="SYS_FORMER_MEMBERS">Ehemalige Mitglieder</string>
   <string name="SYS_FORMER_PL">Ehemalige</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Ehemalige Rollenmitgliedschaften</string>
@@ -735,6 +735,7 @@
   <string name="SYS_GEN_RANDOM_EXCEPTION">Das Programm kann keine zufälligen Zahlen erzeugen.\nError Code: #VAR1#\nError Message: #VAR2#</string>
   <string name="SYS_GEN_RANDOM_TWO_DISTINCT_CHARS">Das Programm erwartet eine Zeichenkette mit mindestens 2 unterschiedlichen Zeichen.</string>
   <string name="SYS_GREETING_CARD">Grußkarte</string>
+  <string name="SYS_GROUP_ROLE_MEMBERSHIP">Rollen-/Gruppenmitgliedschaft</string>
   <string name="SYS_GROUPS_ROLES">Gruppen &amp; Rollen</string>
   <string name="SYS_GROUPS_ROLES_DESC">Übersicht und Verwaltung aller Gruppen und Rollen der Organisation. Es können verschiedene Mitgliederlisten angezeigt, exportiert und eigene Listen erstellt werden.</string>
   <string name="SYS_HALF_YEARLY">Halbjährlich</string>
@@ -881,8 +882,8 @@
   <string name="SYS_MEGAPIXEL">Megapixel</string>
   <string name="SYS_MEMBER">Mitglied</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Mitgliederzuordnung</string>
-  <string name="SYS_MEMBER_OF_GROUP">Mitglied der Gruppe #VAR1#</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Mitglied der Organisation #VAR1#</string>
+  <string name="SYS_MEMBER_OF_ROLE_GROUP">Mitglied der Gruppe/Rolle #VAR1#</string>
   <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Mitglieder zwischen #VAR1# und #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Mitgliederverwaltung genutzt werden. Es werden anschließend in der Mitgliederverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>

--- a/languages/de-DE.xml
+++ b/languages/de-DE.xml
@@ -238,6 +238,7 @@
   <string name="SYS_ALBUM_NOT_APPROVED">Das Album ist momentan gesperrt und wird Gästen und Mitgliedern aus diesem Grund nicht angezeigt.</string>
   <string name="SYS_ALL">Alle</string>
   <string name="SYS_ALL_DAY">Ganztägig</string>
+  <string name="SYS_ALL_MEMBERS">Alle Mitglieder</string>
   <string name="SYS_ALL_ORGANIZATIONS">Alle Organisationen</string>
   <string name="SYS_ALL_ORGANIZATIONS_DESC">Die ausgewählte Kategorie ist für alle Organisationen freigegeben.\nDas gerade bearbeitete Objekt (Veranstaltung, Ankündigung, Profilfeld, Weblink ...) wird also nicht nur in dieser Organisation sichtbar sein, sondern in allen folgenden Organisationen ebenfalls angezeigt: #VAR1#.</string>
   <string name="SYS_ALL_OTHERS">Alle anderen</string>
@@ -682,6 +683,7 @@
   <string name="SYS_FILENAME_INVALID">Der ausgewählte Dateiname #VAR1_BOLD# enthält ungültige Zeichen. Bitte prüfen Sie den Dateinamen.\n\n Die folgenden Sonderzeichen sind nicht erlaubt: ? * ~ ; : \" | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">Die Datenbankversion #VAR1# ist höher als die Version der Admidio-Scripte #VAR2#.\n\nAktualisieren Sie bitte Ihre Admidio-Dateien auf dem FTP-Server #VAR3#mit der aktuelleren Admidio-Version#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
+  <string name="SYS_FILTER_MEMBERS">Mitglieder filtern</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter zum Exportieren</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">Erste Zeile beinhaltet die Spaltenbezeichnungen</string>
   <string name="SYS_FIRSTNAME">Vorname</string>
@@ -968,6 +970,7 @@
   <string name="SYS_NONE">Keiner</string>
   <string name="SYS_NOT_AT_REGISTRATION">Nicht bei Registrierung</string>
   <string name="SYS_NOT_EMPTY">Nicht leer</string>
+  <string name="SYS_NOT_MEMBER_OF_ANY_ORGANIZATION">Kein Mitglied einer Organisation</string>
   <string name="SYS_NOT_MEMBER_OF_ORGANIZATION">Nicht Mitglied der Organisation #VAR1#</string>
   <string name="SYS_NOT_NUMERIC">Bitte in der Bedingung des Feldes #VAR1_BOLD# nur gültige Zahlen verwenden.</string>
   <string name="SYS_NOT_REGISTERED">nicht registriert</string>
@@ -1285,7 +1288,7 @@
   <string name="SYS_SETTINGS">Einstellungen</string>
   <string name="SYS_SHOW_ALL">Alle anzeigen</string>
   <string name="SYS_SHOW_ALL_CONTACTS">Optional alle Kontakte anzeigen</string>
-  <string name="SYS_SHOW_ALL_CONTACTS_DESC">Ist diese Option gesetzt, können neben den aktiven Kontakten der aktuellen Organisation optional auch ehemalige Kontakte und Kontakte anderer Organisationen in der Mitgliederverwaltung angezeigt werden. Ansonsten werden nur aktive Kontakte der aktuellen Organisation angezeigt. Beim Anlegen neuer Kontakte oder beim Zuweisen von Registrierungen wird jedoch weiterhin die gesamte Datenbank aller Organisationen nach bestehenden Kontakten durchsucht. (Voreinstellung: ja)</string>
+  <string name="SYS_SHOW_ALL_CONTACTS_DESC">Ist diese Option gesetzt, können neben den Kontakten der aktuellen Organisation optional auch Kontakte anderer Organisationen in der Mitgliederverwaltung angezeigt werden. Ansonsten werden nur aktive und inaktive Kontakte der aktuellen Organisation angezeigt. Beim Anlegen neuer Kontakte oder beim Zuweisen von Registrierungen wird jedoch weiterhin die gesamte Datenbank aller Organisationen nach bestehenden Kontakten durchsucht. (Voreinstellung: ja)</string>
   <string name="SYS_SHOW_ALL_DESC">Bei gesetzter Einstellung werden neben den aktiven Mitgliedern dieser Organisation auch ehemalige Mitglieder, sowie Mitglieder anderer Organisationen angezeigt.</string>
   <string name="SYS_SHOW_CALENDAR">Kalender anzeigen</string>
   <string name="SYS_SHOW_CAPTCHA_DESC">Für nicht angemeldete Benutzer:innen wird im E-Mailformular bei aktiviertem Captcha ein alphanumerischer Code eingeblendet. Diesen muss die Benutzerin oder der Benutzer vor dem E-Mailversand korrekt eingeben. Dies soll sicherstellen, dass das Formular nicht von Spammern missbraucht werden kann. (Voreinstellung: ja)</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -683,7 +683,7 @@
   <string name="SYS_FILENAME_INVALID">Der ausgewählte Dateiname #VAR1_BOLD# enthält ungültige Zeichen. Bitte prüfe den Dateinamen.\n\n Die folgenden Sonderzeichen sind nicht erlaubt: ? * ~ ; : " | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">Die Datenbankversion #VAR1# ist höher als die Version der Admidio-Scripte #VAR2#.\n\nAktualisiere bitte deine Admidio-Dateien auf dem FTP-Server #VAR3#mit der aktuelleren Admidio-Version#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
-  <string name="SYS_FILTER_MEMBERS">Mitglieder filtern</string>
+  <string name="SYS_FILTER_MEMBERS">Mitglieder</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter zum Exportieren</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">Erste Zeile beinhaltet die Spaltenbezeichnungen</string>
   <string name="SYS_FIRSTNAME">Vorname</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -202,6 +202,7 @@
   <string name="SYS_A_TO_Z">A bis Z</string>
   <string name="SYS_ABORT">Abbrechen</string>
   <string name="SYS_ABR_NO" description="Abbreviation for Number">Nr.</string>
+  <string name="SYS_ACTIVE_CONTACTS">Aktive Kontakte</string>
   <string name="SYS_ACTIVE_FORMER_MEMBERS">Aktive und ehemalige Mitglieder</string>
   <string name="SYS_ACTIVE_FORMER_MEMBERS_SHORT">Aktive und ehemalige</string>
   <string name="SYS_ACTIVE_MEMBERS">Aktive Mitglieder</string>
@@ -237,6 +238,7 @@
   <string name="SYS_ALBUM_FOLDER_NOT_FOUND">Der zugehörige Ordner wurde nicht gefunden. Sollte er bewusst über FTP gelöscht worden sein oder nicht mehr die Möglichkeit bestehen ihn wieder herzustellen, dann bitte den Ordner über die Oberfläche löschen.\nBesucher:innen der Webseite ohne Fotoverwaltungsrecht, wird dieses Album nicht mehr angezeigt.</string>
   <string name="SYS_ALBUM_NOT_APPROVED">Das Album ist momentan gesperrt und wird Gästen und Mitgliedern aus diesem Grund nicht angezeigt.</string>
   <string name="SYS_ALL">Alle</string>
+  <string name="SYS_ALL_CONTACTS">Alle Kontakte</string>
   <string name="SYS_ALL_DAY">Ganztägig</string>
   <string name="SYS_ALL_MEMBERS">Alle Mitglieder</string>
   <string name="SYS_ALL_ORGANIZATIONS">Alle Organisationen</string>
@@ -378,6 +380,8 @@
   <string name="SYS_CONTACTS">Kontakte</string>
   <string name="SYS_CONTENT">Inhalt</string>
   <string name="SYS_CONTENTS">Inhalt</string>
+  <string name="SYS_CONTACTS_DESC">Hier können alle aktiven und ehemaligen Mitglieder angezeigt und organisiert werden. Neue Kontakte können importiert oder erstellt werden.</string>
+  <string name="SYS_CONTACTS_PER_PAGE">Anzahl der Kontakte pro Seite</string>
   <string name="SYS_CONTRIBUTION">Beitrag</string>
   <string name="SYS_CONTRIBUTION_PERIOD">Beitragszeitraum</string>
   <string name="SYS_CONVERSATION_PARTNER">Gesprächspartner</string>
@@ -426,8 +430,10 @@
   <string name="SYS_CURRENT_DATABASE_VERSION">Aktuelle Datenbankversion</string>
   <string name="SYS_CURRENT_EVENTS_OF_ORGA">Aktuelle Veranstaltungen der Organisation #VAR1#</string>
   <string name="SYS_CURRENT_MEMBER">Aktuelles Mitglied</string>
+  <string name="SYS_CURRENT_ORGANIZATION">Aktuelle Organisation</string>
   <string name="SYS_CURRENT_PASSWORD">Aktuelles Passwort</string>
   <string name="SYS_CURRENT_PROFILE_PICTURE">Aktuelles Profilfoto</string>
+  <string name="SYS_CURRENT_ROLE_MEMBERSHIP">Aktuelle Rollenmitgliedschaften</string>
   <string name="SYS_CURRENT_USER_NO_EMAIL" description="Var1 und Var2 erzeugen den Profil-Link">Du hast keine gültige E-Mail-Adresse hinterlegt!\n\nTrage bitte in deinem #VAR1#Profil#VAR2# eine E-Mail-Adresse ein.</string>
   <string name="SYS_DATA_CATEGORY_GLOBAL">Ist diese Option aktiviert, so sind die Objekte (Veranstaltungen, Ankündigungen, Weblinks ...) dieser Kategorie auch auf den Webseiten folgender Organisationen sichtbar:\n#VAR1_BOLD#</string>
   <string name="SYS_DATA_MULTI_ORGA">Daten für mehrere Organisationen sichtbar</string>
@@ -683,7 +689,7 @@
   <string name="SYS_FILENAME_INVALID">Der ausgewählte Dateiname #VAR1_BOLD# enthält ungültige Zeichen. Bitte prüfe den Dateinamen.\n\n Die folgenden Sonderzeichen sind nicht erlaubt: ? * ~ ; : " | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">Die Datenbankversion #VAR1# ist höher als die Version der Admidio-Scripte #VAR2#.\n\nAktualisiere bitte deine Admidio-Dateien auf dem FTP-Server #VAR3#mit der aktuelleren Admidio-Version#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
-  <string name="SYS_FILTER_MEMBERS">Mitglieder</string>
+  <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter zum Exportieren</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">Erste Zeile beinhaltet die Spaltenbezeichnungen</string>
   <string name="SYS_FIRSTNAME">Vorname</string>
@@ -702,6 +708,7 @@
   <string name="SYS_FONT">Schriftart</string>
   <string name="SYS_FORMAT">Format</string>
   <string name="SYS_FORMER">Ehemaliger</string>
+  <string name="SYS_FORMER_CONTACTS">Ehemalige Kontakte</string>
   <string name="SYS_FORMER_MEMBERS">Ehemalige Mitglieder</string>
   <string name="SYS_FORMER_PL">Ehemalige</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Ehemalige Rollenmitgliedschaften</string>
@@ -874,10 +881,9 @@
   <string name="SYS_MEMBER">Mitglied</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Mitgliederzuordnung</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Mitglied der Organisation #VAR1#</string>
+  <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Mitglieder zwischen #VAR1# und #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Mitgliederverwaltung genutzt werden. Es werden anschließend in der Mitgliederverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>
-  <string name="SYS_CONTACTS_DESC">Hier können alle aktiven und ehemaligen Mitglieder angezeigt und organisiert werden. Neue Kontakte können importiert oder erstellt werden.</string>
-  <string name="SYS_CURRENT_ROLE_MEMBERSHIP">Aktuelle Rollenmitgliedschaften</string>
   <string name="SYS_MEMBERS_PER_PAGE">Anzahl Teilnehmende pro Seite</string>
   <string name="SYS_MEMBERS_PER_PAGE_DESC">Anzahl der Mitglieder, die in der HTML-Ansicht dargestellt werden. Weitere Mitglieder können durch das Weiterblättern erreicht werden. Die Druckvorschau und der Export sind von diesem Wert nicht betroffen. (Voreinstellung: 25)</string>
   <string name="SYS_MEMBERS_SIMILAR_NAME">Es wurden #VAR1# Mitglieder mit einem ähnlichen Namen gefunden.</string>
@@ -1600,7 +1606,6 @@
   <string name="SYS_USERNAME_DESCRIPTION">Mit diesem Namen kannst du dich anschließend im System anmelden.\nDer Name muss im System eindeutig sein. Ist dein Wunschname bereits vergeben, dann versuche es mit Kombinationen, wie zum Beispiel Andi78 oder StefanT.</string>
   <string name="SYS_USERNAME_OR_EMAIL">Anmeldename oder E-Mail</string>
   <string name="SYS_USERNAME_WITH_TIMESTAMP">#VAR1# am #VAR2# um #VAR3#</string>
-  <string name="SYS_CONTACTS_PER_PAGE">Anzahl der Kontakte pro Seite</string>
   <string name="SYS_USING_CURRENT_VERSION">Du benutzt eine aktuelle #VAR1#Version von Admidio!</string>
   <string name="SYS_UTF8">UTF-8</string>
   <string name="SYS_UTF16BE">UTF-16BE</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -1018,6 +1018,7 @@
   <string name="SYS_OPTIONAL">Optional</string>
   <string name="SYS_ORDER">Reihenfolge</string>
   <string name="SYS_ORGANIZATION">Organisation</string>
+  <string name="SYS_ORGANIZATION_AFFILIATION">Organisationszugehörigkeit</string>
   <string name="SYS_ORGANIZATION_DESC">Name und Kontaktangaben der aktuellen Organisation mit der Möglichkeit, Unterorganisationen zu erstellen und anzuzeigen.</string>
   <string name="SYS_OTHER_TABLES">Andere Tabellen (Module von Drittanbietern; nur für Administratoren sichtbar)</string>
   <string name="SYS_OVERHANG">Überhang</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -710,7 +710,7 @@
   <string name="SYS_FORMER">Ehemaliger</string>
   <string name="SYS_FORMER_CONTACTS">Ehemalige Kontakte</string>
   <string name="SYS_FORMER_MEMBER">Ehemaliges Mitglied</string>
-  <string name="SYS_FORMER_MEMBER_OF_GROUP">Ehemaliges Mitglied der Gruppe #VAR1#</string>
+  <string name="SYS_FORMER_MEMBER_OF_ROLE_GROUP">Ehemaliges Mitglied der Rolle/Gruppe #VAR1#</string>
   <string name="SYS_FORMER_MEMBERS">Ehemalige Mitglieder</string>
   <string name="SYS_FORMER_PL">Ehemalige</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Ehemalige Rollenmitgliedschaften</string>
@@ -736,6 +736,7 @@
   <string name="SYS_GEN_RANDOM_EXCEPTION">Das Programm kann keine zufälligen Zahlen erzeugen.\nError Code: #VAR1#\nError Message: #VAR2#</string>
   <string name="SYS_GEN_RANDOM_TWO_DISTINCT_CHARS">Das Programm erwartet eine Zeichenkette mit mindestens 2 unterschiedlichen Zeichen.</string>
   <string name="SYS_GREETING_CARD">Grußkarte</string>
+  <string name="SYS_GROUP_ROLE_MEMBERSHIP">Rollen-/Gruppenmitgliedschaft</string>
   <string name="SYS_GROUPS_ROLES">Gruppen &amp; Rollen</string>
   <string name="SYS_GROUPS_ROLES_DESC">Übersicht und Verwaltung aller Gruppen und Rollen der Organisation. Es können verschiedene Mitgliederlisten angezeigt, exportiert und eigene Listen erstellt werden.</string>
   <string name="SYS_HALF_YEARLY">Halbjährlich</string>
@@ -882,8 +883,8 @@
   <string name="SYS_MEGAPIXEL">Megapixel</string>
   <string name="SYS_MEMBER">Mitglied</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Mitgliederzuordnung</string>
-  <string name="SYS_MEMBER_OF_GROUP">Mitglied der Gruppe #VAR1#</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Mitglied der Organisation #VAR1#</string>
+  <string name="SYS_MEMBER_OF_ROLE_GROUP">Mitglied der Rolle/Gruppe #VAR1#</string>
   <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Mitglieder zwischen #VAR1# und #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">Eine der hier vorgegebenen Konfigurationen kann für die Anzeige der Mitgliederverwaltung genutzt werden. Es werden anschließend in der Mitgliederverwaltung die Spalten der ausgewählten Listenkonfiguration angezeigt.</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -238,6 +238,7 @@
   <string name="SYS_ALBUM_NOT_APPROVED">Das Album ist momentan gesperrt und wird Gästen und Mitgliedern aus diesem Grund nicht angezeigt.</string>
   <string name="SYS_ALL">Alle</string>
   <string name="SYS_ALL_DAY">Ganztägig</string>
+  <string name="SYS_ALL_MEMBERS">Alle Mitglieder</string>
   <string name="SYS_ALL_ORGANIZATIONS">Alle Organisationen</string>
   <string name="SYS_ALL_ORGANIZATIONS_DESC">Die ausgewählte Kategorie ist für alle Organisationen freigegeben.\nDas gerade bearbeitete Objekt (Veranstaltung, Ankündigung, Profilfeld, Weblink ...) wird also nicht nur in dieser Organisation sichtbar sein, sondern in allen folgenden Organisationen ebenfalls angezeigt: #VAR1#.</string>
   <string name="SYS_ALL_OTHERS">Alle anderen</string>
@@ -682,6 +683,7 @@
   <string name="SYS_FILENAME_INVALID">Der ausgewählte Dateiname #VAR1_BOLD# enthält ungültige Zeichen. Bitte prüfe den Dateinamen.\n\n Die folgenden Sonderzeichen sind nicht erlaubt: ? * ~ ; : " | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">Die Datenbankversion #VAR1# ist höher als die Version der Admidio-Scripte #VAR2#.\n\nAktualisiere bitte deine Admidio-Dateien auf dem FTP-Server #VAR3#mit der aktuelleren Admidio-Version#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
+  <string name="SYS_FILTER_MEMBERS">Mitglieder filtern</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter zum Exportieren</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">Erste Zeile beinhaltet die Spaltenbezeichnungen</string>
   <string name="SYS_FIRSTNAME">Vorname</string>
@@ -968,6 +970,7 @@
   <string name="SYS_NONE">Keiner</string>
   <string name="SYS_NOT_AT_REGISTRATION">Nicht bei Registrierung</string>
   <string name="SYS_NOT_EMPTY">Nicht leer</string>
+  <string name="SYS_NOT_MEMBER_OF_ANY_ORGANIZATION">Kein Mitglied einer Organisation</string>
   <string name="SYS_NOT_MEMBER_OF_ORGANIZATION">Nicht Mitglied der Organisation #VAR1#</string>
   <string name="SYS_NOT_NUMERIC">Bitte in der Bedingung des Feldes #VAR1_BOLD# nur gültige Zahlen verwenden.</string>
   <string name="SYS_NOT_REGISTERED">nicht registriert</string>
@@ -1285,7 +1288,7 @@
   <string name="SYS_SETTINGS">Einstellungen</string>
   <string name="SYS_SHOW_ALL">Alle anzeigen</string>
   <string name="SYS_SHOW_ALL_CONTACTS">Optional alle Kontakte anzeigen</string>
-  <string name="SYS_SHOW_ALL_CONTACTS_DESC">Ist diese Option gesetzt, können neben den aktiven Kontakten der aktuellen Organisation optional auch ehemalige Kontakte und Kontakte anderer Organisationen in der Mitgliederverwaltung angezeigt werden. Ansonsten werden nur aktive Kontakte der aktuellen Organisation angezeigt. Beim Anlegen neuer Kontakte oder beim Zuweisen von Registrierungen wird jedoch weiterhin die gesamte Datenbank aller Organisationen nach bestehenden Kontakten durchsucht. (Voreinstellung: ja)</string>
+  <string name="SYS_SHOW_ALL_CONTACTS_DESC">Ist diese Option gesetzt, können neben den Kontakten der aktuellen Organisation optional auch Kontakte anderer Organisationen in der Mitgliederverwaltung angezeigt werden. Ansonsten werden nur aktive und inaktive Kontakte der aktuellen Organisation angezeigt. Beim Anlegen neuer Kontakte oder beim Zuweisen von Registrierungen wird jedoch weiterhin die gesamte Datenbank aller Organisationen nach bestehenden Kontakten durchsucht. (Voreinstellung: ja)</string>
   <string name="SYS_SHOW_ALL_DESC">Bei gesetzter Einstellung werden neben den aktiven Mitgliedern dieser Organisation auch ehemalige Mitglieder, sowie Mitglieder anderer Organisationen angezeigt.</string>
   <string name="SYS_SHOW_CALENDAR">Kalender anzeigen</string>
   <string name="SYS_SHOW_CAPTCHA_DESC">Für nicht angemeldete Benutzer:innen wird im E-Mailformular bei aktiviertem Captcha ein alphanumerischer Code eingeblendet. Diesen muss die Benutzerin oder der Benutzer vor dem E-Mailversand korrekt eingeben. Dies soll sicherstellen, dass das Formular nicht von Spammern missbraucht werden kann. (Voreinstellung: ja)</string>

--- a/languages/de.xml
+++ b/languages/de.xml
@@ -709,6 +709,8 @@
   <string name="SYS_FORMAT">Format</string>
   <string name="SYS_FORMER">Ehemaliger</string>
   <string name="SYS_FORMER_CONTACTS">Ehemalige Kontakte</string>
+  <string name="SYS_FORMER_MEMBER">Ehemaliges Mitglied</string>
+  <string name="SYS_FORMER_MEMBER_OF_GROUP">Ehemaliges Mitglied der Gruppe #VAR1#</string>
   <string name="SYS_FORMER_MEMBERS">Ehemalige Mitglieder</string>
   <string name="SYS_FORMER_PL">Ehemalige</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Ehemalige Rollenmitgliedschaften</string>
@@ -880,6 +882,7 @@
   <string name="SYS_MEGAPIXEL">Megapixel</string>
   <string name="SYS_MEMBER">Mitglied</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Mitgliederzuordnung</string>
+  <string name="SYS_MEMBER_OF_GROUP">Mitglied der Gruppe #VAR1#</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Mitglied der Organisation #VAR1#</string>
   <string name="SYS_MEMBERS">Mitglieder</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Mitglieder zwischen #VAR1# und #VAR2#</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -708,6 +708,8 @@
   <string name="SYS_FORMAT">Format</string>
   <string name="SYS_FORMER">Former</string>
   <string name="SYS_FORMER_CONTACTS">Former contacts</string>
+  <string name="SYS_FORMER_MEMBER">Former member</string>
+  <string name="SYS_FORMER_MEMBER_OF_GROUP">Former member of group #VAR1#</string>
   <string name="SYS_FORMER_MEMBERS">Former members</string>
   <string name="SYS_FORMER_PL">Former</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Former role memberships</string>
@@ -879,6 +881,7 @@
   <string name="SYS_MEGAPIXEL">Megapixel</string>
   <string name="SYS_MEMBER">Member</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Member assignment</string>
+  <string name="SYS_MEMBER_OF_GROUP">Member of group #VAR1#</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Member of organization #VAR1#</string>
   <string name="SYS_MEMBERS">Members</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Members between #VAR1# and #VAR2#</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -202,6 +202,7 @@
   <string name="SYS_A_TO_Z">A to Z</string>
   <string name="SYS_ABORT">Cancel</string>
   <string name="SYS_ABR_NO" description="Abbreviation for Number">No.</string>
+  <string name="SYS_ACTIVE_CONTACTS">Active contacts</string>
   <string name="SYS_ACTIVE_FORMER_MEMBERS">Active and former members</string>
   <string name="SYS_ACTIVE_FORMER_MEMBERS_SHORT">Active and former</string>
   <string name="SYS_ACTIVE_MEMBERS">Active Members</string>
@@ -237,6 +238,7 @@
   <string name="SYS_ALBUM_FOLDER_NOT_FOUND">Folder could not be found. In case the folder was deleted by using FTP or in case to be  inaccessible, please delete the folder in Admidio.\nGuests without photo management permission can not display selected album.</string>
   <string name="SYS_ALBUM_NOT_APPROVED">The album is currently locked and will not be shown to visitors and members for this reason.</string>
   <string name="SYS_ALL">All</string>
+  <string name="SYS_ALL_CONTACTS">All contacts</string>
   <string name="SYS_ALL_DAY">Full time</string>
   <string name="SYS_ALL_MEMBERS">All members</string>
   <string name="SYS_ALL_ORGANIZATIONS">All organizations</string>
@@ -376,6 +378,8 @@
   <string name="SYS_CONTACT_NOT_FOUND_CREATE_NEW">If the new contact cannot be assigned to an existing contact with a similar name, you can create a new contact and assign the appropriate roles to it.</string>
   <string name="SYS_CONTACT_SIMILAR_NAME">A contact with a similar name was found.</string>
   <string name="SYS_CONTACTS">Contacts</string>
+  <string name="SYS_CONTACTS_DESC">Display and organize all active and former members here. New contacts can be imported or created.</string>
+  <string name="SYS_CONTACTS_PER_PAGE">Number of contacts per page</string>
   <string name="SYS_CONTENT">Content</string>
   <string name="SYS_CONTENTS">Contents</string>
   <string name="SYS_CONTRIBUTION">Contribution</string>
@@ -426,8 +430,10 @@
   <string name="SYS_CURRENT_DATABASE_VERSION">Current database version</string>
   <string name="SYS_CURRENT_EVENTS_OF_ORGA">Current events of organizations #VAR1#</string>
   <string name="SYS_CURRENT_MEMBER">Current member</string>
+  <string name="SYS_CURRENT_ORGANIZATION">Current organization</string>
   <string name="SYS_CURRENT_PASSWORD">Current password</string>
   <string name="SYS_CURRENT_PROFILE_PICTURE">Current profile picture</string>
+  <string name="SYS_CURRENT_ROLE_MEMBERSHIP">Current role memberships</string>
   <string name="SYS_CURRENT_USER_NO_EMAIL" description="Var1 und Var2 erzeugen den Profil-Link">No valid e-mail address has been provided!\n\nPlease provide an e-mail address in your #VAR1#profile#VAR2#.</string>
   <string name="SYS_DATA_CATEGORY_GLOBAL">If this option is enabled, the data (Events, announcements, web links ...) in this category will also appear on the websites of the following organizations:\n#VAR1_BOLD#</string>
   <string name="SYS_DATA_MULTI_ORGA">Data visible to multiple organizations</string>
@@ -701,6 +707,7 @@
   <string name="SYS_FONT">Font</string>
   <string name="SYS_FORMAT">Format</string>
   <string name="SYS_FORMER">Former</string>
+  <string name="SYS_FORMER_CONTACTS">Former contacts</string>
   <string name="SYS_FORMER_MEMBERS">Former members</string>
   <string name="SYS_FORMER_PL">Former</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Former role memberships</string>
@@ -876,8 +883,6 @@
   <string name="SYS_MEMBERS">Members</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Members between #VAR1# and #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">One of the configurations specified here can be used to display the members administration. The columns of the selected list configuration are then displayed in the members administration.</string>
-  <string name="SYS_CONTACTS_DESC">Display and organize all active and former members here. New contacts can be imported or created.</string>
-  <string name="SYS_CURRENT_ROLE_MEMBERSHIP">Current role memberships</string>
   <string name="SYS_MEMBERS_PER_PAGE">Members displayed per page</string>
   <string name="SYS_MEMBERS_PER_PAGE_DESC">Number of members listed in the HTML view. More members can be listed by using the pagination function. This value won\'t affect print preview and export functionality (Default: 25).</string>
   <string name="SYS_MEMBERS_SIMILAR_NAME">Found #VAR1# members with a similar name.</string>
@@ -1600,7 +1605,6 @@
   <string name="SYS_USERNAME_DESCRIPTION">You can log in to the system with this name.\nThe name must be unique in the system. If your desired name is already taken, try combinations such as Andi78 or SteveT.</string>
   <string name="SYS_USERNAME_OR_EMAIL">Username or E-mail</string>
   <string name="SYS_USERNAME_WITH_TIMESTAMP">#VAR1# on #VAR2# at #VAR3#</string>
-  <string name="SYS_CONTACTS_PER_PAGE">Number of contacts per page</string>
   <string name="SYS_USING_CURRENT_VERSION">You are using a current #VAR1#version of Admidio!</string>
   <string name="SYS_UTF8">UTF-8</string>
   <string name="SYS_UTF16BE">UTF-16BE</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -238,6 +238,7 @@
   <string name="SYS_ALBUM_NOT_APPROVED">The album is currently locked and will not be shown to visitors and members for this reason.</string>
   <string name="SYS_ALL">All</string>
   <string name="SYS_ALL_DAY">Full time</string>
+  <string name="SYS_ALL_MEMBERS">All members</string>
   <string name="SYS_ALL_ORGANIZATIONS">All organizations</string>
   <string name="SYS_ALL_ORGANIZATIONS_DESC">The selected category is shared for all organizations.\nThe current object (event, announcement, profile field, web link, etc.) will be visible not only in this organization but also in all the following organizations: #VAR1#.</string>
   <string name="SYS_ALL_OTHERS">All others</string>
@@ -682,6 +683,7 @@
   <string name="SYS_FILENAME_INVALID">The selected file name #VAR1_BOLD# contains invalid characters. Please check the file name.\n\nThe following special characters are not allowed: ? * ~ ; : \" | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">The database version #VAR1# is higher than the version of the Admidio scripts #VAR2#.\n\nPlease update your Admidio files on the server #VAR3# by using a later version of Admidio#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
+  <string name="SYS_FILTER_MEMBERS">Filter members</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter to export</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">First line contains the column name</string>
   <string name="SYS_FIRSTNAME">First name</string>
@@ -968,6 +970,7 @@
   <string name="SYS_NONE">None</string>
   <string name="SYS_NOT_AT_REGISTRATION">Not at registration</string>
   <string name="SYS_NOT_EMPTY">Not empty</string>
+  <string name="SYS_NOT_MEMBER_OF_ANY_ORGANIZATION">Not member of any organization</string>
   <string name="SYS_NOT_MEMBER_OF_ORGANIZATION">Not member of organization #VAR1#</string>
   <string name="SYS_NOT_NUMERIC">Please use a valid number as condition for field #VAR1_BOLD#.</string>
   <string name="SYS_NOT_REGISTERED">Not registered</string>
@@ -1285,7 +1288,7 @@
   <string name="SYS_SETTINGS">Preferences</string>
   <string name="SYS_SHOW_ALL">Show all</string>
   <string name="SYS_SHOW_ALL_CONTACTS">Optional show all contacts</string>
-  <string name="SYS_SHOW_ALL_CONTACTS_DESC">If this option is set, former contacts and contacts of other organizations can optionally be displayed in the member administration in addition to the active contacts of the current organization. Otherwise, only active contacts of the current organization are displayed. However, when creating new contacts or assigning registrations, the entire database of all organizations is still searched for existing contacts. (default: yes)</string>
+  <string name="SYS_SHOW_ALL_CONTACTS_DESC">If this option is set, contacts of other organizations can optionally be displayed in the member administration in addition to the contacts of the current organization. Otherwise, only active and inactive contacts of the current organization are displayed. However, when creating new contacts or assigning registrations, the entire database of all organizations is still searched for existing contacts. (default: yes)</string>
   <string name="SYS_SHOW_ALL_DESC">If this setting is set, former members as well as members of other organizations are displayed in addition to the active members of this organization.</string>
   <string name="SYS_SHOW_CALENDAR">Display calendar</string>
   <string name="SYS_SHOW_CAPTCHA_DESC">For logged out users an alphanumeric text will appear when captcha module is activated. The provided text has to be entered into the proper field. This should prevent abuse of the form by spammers. (default: yes)</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -683,7 +683,7 @@
   <string name="SYS_FILENAME_INVALID">The selected file name #VAR1_BOLD# contains invalid characters. Please check the file name.\n\nThe following special characters are not allowed: ? * ~ ; : \" | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">The database version #VAR1# is higher than the version of the Admidio scripts #VAR2#.\n\nPlease update your Admidio files on the server #VAR3# by using a later version of Admidio#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
-  <string name="SYS_FILTER_MEMBERS">Filter members</string>
+  <string name="SYS_FILTER_MEMBERS">members</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter to export</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">First line contains the column name</string>
   <string name="SYS_FIRSTNAME">First name</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -709,7 +709,7 @@
   <string name="SYS_FORMER">Former</string>
   <string name="SYS_FORMER_CONTACTS">Former contacts</string>
   <string name="SYS_FORMER_MEMBER">Former member</string>
-  <string name="SYS_FORMER_MEMBER_OF_GROUP">Former member of group #VAR1#</string>
+  <string name="SYS_FORMER_MEMBER_OF_ROLE_GROUP">Former member of role/group #VAR1#</string>
   <string name="SYS_FORMER_MEMBERS">Former members</string>
   <string name="SYS_FORMER_PL">Former</string>
   <string name="SYS_FORMER_ROLE_MEMBERSHIP">Former role memberships</string>
@@ -735,6 +735,7 @@
   <string name="SYS_GEN_RANDOM_EXCEPTION">The program can not generate random numbers.\nError Code: #VAR1#\nError Message: #VAR2#</string>
   <string name="SYS_GEN_RANDOM_TWO_DISTINCT_CHARS">The program expects a string with at least 2 different characters.</string>
   <string name="SYS_GREETING_CARD">Greeting card</string>
+  <string name="SYS_GROUP_ROLE_MEMBERSHIP">Group/role membership</string>
   <string name="SYS_GROUPS_ROLES">Groups &amp; roles</string>
   <string name="SYS_GROUPS_ROLES_DESC">Overview and management of all groups and roles of the organization. Different member lists can be displayed, exported and own lists can be created.</string>
   <string name="SYS_HALF_YEARLY">Half-yearly</string>
@@ -881,8 +882,8 @@
   <string name="SYS_MEGAPIXEL">Megapixel</string>
   <string name="SYS_MEMBER">Member</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Member assignment</string>
-  <string name="SYS_MEMBER_OF_GROUP">Member of group #VAR1#</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Member of organization #VAR1#</string>
+  <string name="SYS_MEMBER_OF_ROLE_GROUP">Member of role/group #VAR1#</string>
   <string name="SYS_MEMBERS">Members</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Members between #VAR1# and #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">One of the configurations specified here can be used to display the members administration. The columns of the selected list configuration are then displayed in the members administration.</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -1017,6 +1017,7 @@
   <string name="SYS_OPTIONAL">Optional</string>
   <string name="SYS_ORDER">Order</string>
   <string name="SYS_ORGANIZATION">Organization</string>
+  <string name="SYS_ORGANIZATION_AFFILIATION">Organization affiliation</string>
   <string name="SYS_ORGANIZATION_DESC">Name and contact details of the current organization with the option of creating and displaying sub-organizations.</string>
   <string name="SYS_OTHER_TABLES">Other tables (third-party modules; only visible to administrators)</string>
   <string name="SYS_OVERHANG">Overhang</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -683,7 +683,6 @@
   <string name="SYS_FILENAME_INVALID">The selected file name #VAR1_BOLD# contains invalid characters. Please check the file name.\n\nThe following special characters are not allowed: ? * ~ ; : \" | &lt; &gt;</string>
   <string name="SYS_FILESYSTEM_VERSION_INVALID" description="Var3 and Var4 create link to download">The database version #VAR1# is higher than the version of the Admidio scripts #VAR2#.\n\nPlease update your Admidio files on the server #VAR3# by using a later version of Admidio#VAR4#.</string>
   <string name="SYS_FILTER">Filter</string>
-  <string name="SYS_FILTER_MEMBERS">members</string>
   <string name="SYS_FILTER_TO_EXPORT">Filter to export</string>
   <string name="SYS_FIRST_LINE_COLUMN_NAME">First line contains the column name</string>
   <string name="SYS_FIRSTNAME">First name</string>
@@ -874,6 +873,7 @@
   <string name="SYS_MEMBER">Member</string>
   <string name="SYS_MEMBER_ASSIGNMENT">Member assignment</string>
   <string name="SYS_MEMBER_OF_ORGANIZATION" description="MEM_MEMBER_OF">Member of organization #VAR1#</string>
+  <string name="SYS_MEMBERS">Members</string>
   <string name="SYS_MEMBERS_BETWEEN_PERIOD">Members between #VAR1# and #VAR2#</string>
   <string name="SYS_MEMBERS_CONFIGURATION_DESC">One of the configurations specified here can be used to display the members administration. The columns of the selected list configuration are then displayed in the members administration.</string>
   <string name="SYS_CONTACTS_DESC">Display and organize all active and former members here. New contacts can be imported or created.</string>

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -9,8 +9,9 @@
  *
  * Parameters:
  *
- * members - true : (Default) Show only active contacts of the current organization
- *           false  : Show active and inactive contacts of all organizations in database
+ * mem_show_filter - 0  : (Default) Show only active contacts for current or all organizations
+ *                   1  : Show only inactive contacts for current or all organizations
+ *                   2  : Show active and inactive contacts for current or all organizations
  ***********************************************************************************************
  */
 use Admidio\Infrastructure\Exception;
@@ -25,11 +26,7 @@ try {
     require_once(__DIR__ . '/../../system/login_valid.php');
 
     // Initialize and check the parameters
-    $getMembers = admFuncVariableIsValid($_GET, 'members', 'bool', array('defaultValue' => true));// if only active members should be shown then set parameter
-
-    if (!$gSettingsManager->getBool('contacts_show_all')) {
-        $getMembers = true;
-    }
+    $getMembersShowFiler = admFuncVariableIsValid($_GET, 'mem_show_filter', 'int', array('defaultValue' => 0));
 
     // set headline of the script
     $headline = $gL10n->get('SYS_CONTACTS');// Navigation of the module starts here
@@ -42,7 +39,6 @@ try {
     $_SESSION['contacts_list_configuration'] = $contactsListConfig;
 
     // Link mit dem alle Benutzer oder nur Mitglieder angezeigt werden setzen
-    $flagShowMembers = !$getMembers;// create html page object
     $page = PagePresenter::withHtmlIDAndHeadline('admidio-contacts', $headline);
     $page->setContentFullWidth();
 
@@ -53,8 +49,11 @@ try {
             $("#menu_item_contacts_create_contact").attr("class", "nav-link btn btn-secondary openPopup");
 
             // change mode of users that should be shown
-            $("#mem_show_all").click(function() {
-                window.location.replace("' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/contacts/contacts.php', array('members' => $flagShowMembers)) . '");
+            $("#mem_show_filter").on("change", function() {
+                var form = $("#adm_navbar_filter_form");
+                var contactsSelect = $("#mem_show_filter");
+                contactsSelect.attr("name", "mem_show_filter");
+                form.submit();
             });', true);
 
         $page->addPageFunctionsMenuItem(
@@ -66,19 +65,32 @@ try {
 
         ChangelogService::displayHistoryButton($page, 'contacts', 'users,user_data,members');
 
-        // show checkbox to select all users or only active members
-        if ($gSettingsManager->getBool('contacts_show_all')) {
-            // create filter menu with elements for category
-            $form = new FormPresenter(
-                'adm_navbar_filter_form',
-                'sys-template-parts/form.filter.tpl',
-                '',
-                $page,
-                array('type' => 'navbar', 'setFocus' => false)
-            );
-            $form->addCheckbox('mem_show_all', $gL10n->get('SYS_SHOW_ALL'), $flagShowMembers, array('helpTextId' => 'SYS_SHOW_ALL_DESC'));
-            $form->addToHtmlPage();
-        }
+        // create filter menu with elements for category
+        $form = new FormPresenter(
+            'adm_navbar_filter_form',
+            'sys-template-parts/form.filter.tpl',
+            '',
+            $page,
+            array('type' => 'navbar', 'setFocus' => false)
+        );
+        
+        $selectBoxValues = array(
+            '0' => $gL10n->get('SYS_ACTIVE_MEMBERS'),
+            '1' => $gL10n->get('SYS_FORMER_MEMBERS'),
+            '2' => $gL10n->get('SYS_ALL_MEMBERS')
+        );
+
+        // filter all items
+        $form->addSelectBox(
+            'mem_show_filter',
+            $gL10n->get('SYS_FILTER_MEMBERS'),
+            $selectBoxValues,
+            array(
+                'defaultValue' => $getMembersShowFiler,
+                'showContextDependentFirstEntry' => false
+            )
+        );
+        $form->addToHtmlPage();
 
         // show link to import users
         $page->addPageFunctionsMenuItem(
@@ -112,7 +124,7 @@ try {
     $columnAlignment = $contactsListConfig->getColumnAlignments();
     array_unshift($columnAlignment, 'left', 'left');
     $columnAlignment[] = 'right';
-    $contactsTable->setServerSideProcessing(SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/contacts/contacts_data.php', array('members' => $getMembers)));
+    $contactsTable->setServerSideProcessing(SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/contacts/contacts_data.php', array('mem_show_filter' => $getMembersShowFiler)));
     $contactsTable->setColumnAlignByArray($columnAlignment);
     $contactsTable->disableDatatablesColumnsSort(array(1, count($columnHeading)));// disable sort in last column
     $contactsTable->setDatatablesColumnsNotHideResponsive(array(count($columnHeading)));

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -73,7 +73,7 @@ try {
             $page,
             array('type' => 'navbar', 'setFocus' => false)
         );
-        
+
         $selectBoxValues = array(
             '0' => $gL10n->get('SYS_ACTIVE_MEMBERS'),
             '1' => $gL10n->get('SYS_FORMER_MEMBERS'),
@@ -83,7 +83,7 @@ try {
         // filter all items
         $form->addSelectBox(
             'mem_show_filter',
-            $gL10n->get('SYS_FILTER_MEMBERS'),
+            $gL10n->get('SYS_MEMBERS'),
             $selectBoxValues,
             array(
                 'defaultValue' => $getMembersShowFiler,

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -9,9 +9,10 @@
  *
  * Parameters:
  *
- * mem_show_filter - 0  : (Default) Show only active contacts for current or all organizations
- *                   1  : Show only inactive contacts for current or all organizations
- *                   2  : Show active and inactive contacts for current or all organizations
+ * mem_show_filter - 0  : (Default) Show only active contacts for current organization
+ *                   1  : Show only inactive contacts for current organization
+ *                   2  : Show active and inactive contacts for current organization
+ *                   3  : Show active and inactive contacts for all organizations (only Admin)
  ***********************************************************************************************
  */
 use Admidio\Infrastructure\Exception;

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -75,7 +75,7 @@ try {
         );
 
 
-        if ($gCurrentUser->isAdministrator()) {
+        if ($gCurrentUser->isAdministrator() && $gSettingsManager->getBool('contacts_show_all')) {
             $selectBoxValues = array(
                 '0' => array('0', $gL10n->get('SYS_ACTIVE_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
                 '1' => array('1', $gL10n->get('SYS_FORMER_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -128,7 +128,7 @@ try {
     array_unshift(
         $columnHeading,
         $gL10n->get('SYS_ABR_NO'),
-        '<i class="bi bi-person-fill" data-bs-toggle="tooltip" title="' . $gL10n->get('SYS_MEMBER_OF_ORGANIZATION', array($orgName)) . '"></i>'
+        '<i class="bi bi-person-fill" data-bs-toggle="tooltip" title="' . $gL10n->get('SYS_ORGANIZATION_AFFILIATION') . '"></i>'
     );
     $columnHeading[] = '&nbsp;';
     $columnAlignment = $contactsListConfig->getColumnAlignments();

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -80,8 +80,7 @@ try {
                 '0' => array('0', $gL10n->get('SYS_ACTIVE_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
                 '1' => array('1', $gL10n->get('SYS_FORMER_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
                 '2' => array('2', $gL10n->get('SYS_ALL_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
-                '3' => array('3', $gL10n->get('SYS_FORMER_CONTACTS'), $gL10n->get('SYS_ALL_ORGANIZATIONS')),
-                '4' => array('4', $gL10n->get('SYS_ALL_CONTACTS'), $gL10n->get('SYS_ALL_ORGANIZATIONS'))
+                '3' => array('3', $gL10n->get('SYS_ALL_CONTACTS'), $gL10n->get('SYS_ALL_ORGANIZATIONS'))
             );
         } else {
             $selectBoxValues = array(

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -74,16 +74,27 @@ try {
             array('type' => 'navbar', 'setFocus' => false)
         );
 
-        $selectBoxValues = array(
-            '0' => $gL10n->get('SYS_ACTIVE_MEMBERS'),
-            '1' => $gL10n->get('SYS_FORMER_MEMBERS'),
-            '2' => $gL10n->get('SYS_ALL_MEMBERS')
-        );
+
+        if ($gCurrentUser->isAdministrator()) {
+            $selectBoxValues = array(
+                '0' => array('0', $gL10n->get('SYS_ACTIVE_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
+                '1' => array('1', $gL10n->get('SYS_FORMER_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
+                '2' => array('2', $gL10n->get('SYS_ALL_CONTACTS'), $gL10n->get('SYS_CURRENT_ORGANIZATION')),
+                '3' => array('3', $gL10n->get('SYS_FORMER_CONTACTS'), $gL10n->get('SYS_ALL_ORGANIZATIONS')),
+                '4' => array('4', $gL10n->get('SYS_ALL_CONTACTS'), $gL10n->get('SYS_ALL_ORGANIZATIONS'))
+            );
+        } else {
+            $selectBoxValues = array(
+                '0' => $gL10n->get('SYS_ACTIVE_CONTACTS'),
+                '1' => $gL10n->get('SYS_FORMER_CONTACTS'),
+                '2' => $gL10n->get('SYS_ALL_CONTACTS')
+            );
+        }
 
         // filter all items
         $form->addSelectBox(
             'mem_show_filter',
-            $gL10n->get('SYS_MEMBERS'),
+            $gL10n->get('SYS_CONTACTS'),
             $selectBoxValues,
             array(
                 'defaultValue' => $getMembersShowFiler,

--- a/modules/contacts/contacts_data.php
+++ b/modules/contacts/contacts_data.php
@@ -216,7 +216,6 @@ try {
     } elseif (($getMembersShowFilter === 1) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
-                'showAllMembersDatabase' => false,
                 'showFormerMembers' => true,
                 'showUserUUID' => true,
                 'useConditions' => false,
@@ -226,7 +225,6 @@ try {
     } elseif (($getMembersShowFilter === 2) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
-                'showAllMembersDatabase' => false,
                 'showAllMembersThisOrga' => true,
                 'showFormerMembers' => true,
                 'showUserUUID' => true,
@@ -237,9 +235,7 @@ try {
     } elseif (($getMembersShowFilter === 3) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
-                'showAllMembersDatabase' => ($gSettingsManager->getBool('contacts_show_all')) ? true : false,
-                'showAllMembersThisOrga' => ($gSettingsManager->getBool('contacts_show_all')) ? false : true,
-                'showFormerMembers' => ($gSettingsManager->getBool('contacts_show_all')) ? false : true,
+                'showAllMembersDatabase' => true,
                 'showUserUUID' => true,
                 'useConditions' => false,
                 'useOrderBy' => $useOrderBy

--- a/modules/contacts/contacts_data.php
+++ b/modules/contacts/contacts_data.php
@@ -32,29 +32,31 @@
  *
  * Parameters:
  *
- * members - true : (Default) Show only active contacts of the current organization
- *           false  : Show active and inactive contacts of all organizations in database
- * draw    - Number to validate the right inquiry from DataTables.
- * start   - Paging first record indicator. This is the start point in the current data set
- *           (0 index based - i.e. 0 is the first record).
- * length  - Number of records that the table can display in the current draw. It is expected that
- *           the number of records returned will be equal to this number, unless the server has
- *           fewer records to return. Note that this can be -1 to indicate that all records should
- *           be returned (although that negates any benefits of server-side processing!)
- * search[value] - Global search value.
+ * mem_show_filter  - 0  : (Default) Show only active contacts of the current organization in database
+ *                    1  : Show only inactive contacts of the current or all organizations in database
+ *                    2  : Show active and inactive contacts of the current or all organizations in database
+ * draw             - Number to validate the right inquiry from DataTables.
+ * start            - Paging first record indicator. This is the start point in the current data set
+ *                    (0 index based - i.e. 0 is the first record).
+ * length           - Number of records that the table can display in the current draw. It is expected that
+ *                    the number of records returned will be equal to this number, unless the server has
+ *                    fewer records to return. Note that this can be -1 to indicate that all records should
+ *                    be returned (although that negates any benefits of server-side processing!)
+ * search[value]    - Global search value.
  ***********************************************************************************************
  */
 
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\SecurityUtils;
+use Admidio\Organizations\Entity\Organization;
 
 try {
     require_once(__DIR__ . '/../../system/common.php');
     require_once(__DIR__ . '/../../system/login_valid.php');
 
     // Initialize and check the parameters
-    $getMembers = admFuncVariableIsValid($_GET, 'members', 'bool', array('defaultValue' => true));
+    $getMembersShowFilter = admFuncVariableIsValid($_GET, 'mem_show_filter', 'int', array('defaultValue' => 0));
     $getDraw = admFuncVariableIsValid($_GET, 'draw', 'int', array('requireValue' => true));
     $getStart = admFuncVariableIsValid($_GET, 'start', 'int', array('requireValue' => true));
     $getLength = admFuncVariableIsValid($_GET, 'length', 'int', array('requireValue' => true));
@@ -64,10 +66,8 @@ try {
 
     header('Content-Type: application/json');
 
-    // if only active members should be shown then set parameter
-    if (!$gSettingsManager->getBool('contacts_show_all')) {
-        $getMembers = true;
-    }
+    // show all members of all organizations
+    $getMembersAllOrgs = $gSettingsManager->getBool('contacts_show_all');
 
     if (isset($_SESSION['contacts_list_configuration'])) {
         $contactsListConfig = $_SESSION['contacts_list_configuration'];
@@ -122,7 +122,7 @@ try {
     }
 
     // create a subselect to check if the user is an active member of the current organization
-    $sqlSubSelect = '(SELECT COUNT(*) AS count_this
+    $contactsOfThisOrganizationSelectPlaceholder = '
                     FROM ' . TBL_MEMBERS . '
               INNER JOIN ' . TBL_ROLES . '
                       ON rol_id = mem_rol_id
@@ -130,40 +130,91 @@ try {
                       ON cat_id = rol_cat_id
                    WHERE mem_usr_id  = usr_id
                      AND mem_begin  <= \'' . DATE_NOW . '\'
-                     AND mem_end     > \'' . DATE_NOW . '\'
+                     %s    -- logic placeholder for mem_end
                      AND rol_valid = true
                      AND cat_name_intern <> \'EVENTS\'
                      AND (  cat_org_id = ' . $gCurrentOrgId . '
                          OR cat_org_id IS NULL ))';
 
-    if ($getMembers) {
-        $contactsOfThisOrganizationCondition = ' AND ' . $sqlSubSelect . ' > 0 ';
-        $contactsOfThisOrganizationSelect = ' 1 ';
-    } else {
-        $contactsOfThisOrganizationCondition = '';
-        $contactsOfThisOrganizationSelect = $sqlSubSelect;
+    $placeholderCurrentThisOrg = ' AND mem_end > \'' . DATE_NOW . '\'';
+    $placeholderFormerThisOrg = ' AND mem_end <= \'' . DATE_NOW . '\'
+            AND NOT EXISTS (
+                SELECT 1
+                FROM ' . TBL_MEMBERS . '
+            INNER JOIN ' . TBL_ROLES . '      ON rol_id    = mem_rol_id
+            INNER JOIN ' . TBL_CATEGORIES . ' ON cat_id    = rol_cat_id
+                WHERE mem_usr_id   = usr_id
+                AND mem_begin   <= \'' . DATE_NOW . '\'
+                AND mem_end      > \'' . DATE_NOW . '\'
+                AND rol_valid    = true
+                AND cat_name_intern <> \'EVENTS\'
+                AND (  cat_org_id   = ' . $gCurrentOrgId . '
+                         OR cat_org_id IS NULL ))';
+
+    if ($getMembersShowFilter === 0) {
+        // show only active members of the current organization
+        $contactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderCurrentThisOrg);
+        $formerContactsOfThisOrganizationSelect = ' 0 '; // no former members of the current organization should be shown
+    } elseif ($getMembersShowFilter === 1) {
+        // show only former members of the current organization
+        $contactsOfThisOrganizationSelect = ' 0 '; // no current members of the current organization should be shown
+        $formerContactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this_former' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderFormerThisOrg);
+    } elseif ($getMembersShowFilter === 2) {
+        // show all members of all organizations
+        $contactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderCurrentThisOrg);
+        $formerContactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this_former' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderFormerThisOrg);
     }
 
     // create a subselect to check if the user is also an active member of another organization
-    $contactsOfOtherOrganizationSelect = ' 0 ';
-    if ($gCurrentOrganization->countAllRecords() > 1) {
-        $contactsOfOtherOrganizationSelect = '
-        (SELECT COUNT(*) AS count_other
-           FROM ' . TBL_MEMBERS . '
-     INNER JOIN ' . TBL_ROLES . '
-             ON rol_id = mem_rol_id
-     INNER JOIN ' . TBL_CATEGORIES . '
-             ON cat_id = rol_cat_id
-          WHERE mem_usr_id  = usr_id
-            AND mem_begin  <= \'' . DATE_NOW . '\'
-            AND mem_end     > \'' . DATE_NOW . '\'
-            AND rol_valid = true
-            AND cat_name_intern <> \'EVENTS\'
-            AND cat_org_id <> ' . $gCurrentOrgId . ')';
+    if ($gCurrentOrganization->countAllRecords() > 1  && $gCurrentUser->isAdministratorUsers()) {
+        $contactsOfOtherOrganizationSelectPlaceholder = '
+            FROM ' . TBL_MEMBERS . '
+        INNER JOIN ' . TBL_ROLES . '
+                ON rol_id = mem_rol_id
+        INNER JOIN ' . TBL_CATEGORIES . '
+                ON cat_id = rol_cat_id
+            WHERE mem_usr_id  = usr_id
+                AND mem_begin  <= \'' . DATE_NOW . '\'
+                %s    -- logic placeholder for mem_end
+                AND rol_valid = true
+                AND cat_name_intern <> \'EVENTS\'
+                AND cat_org_id <> ' . $gCurrentOrgId . ')';
+
+        $placeholderCurrentOtherOrg = "AND mem_end > '" . DATE_NOW . "'";
+        $placeholderFormerOtherOrg = "AND mem_end <= '" . DATE_NOW . "'
+            AND NOT EXISTS (
+                SELECT 1
+                FROM " . TBL_MEMBERS . "
+            INNER JOIN " . TBL_ROLES . "      ON rol_id    = mem_rol_id
+            INNER JOIN " . TBL_CATEGORIES . " ON cat_id    = rol_cat_id
+                WHERE mem_usr_id   = usr_id
+                AND mem_begin   <= '" . DATE_NOW . "'
+                AND mem_end      > '" . DATE_NOW . "'
+                AND rol_valid    = true
+                AND cat_name_intern <> 'EVENTS'
+                AND cat_org_id   <> " . $gCurrentOrgId . ")";
+
+        if ($getMembersShowFilter === 0) {
+            // show only active members of another organization or all members of all organizations
+            $contactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderCurrentOtherOrg);
+            $formerContactsOfOtherOrganizationSelect = ' 0 '; // no former members of other organizations should be shown
+        } elseif ($getMembersShowFilter === 1) {
+            // show only former members of another organization
+            $contactsOfOtherOrganizationSelect = ' 0 '; // no current members of other organizations should be shown
+            $formerContactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other_former' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderFormerOtherOrg);
+        } elseif ($getMembersShowFilter === 2) {
+            // show all members of all organizations
+            $contactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderCurrentOtherOrg);
+            $formerContactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other_former' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderFormerOtherOrg);
+        }
+    } else {
+        // if there is only one organization then no other members of other organizations should be shown
+        $contactsOfOtherOrganizationSelect = ' 0 ';
+        $formerContactsOfOtherOrganizationSelect = ' 0 ';
     }
 
-    // create sql to show all members (not accepted users should not be shown)
-    if ($getMembers && $gCurrentUser->isAdministratorUsers()) {
+    // create main sql statement
+    if (($getMembersShowFilter === 0) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
                 'showAllMembersThisOrga' => true,
@@ -172,10 +223,22 @@ try {
                 'useOrderBy' => $useOrderBy
             )
         );
-    } elseif ($gCurrentUser->isAdministratorUsers()) {
+    } elseif (($getMembersShowFilter === 1) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
-                'showAllMembersDatabase' => true,
+                'showAllMembersDatabase' => $gSettingsManager->getBool('contacts_show_all') ? true : false,
+                'showFormerMembers' => true,
+                'showUserUUID' => true,
+                'useConditions' => false,
+                'useOrderBy' => $useOrderBy
+            )
+        );
+    } elseif (($getMembersShowFilter === 2) && $gCurrentUser->isAdministratorUsers()) {
+        $mainSql = $contactsListConfig->getSql(
+            array(
+                'showAllMembersDatabase' => $gSettingsManager->getBool('contacts_show_all') ? true : false,
+                'showAllMembersThisOrga' => $gSettingsManager->getBool('contacts_show_all') ? false : true,
+                'showFormerMembers' => $gSettingsManager->getBool('contacts_show_all') ? false : true,
                 'showUserUUID' => true,
                 'useConditions' => false,
                 'useOrderBy' => $useOrderBy
@@ -192,7 +255,18 @@ try {
         );
     }
 
-    $mainSql = 'SELECT DISTINCT ' . $contactsOfThisOrganizationSelect . ' AS member_this_orga, ' . $contactsOfOtherOrganizationSelect . ' AS member_other_orga, usr_login_name as loginname,
+    $mainSql = 'SELECT DISTINCT ' . $contactsOfThisOrganizationSelect . ' AS member_this_orga, ' . $formerContactsOfThisOrganizationSelect . ' AS former_member_this_orga, ' . $contactsOfOtherOrganizationSelect . ' AS member_other_orga, ' . $formerContactsOfOtherOrganizationSelect . ' AS former_member_other_orga, 
+                (SELECT GROUP_CONCAT(DISTINCT cat_org.cat_org_id
+                        ORDER BY cat_org.cat_org_id
+                        SEPARATOR \',\')
+                    FROM ' . TBL_MEMBERS . ' AS mem_org
+                    INNER JOIN ' . TBL_ROLES . ' AS rol_org
+                        ON rol_org.rol_id = mem_org.mem_rol_id
+                    INNER JOIN ' . TBL_CATEGORIES . ' AS cat_org
+                        ON cat_org.cat_id = rol_org.rol_cat_id
+                    WHERE mem_org.mem_usr_id = usr_id
+                ) AS member_org_ids,
+                usr_login_name as loginname,
                 (SELECT email.usd_value FROM ' . TBL_USER_DATA . ' email
                   WHERE  email.usd_usr_id = usr_id
                     AND email.usd_usf_id = ? /* $gProfileFields->getProperty(\'email\', \'usf_id\') */
@@ -220,7 +294,7 @@ try {
     $queryParamsMain = array_merge($queryParamsEmail, $queryParamsSearch);
     $mglStatement = $gDb->queryPrepared($sql, $queryParamsMain); // TODO add more params
 
-    $orgName = $gCurrentOrganization->getValue('org_longname');
+    $currentOrgName = $gCurrentOrganization->getValue('org_longname');
     $rowNumber = $getStart; // count for every row
 
     // get count of all members and store into json
@@ -232,11 +306,27 @@ try {
 
     while ($row = $mglStatement->fetch(PDO::FETCH_BOTH)) {
         ++$rowNumber;
-        $ColumnNumberSql = 5;
+        $ColumnNumberSql = 8;
         $columnNumberJson = 2;
 
         $contactsOfThisOrganization = (bool)$row['member_this_orga'];
+        $formerContactsOfThisOrganization = (bool)$row['former_member_this_orga'];
         $contactsOfOtherOrganization = (bool)$row['member_other_orga'];
+        $formerContactsOfOtherOrganization = (bool)$row['former_member_other_orga'];
+
+        $otherOrgName = '';
+        if ($row['member_org_ids'] !== null) {
+            $usrOrgIds = explode(',', $row['member_org_ids']);
+            if (count($usrOrgIds) > 0) {
+                // remove current organization from the list of user organizations
+                $usrOrgIds = array_values(array_diff($usrOrgIds, array($gCurrentOrgId)));
+                // if user is member of more than one organization then show the name of the first organization
+                if (count($usrOrgIds) > 0) {
+                    $otherOrg = new Organization($gDb, $usrOrgIds[0]);
+                    $otherOrgName = $otherOrg->getValue('org_longname');
+                }
+            }
+        }
 
         // Create row and add first column
         $columnValues = array('DT_RowId' => 'row_members_' . $row['usr_uuid'], '0' => $rowNumber);
@@ -244,10 +334,19 @@ try {
         // Add icon for member or no member of the organization
         if ($contactsOfThisOrganization) {
             $icon = 'bi-person-fill';
-            $iconText = $gL10n->get('SYS_MEMBER_OF_ORGANIZATION', array($orgName));
+            $iconText = $gL10n->get('SYS_MEMBER_OF_ORGANIZATION', array($currentOrgName));
+        } elseif ($formerContactsOfThisOrganization) {
+            $icon = 'bi-person-fill-x';
+            $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ORGANIZATION', array($currentOrgName));
+        } elseif ($contactsOfOtherOrganization) {
+            $icon = 'bi-person-fill text-warning';
+            $iconText = $gL10n->get('SYS_MEMBER_OF_ORGANIZATION', array($otherOrgName));
+        } elseif ($formerContactsOfOtherOrganization) {
+            $icon = 'bi-person-fill-x text-warning';
+            $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ORGANIZATION', array($otherOrgName));
         } else {
             $icon = 'bi-person-fill-dash text-danger';
-            $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ORGANIZATION', array($orgName));
+            $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ANY_ORGANIZATION');
         }
 
         $columnValues['1'] = '<a href="' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/profile/profile.php', array('user_uuid' => $row['usr_uuid'])) . '">

--- a/modules/contacts/contacts_data.php
+++ b/modules/contacts/contacts_data.php
@@ -333,16 +333,16 @@ try {
             $icon = 'bi-person-fill-check';
             $iconText = $gL10n->get('SYS_MEMBER_OF_ORGANIZATION', array($currentOrgName));
         } elseif ($formerContactsOfThisOrganization) {
-            $icon = 'bi-person-fill-x';
+            $icon = 'bi-person-fill-dash';
             $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ORGANIZATION', array($currentOrgName));
         } elseif ($contactsOfOtherOrganization) {
             $icon = 'bi-person-fill-check text-warning';
             $iconText = $gL10n->get('SYS_MEMBER_OF_ORGANIZATION', array($otherOrgName));
         } elseif ($formerContactsOfOtherOrganization) {
-            $icon = 'bi-person-fill-x text-warning';
+            $icon = 'bi-person-fill-dash text-warning';
             $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ORGANIZATION', array($otherOrgName));
         } else {
-            $icon = 'bi-person-fill-dash text-danger';
+            $icon = 'bi-person-fill-x text-danger';
             $iconText = $gL10n->get('SYS_NOT_MEMBER_OF_ANY_ORGANIZATION');
         }
 

--- a/modules/contacts/contacts_data.php
+++ b/modules/contacts/contacts_data.php
@@ -32,9 +32,10 @@
  *
  * Parameters:
  *
- * mem_show_filter  - 0  : (Default) Show only active contacts of the current organization in database
- *                    1  : Show only inactive contacts of the current or all organizations in database
- *                    2  : Show active and inactive contacts of the current or all organizations in database
+ * mem_show_filter - 0  : (Default) Show only active contacts for current organization
+ *                    1  : Show only inactive contacts for current organization
+ *                    2  : Show active and inactive contacts for current organization
+ *                    3  : Show active and inactive contacts for all organizations (only Admin)
  * draw             - Number to validate the right inquiry from DataTables.
  * start            - Paging first record indicator. This is the start point in the current data set
  *                    (0 index based - i.e. 0 is the first record).

--- a/modules/contacts/contacts_data.php
+++ b/modules/contacts/contacts_data.php
@@ -155,11 +155,11 @@ try {
         // show only active members of the current organization
         $contactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderCurrentThisOrg);
         $formerContactsOfThisOrganizationSelect = ' 0 '; // no former members of the current organization should be shown
-    } elseif ($getMembersShowFilter === 1) {
+    } elseif ($getMembersShowFilter === 1 || $getMembersShowFilter === 3) {
         // show only former members of the current organization
         $contactsOfThisOrganizationSelect = ' 0 '; // no current members of the current organization should be shown
         $formerContactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this_former' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderFormerThisOrg);
-    } elseif ($getMembersShowFilter === 2) {
+    } elseif ($getMembersShowFilter === 2 || $getMembersShowFilter === 4) {
         // show all members of all organizations
         $contactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderCurrentThisOrg);
         $formerContactsOfThisOrganizationSelect = '(SELECT COUNT(*) AS count_this_former' . sprintf($contactsOfThisOrganizationSelectPlaceholder, $placeholderFormerThisOrg);
@@ -198,11 +198,11 @@ try {
             // show only active members of another organization or all members of all organizations
             $contactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderCurrentOtherOrg);
             $formerContactsOfOtherOrganizationSelect = ' 0 '; // no former members of other organizations should be shown
-        } elseif ($getMembersShowFilter === 1) {
+        } elseif ($getMembersShowFilter === 1 || $getMembersShowFilter === 3) {
             // show only former members of another organization
             $contactsOfOtherOrganizationSelect = ' 0 '; // no current members of other organizations should be shown
             $formerContactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other_former' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderFormerOtherOrg);
-        } elseif ($getMembersShowFilter === 2) {
+        } elseif ($getMembersShowFilter === 2 || $getMembersShowFilter === 4) {
             // show all members of all organizations
             $contactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderCurrentOtherOrg);
             $formerContactsOfOtherOrganizationSelect = '(SELECT COUNT(*) AS count_other_former' . sprintf($contactsOfOtherOrganizationSelectPlaceholder, $placeholderFormerOtherOrg);
@@ -226,7 +226,7 @@ try {
     } elseif (($getMembersShowFilter === 1) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
-                'showAllMembersDatabase' => $gSettingsManager->getBool('contacts_show_all') ? true : false,
+                'showAllMembersDatabase' => false,
                 'showFormerMembers' => true,
                 'showUserUUID' => true,
                 'useConditions' => false,
@@ -236,9 +236,30 @@ try {
     } elseif (($getMembersShowFilter === 2) && $gCurrentUser->isAdministratorUsers()) {
         $mainSql = $contactsListConfig->getSql(
             array(
-                'showAllMembersDatabase' => $gSettingsManager->getBool('contacts_show_all') ? true : false,
-                'showAllMembersThisOrga' => $gSettingsManager->getBool('contacts_show_all') ? false : true,
-                'showFormerMembers' => $gSettingsManager->getBool('contacts_show_all') ? false : true,
+                'showAllMembersDatabase' => false,
+                'showAllMembersThisOrga' => true,
+                'showFormerMembers' => true,
+                'showUserUUID' => true,
+                'useConditions' => false,
+                'useOrderBy' => $useOrderBy
+            )
+        );
+    } elseif (($getMembersShowFilter === 3) && $gCurrentUser->isAdministratorUsers()) {
+        $mainSql = $contactsListConfig->getSql(
+            array(
+                'showAllMembersDatabase' => ($gSettingsManager->getBool('contacts_show_all')) ? true : false,
+                'showFormerMembers' => true,
+                'showUserUUID' => true,
+                'useConditions' => false,
+                'useOrderBy' => $useOrderBy
+            )
+        );
+    } elseif (($getMembersShowFilter === 4) && $gCurrentUser->isAdministratorUsers()) {
+        $mainSql = $contactsListConfig->getSql(
+            array(
+                'showAllMembersDatabase' => ($gSettingsManager->getBool('contacts_show_all')) ? true : false,
+                'showAllMembersThisOrga' => ($gSettingsManager->getBool('contacts_show_all')) ? false : true,
+                'showFormerMembers' => ($gSettingsManager->getBool('contacts_show_all')) ? false : true,
                 'showUserUUID' => true,
                 'useConditions' => false,
                 'useOrderBy' => $useOrderBy

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -690,7 +690,8 @@ try {
                     $iconText = $gL10n->get('SYS_MEMBER_OF_ROLE_GROUP', array($roleName));
                 }
                 unset($columnValues['mem_former']);
-                $columnValues = array('mem_former' => '<i class="bi ' . $icon . '" data-bs-toggle="tooltip" title="' . $iconText . '"></i>') + $columnValues;
+                $sortingValue = $member['mem_former'] ? 1 : 0;
+                $columnValues = array('mem_former' => array('value' => '<i class="bi ' . $icon . '" data-bs-toggle="tooltip" title="' . $iconText . '"></i>', 'order' => $sortingValue)) + $columnValues;
             }
 
             // in html mode we add a column with leader/member information to

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -256,7 +256,7 @@ try {
 
         if ($getMembersShowFiler === 2) {
             $arrColumnNames = $list->getColumnNames();
-            $arrColumnNames[] = $gL10n->get('INS_MEMBERSHIP');
+            $arrColumnNames[] = $gL10n->get('SYS_GROUP_ROLE_MEMBERSHIP');
              $listData->setColumnHeadlines($arrColumnNames);
         } else {
             $listData->setColumnHeadlines($list->getColumnNames());
@@ -607,7 +607,7 @@ try {
     if ($getMode === 'html') {
          // add column for former status
         if ($getMembersShowFiler === 2) {
-            array_unshift($arrColumnNames, '<i class="bi bi-person-fill" data-bs-toggle="tooltip" title="' . $gL10n->get('INS_MEMBERSHIP') . '"></i>');
+            array_unshift($arrColumnNames, '<i class="bi bi-person-fill" data-bs-toggle="tooltip" title="' . $gL10n->get('SYS_GROUP_ROLE_MEMBERSHIP') . '"></i>');
             array_unshift($arrColumnAlign, 'center');
         }
 
@@ -621,7 +621,7 @@ try {
         }
     }
     elseif ($getMembersShowFiler === 2) {
-        array_unshift($arrColumnNames, $gL10n->get('INS_MEMBERSHIP'));
+        array_unshift($arrColumnNames, $gL10n->get('SYS_GROUP_ROLE_MEMBERSHIP'));
         array_unshift($arrColumnAlign, 'left');
     }
 
@@ -683,11 +683,11 @@ try {
                 // Add icon for member or no member of the organization
                 if ($member['mem_former']) {
                     $icon = 'bi-person-fill-x text-danger';
-                    $iconText = $gL10n->get('SYS_FORMER_MEMBER_OF_GROUP', array($roleName));
+                    $iconText = $gL10n->get('SYS_FORMER_MEMBER_OF_ROLE_GROUP', array($roleName));
                 }
                 else {
                     $icon = 'bi-person-fill-check';
-                    $iconText = $gL10n->get('SYS_MEMBER_OF_GROUP', array($roleName));
+                    $iconText = $gL10n->get('SYS_MEMBER_OF_ROLE_GROUP', array($roleName));
                 }
                 unset($columnValues['mem_former']);
                 $columnValues = array('mem_former' => '<i class="bi ' . $icon . '" data-bs-toggle="tooltip" title="' . $iconText . '"></i>') + $columnValues;

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -460,7 +460,7 @@ try {
             // filter all items
             $form->addSelectBox(
                 'mem_show_filter',
-                $gL10n->get('SYS_FILTER_MEMBERS'),
+                $gL10n->get('SYS_MEMBERS'),
                 $selectBoxValues,
                 array(
                     'defaultValue' => $getMembersShowFiler,

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -717,15 +717,6 @@ try {
 
             // add a column with the row number at the first column
             array_unshift($columnValues, $listRowNumber);
-        } else {
-            // add a column with former status
-            if (isset($member['mem_former'])) {
-                if ($member['mem_former']) {
-                    $columnValues = array('mem_former' => $gL10n->get('SYS_FORMER_MEMBER')) + $columnValues;
-                } else {
-                    $columnValues = array('mem_former' => $gL10n->get('SYS_MEMBER')) + $columnValues;
-                }
-            }
         }
 
         if ($isAdministratorUserstatus) {

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -682,7 +682,7 @@ try {
             if (isset($member['mem_former'])) {
                 // Add icon for member or no member of the organization
                 if ($member['mem_former']) {
-                    $icon = 'bi-person-fill-x text-danger';
+                    $icon = 'bi-person-fill-dash text-danger';
                     $iconText = $gL10n->get('SYS_FORMER_MEMBER_OF_ROLE_GROUP', array($roleName));
                 }
                 else {

--- a/src/Roles/Entity/ListConfiguration.php
+++ b/src/Roles/Entity/ListConfiguration.php
@@ -924,17 +924,7 @@ class ListConfiguration extends Entity
         }
 
         // Set SQL-Statement
-        if ($optionsAll['showAllMembersDatabase'] && $optionsAll['showFormerMembers']) {
-            $sql = 'SELECT DISTINCT ' . $sqlMemLeader . $sqlIdColumns . $sqlColumnNames . ', ' . $sqlFormerSelect . '
-                      FROM ' . TBL_USERS . '
-                INNER JOIN ' . TBL_MEMBERS . ' mem
-                        ON mem_usr_id = usr_id
-                           ' . $sqlJoin . '
-                     WHERE usr_valid = true ' .
-                $sqlMemberStatus .
-                $sqlWhere .
-                $sqlOrderBys;
-        } elseif ($optionsAll['showAllMembersThisOrga'] && $optionsAll['showFormerMembers']) {
+        if ($optionsAll['showAllMembersThisOrga'] && $optionsAll['showFormerMembers']) {
             $sql = 'SELECT DISTINCT ' . $sqlMemLeader . $sqlIdColumns . $sqlColumnNames . ', ' . $sqlFormerSelect . '
                       FROM ' . TBL_MEMBERS . ' mem
                 INNER JOIN ' . TBL_ROLES . '

--- a/src/Roles/ValueObject/ListData.php
+++ b/src/Roles/ValueObject/ListData.php
@@ -82,6 +82,8 @@ class ListData
      */
     protected function prepareOutputFormat(string $outputFormat): array
     {
+        global $gL10n;
+
         $outputData = array();
         $startRow = 0;
 
@@ -96,6 +98,13 @@ class ListData
             foreach($this->data[$rowNumber] as $columnValueKey => $columnValue) {
                 if (in_array($columnValueKey, array('mem_leader', 'usr_uuid'))) {
                     $outputData[$rowNumber][$columnValueKey] = $columnValue;
+                } elseif ($columnValueKey === 'mem_former') {
+                    if ($outputFormat === 'html' || $outputFormat === 'print') {
+                     $outputData[$rowNumber][$columnValueKey] = (bool)$columnValue;
+                    } else {
+                        // For all other formats, we convert the boolean value to a string
+                        $outputData[$rowNumber][$columnValueKey] = (bool)$columnValue ? $gL10n->get('SYS_FORMER_MEMBER') : $gL10n->get('SYS_MEMBER');
+                    }
                 } else {
                     $outputData[$rowNumber][$columnValueKey] =
                         $this->listConfiguration->convertColumnContentForOutput(

--- a/src/Roles/ValueObject/ListData.php
+++ b/src/Roles/ValueObject/ListData.php
@@ -99,8 +99,9 @@ class ListData
                 if (in_array($columnValueKey, array('mem_leader', 'usr_uuid'))) {
                     $outputData[$rowNumber][$columnValueKey] = $columnValue;
                 } elseif ($columnValueKey === 'mem_former') {
-                    if ($outputFormat === 'html' || $outputFormat === 'print') {
-                     $outputData[$rowNumber][$columnValueKey] = (bool)$columnValue;
+                    if ($outputFormat === 'html' || $outputFormat === 'print' || $outputFormat === 'pdf') {
+                        // For HTML, print, and pdf formats, we keep the boolean value as is
+                        $outputData[$rowNumber][$columnValueKey] = (bool)$columnValue;
                     } else {
                         // For all other formats, we convert the boolean value to a string
                         $outputData[$rowNumber][$columnValueKey] = (bool)$columnValue ? $gL10n->get('SYS_FORMER_MEMBER') : $gL10n->get('SYS_MEMBER');

--- a/src/UI/Presenter/GroupsRolesPresenter.php
+++ b/src/UI/Presenter/GroupsRolesPresenter.php
@@ -219,7 +219,7 @@ class GroupsRolesPresenter extends PagePresenter
                     $textFormerMembers = $gL10n->get('SYS_FORMER_PL');
                 }
 
-                $html .= '&nbsp;&nbsp;(<a href="' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/groups-roles/lists_show.php', array('role_list' => $row['rol_uuid'], 'show_former_members' => 1)) . '">' . $row['num_former'] . ' ' . $textFormerMembers . '</a>) ';
+                $html .= '&nbsp;&nbsp;(<a href="' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/groups-roles/lists_show.php', array('role_list' => $row['rol_uuid'], 'mem_show_filter' => 1)) . '">' . $row['num_former'] . ' ' . $textFormerMembers . '</a>) ';
             }
 
             if ($row['num_leader'] > 0) {

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -1307,13 +1307,13 @@ class User extends Entity
         global $gSettingsManager;
 
         if (
-            (int)$gSettingsManager->get('groups_roles_show_former_members') !== 1
+            (int)$gSettingsManager->get('groups_roles_show_former_members') === 1
             && ($this->checkRolesRight('rol_assign_roles')
                 || ($this->isLeaderOfRole($roleId) && in_array($this->rolesMembershipLeader[$roleId], array(1, 3), true)))
         ) {
             return true;
         } elseif (
-            (int)$gSettingsManager->get('groups_roles_show_former_members') !== 2
+            (int)$gSettingsManager->get('groups_roles_show_former_members') === 2
             && ($this->checkRolesRight('rol_edit_user')
                 || ($this->isLeaderOfRole($roleId) && in_array($this->rolesMembershipLeader[$roleId], array(2, 3), true)))
         ) {

--- a/themes/simple/css/admidio.css
+++ b/themes/simple/css/admidio.css
@@ -27,7 +27,7 @@
     --bs-link-color: var(--bs-primary);
     --bs-link-color-rgb: var(--bs-primary-rgb);
     --bs-link-hover-color: color-mix(in srgb, var(--bs-link-color) 80%, white);
-    --bs-link-hover-color-rgb: color-mix(in srgb, var(--bs-link-color-rgb) 80%, white);
+    --bs-link-hover-color-rgb: color-mix(in srgb, rgb(var(--bs-link-color-rgb)) 80%, white);
     --bs-focus-ring-color: #c4e9ef;
 }
 


### PR DESCRIPTION
Implements a select box that lets you filter group members or contacts by status:
- active
- inactive/former
- active and inactive/former

@Fasse: Can you check if the changes made to `ListConfiguration.php` causes any unwanted side-effects?  I haven’t found any myself.