### PR TITLE
Add new static-subinformation form control that shows one row of information and offers an open/close caret with additional lines of information

### DIFF
--- a/src/SSO/Service/OIDCService.php
+++ b/src/SSO/Service/OIDCService.php
@@ -196,14 +196,15 @@ class OIDCService extends SSOService {
      *   where the 'style' key is optional, but 'value' and 'id' are required.
      */
     public function getStaticSettings() : array {
+        global $gL10n;
         $discoveryURL = $this->getDiscoveryURL();
         $staticSettings = array(
-            'SYS_SSO_OIDC_DISCOVERY_URL' => ['value' => '<a href="' . $discoveryURL . '">' . $discoveryURL . '</a>', 'id' => 'discovery_URL'],
-            'SYS_SSO_OIDC_AUTH_ENDPOINT' => ['value' => $this->getAuthorizationEndpoint(), 'id' => 'auth_endpoint'],
-            'SYS_SSO_OIDC_TOKEN_ENDPOINT' => ['value' => $this->getTokenEndpoint(),'id' => 'token_endpoint'],
-            'SYS_SSO_OIDC_USERINFO_ENDPOINT' => ['value' => $this->getUserinfoEndpoint(),'id' => 'userinfo_endpoint'],
-            'SYS_SSO_OIDC_JWKS_ENDPOINT' => ['value' => $this->getJWKSEndpoint(),'id' => 'jwks_endpoint'],
-            'SYS_SSO_OIDC_LOGOUT_ENDPOINT' => ['value' => $this->getLogoutEndpoint(),'id' => 'logout_endpoint'],
+            $gL10n->get('SYS_SSO_OIDC_DISCOVERY_URL') => ['value' => '<a href="' . $discoveryURL . '">' . $discoveryURL . '</a>', 'id' => 'discovery_URL'],
+            $gL10n->get('SYS_SSO_OIDC_AUTH_ENDPOINT') => ['value' => $this->getAuthorizationEndpoint(), 'id' => 'auth_endpoint'],
+            $gL10n->get('SYS_SSO_OIDC_TOKEN_ENDPOINT') => ['value' => $this->getTokenEndpoint(),'id' => 'token_endpoint'],
+            $gL10n->get('SYS_SSO_OIDC_USERINFO_ENDPOINT') => ['value' => $this->getUserinfoEndpoint(),'id' => 'userinfo_endpoint'],
+            $gL10n->get('SYS_SSO_OIDC_JWKS_ENDPOINT') => ['value' => $this->getJWKSEndpoint(),'id' => 'jwks_endpoint'],
+            $gL10n->get('SYS_SSO_OIDC_LOGOUT_ENDPOINT') => ['value' => $this->getLogoutEndpoint(),'id' => 'logout_endpoint'],
         );
         return $staticSettings;
     }

--- a/src/SSO/Service/SAMLService.php
+++ b/src/SSO/Service/SAMLService.php
@@ -108,7 +108,7 @@ class SAMLService extends SSOService {
      *   where the 'style' key is optional, but 'value' and 'id' are required.
      */
     public function getStaticSettings() : array {
-        global $gSettingsManager;
+        global $gSettingsManager, $gL10n;
 
         // Load Certificate PEM
         $signatureKeyID = $gSettingsManager->get('sso_saml_signing_key');
@@ -117,10 +117,10 @@ class SAMLService extends SSOService {
 
         $metaURL = $this->getMetadataUrl();
         $staticSettings = array(
-            'SYS_SSO_SAML_METADATA_URL' => ['value' => '<a href="' . $metaURL . '">' . $metaURL . '</a>', 'id' => 'metadata_URL'],
-            'SYS_SSO_SAML_SSO_ENDPOINT' => ['value' => $this->getSsoEndpoint(), 'id' => 'SSO_endpoint'],
-            'SYS_SSO_SAML_SLO_ENDPOINT' => ['value' => $this->getSloEndpoint(),'id' => 'SLO_endpoint'],
-            'SYS_SSO_KEY_CERTIFICATE'   => ['value' => $idpCertPem,  'id' => 'wrapper_certificate', 'style' => 'white-space: pre-wrap; word-wrap: break-word; background-color: #f8f9fa;
+            $gL10n->get('SYS_SSO_SAML_METADATA_URL') => ['value' => '<a href="' . $metaURL . '">' . $metaURL . '</a>', 'id' => 'metadata_URL'],
+            $gL10n->get('SYS_SSO_SAML_SSO_ENDPOINT') => ['value' => $this->getSsoEndpoint(), 'id' => 'SSO_endpoint'],
+            $gL10n->get('SYS_SSO_SAML_SLO_ENDPOINT') => ['value' => $this->getSloEndpoint(),'id' => 'SLO_endpoint'],
+            $gL10n->get('SYS_SSO_KEY_CERTIFICATE')   => ['value' => $idpCertPem,  'id' => 'wrapper_certificate', 'style' => 'white-space: pre-wrap; word-wrap: break-word; background-color: #f8f9fa;
                     border: 1px solid #ced4da; padding: 0.375rem 0.75rem; font-family: monospace; width: 100%;
                     max-height: 120px; overflow: auto; border-radius: 0.375rem; font-size: smaller;']
         );

--- a/src/SSO/Service/SSOService.php
+++ b/src/SSO/Service/SSOService.php
@@ -67,40 +67,6 @@ class SSOService {
     }
 
     /**
-     * Returns a HTML array representation with labels and links for the static IdP configuration data 
-     * (metadata/discovery URL, SSO/SLO endpoints, etc.).
-     * @return string HTML array of the static IdP settings, including copy images, links, etc.
-     */
-    public function getStaticSettingsHTML(string $id = 'sso_staticsettings', string $class = '') : string {
-        global $gL10n;
-        $staticSettings = $this->getStaticSettings();
- 
-
-        $first = true;
-        $html = '<table id="' . $id . '" style="width: 100%" class="' . $class . ' table table-sm table-striped"><tbody>';
-        foreach ($staticSettings as $label => $value) {
-            $html .= '<tr><td>';
-            if ($first) {
-                $html .= '<a id="' . $id . '_caret" class=" admidio-open-close-caret" data-target="' . $id . '_contents">
-                        <i class="bi bi-caret-right-fill" style="margin-right: 0"></i>
-                    </a>';
-            }
-            $html .= $gL10n->get($label) . ':&nbsp;</td>
-            <td><div class="copy-container" id="' . $value['id'] . '"' . 
-                        (array_key_exists('style', $value) ? (' style="' . $value['style'] . '"') : '') .
-                '>' . $value['value'] . '</div></td></tr>';
-            if ($first) {
-                $html .= '</tbody>
-                        <tbody id="' . $id . '_contents" style="display: none">
-                ';
-            }
-            $first = false;
-        }
-        $html .= '</tbody></table>';
-        return $html;
-    }
-
-    /**
      * Save data from the SSO client edit form into the database (works for both SAML and OIDC).
      * @throws Exception
      */

--- a/src/UI/Presenter/PreferencesPresenter.php
+++ b/src/UI/Presenter/PreferencesPresenter.php
@@ -1895,8 +1895,8 @@ class PreferencesPresenter extends PagePresenter
         $formSSO->addCustomContent(
             'sso_saml_sso_staticsettings',
             $gL10n->get('SYS_SSO_STATIC_SETTINGS'),
-            $samlService->getStaticSettingsHTML('sso_saml_sso_staticsettings', "if-saml-enabled"),
-            array()
+            '',
+            array('data' => $samlService->getStaticSettings())
         );
 
         // Link to SAML Client administration
@@ -1972,8 +1972,8 @@ class PreferencesPresenter extends PagePresenter
         $formSSO->addCustomContent(
             'sso_oidc_sso_staticsettings',
             $gL10n->get('SYS_SSO_STATIC_SETTINGS'),
-            $oidcService->getStaticSettingsHTML('sso_oidc_sso_staticsettings', "if-oidc-enabled"),
-            array()
+            '',
+            array('data' => $oidcService->getStaticSettings())
         );
 
         // Link to OIDC Client administration

--- a/src/UI/Presenter/SSOClientPresenter.php
+++ b/src/UI/Presenter/SSOClientPresenter.php
@@ -204,8 +204,8 @@ class SSOClientPresenter extends PagePresenter
         $form->addCustomContent(
             'sso_saml_sso_staticsettings',
             $gL10n->get('SYS_SSO_STATIC_SETTINGS'),
-            $SAMLService->getStaticSettingsHTML('sso_saml_sso_staticsettings', "if-saml-enabled"),
-            array()
+            '',
+            array('data' => $SAMLService->getStaticSettings())
         );
 
         $form->addCheckbox(
@@ -547,8 +547,8 @@ class SSOClientPresenter extends PagePresenter
         $form->addCustomContent(
             'sso_oidc_sso_staticsettings',
             $gL10n->get('SYS_SSO_STATIC_SETTINGS'),
-            $OIDCService->getStaticSettingsHTML('sso_oidc_sso_staticsettings', "if-oidc-enabled"),
-            array()
+            '',
+            array('data' => $OIDCService->getStaticSettings())
         );
 
         $form->addCheckbox(

--- a/themes/simple/css/admidio.css
+++ b/themes/simple/css/admidio.css
@@ -778,3 +778,31 @@ tr.admidio-event-highlight {
 ul.changelog-tableselect-list {
     list-style-type: none;
 }
+
+/************************************/
+/* subinfo form controls (showing/hiding rows) */
+/************************************/
+
+.subinfo-row .subinfo-sub-row label, .col-form-sublabel {
+  padding-left: 2.5em;
+  font-weight: normal;
+}
+.subinfo-sub-row, .subinfo-row {
+  margin-bottom: 0pt !important;
+}
+.subinfo_head {
+  margin-bottom: 1.5rem;
+}
+.col-form-label.col-form-sublabel {
+    padding-top: 2pt;
+    padding-bottom: 2pt;
+}
+
+.subinfo-row .form-control-plaintext {
+  width: 75%;
+}
+.subinfo-sub-row .form-control-plaintext {
+  width: 75%;
+  padding-bottom: 0;
+  padding-top: 0;
+}

--- a/themes/simple/templates/modules/oidc_client.edit.tpl
+++ b/themes/simple/templates/modules/oidc_client.edit.tpl
@@ -7,7 +7,7 @@
     <div class="card admidio-field-group">
         <div class="card-header">{$l10n->get('SYS_SSO_AUTO_SETUP')}</div>
         <div class="card-body">
-            {include 'sys-template-parts/form.custom-content.tpl' data=$elements['sso_oidc_sso_staticsettings']}
+            {include 'sys-template-parts/form.static-subinformation.tpl' data=$elements['sso_oidc_sso_staticsettings']}
         </div>
     </div>
     <div class="card admidio-field-group">

--- a/themes/simple/templates/modules/saml_client.edit.tpl
+++ b/themes/simple/templates/modules/saml_client.edit.tpl
@@ -9,7 +9,7 @@
         <div class="card-body">
             {include 'sys-template-parts/form.input.tpl' data=$elements['smc_metadata_url']}
             {include 'sys-template-parts/form.button.tpl' data=$elements['adm_button_metadata_setup']}
-            {include 'sys-template-parts/form.custom-content.tpl' data=$elements['sso_saml_sso_staticsettings']}
+            {include 'sys-template-parts/form.static-subinformation.tpl' data=$elements['sso_saml_sso_staticsettings']}
         </div>
     </div>
     <div class="card admidio-field-group">

--- a/themes/simple/templates/preferences/preferences.sso.tpl
+++ b/themes/simple/templates/preferences/preferences.sso.tpl
@@ -111,7 +111,7 @@
 
     {include 'sys-template-parts/form.checkbox.tpl' data=$elements['sso_saml_want_requests_signed']}
 
-    {include 'sys-template-parts/form.custom-content.tpl' data=$elements['sso_saml_sso_staticsettings']}
+    {include 'sys-template-parts/form.static-subinformation.tpl' data=$elements['sso_saml_sso_staticsettings']}
     {include 'sys-template-parts/form.custom-content.tpl' data=$elements['sso_saml_clients']}
 
 
@@ -126,7 +126,7 @@
     {include 'sys-template-parts/form.input.tpl' data=$elements['sso_oidc_issuer_url']}
     {include 'sys-template-parts/form.select.tpl' data=$elements['sso_oidc_signing_key']}
 
-    {include 'sys-template-parts/form.custom-content.tpl' data=$elements['sso_oidc_sso_staticsettings']}
+    {include 'sys-template-parts/form.static-subinformation.tpl' data=$elements['sso_oidc_sso_staticsettings']}
     {include 'sys-template-parts/form.custom-content.tpl' data=$elements['sso_oidc_clients']}
     
 

--- a/themes/simple/templates/sys-template-parts/form.static-subinformation.tpl
+++ b/themes/simple/templates/sys-template-parts/form.static-subinformation.tpl
@@ -1,0 +1,24 @@
+<div class="{$data.id}_head subinfo subinfo_head">
+{foreach from=$data.data key=label item=info name=staticInfoLoop}
+    <div class="admidio-form-group admidio-form-custom-content row mb-3 subinfo-row{if !$smarty.foreach.staticInfoLoop.first} subinfo-sub-row{/if}">
+        <label class="col-sm-3 col-form-label{if !$smarty.foreach.staticInfoLoop.first} col-form-sublabel{/if}">
+        {if $smarty.foreach.staticInfoLoop.first}
+            <a id="{$data.id}_caret" class=" admidio-open-close-caret" data-target="{$data.id}_contents">
+                <i class="bi bi-caret-right-fill" style="margin-right: 0"></i>
+            </a>
+        {/if}
+        {$label}:&nbsp;</label>
+        <div class="col-sm-9 form-control-plaintext">
+            <div class="copy-container {if isset($info.class)}{$info.class}{/if}" id="{$info.id}" 
+                {if isset($info.style) and $info.style neq ''} style="{$info.style}"{/if}
+                >{$info.value}</div>
+        </div>
+    </div>
+    {if $smarty.foreach.staticInfoLoop.first}
+        <div id="{$data.id}_contents" style="display: none">
+    {/if}
+{foreachelse}
+        <div id="{$data.id}_contents" style="display: none">
+{/foreach}
+</div>
+</div>


### PR DESCRIPTION
Add new static-subinformation form control that shows one row of information and offers an open/close caret with additional lines of information. 

The new static-subinformation form control can be used to show static information to the user with hidable sub-items. Only the first entry will e displayed together with a caret to open/close the section with additional information.

Usage:
```php
$formSSO->addCustomContent(
    'sso_saml_sso_staticsettings',
    $gL10n->get('SYS_SSO_STATIC_SETTINGS'),
    '',
    array('data' => [
        'label1' => [ 'value' => 'Displayed text', 'id' => 'id_of_the_html_div'],
        'label2' => [ 'value' => 'Text of the second information, hidden by default', 'id' => 'id_second', 'class' => 'css-class-to-be-used'],
        'label3' => [ 'value' => 'Text of third information', 'id' => 'id_third', 'style' => 'font-size: 38pt']
    ])
);
```

In the Smarty templates, this form control can be used like:
```smarty
{include 'sys-template-parts/form.static-subinformation.tpl' data=$elements['sso_oidc_sso_staticsettings']}
```

Closed:
![image](https://github.com/user-attachments/assets/756d0b4d-8cae-4187-8dad-3ba3c42b4ba8)
Opened:
![image](https://github.com/user-attachments/assets/9a8e5cb7-32b5-4fe5-8cb5-934d0d5b54a9)

