### PR TITLE
Category report export to Excel should not include html links to mail, phone or URL

### DIFF
--- a/modules/category-report/category_report.php
+++ b/modules/category-report/category_report.php
@@ -415,8 +415,8 @@ try {
                         $htmlValue = $gProfileFields->getHtmlValue($gProfileFields->getPropertyById($usf_id, 'usf_name_intern'), $content);
                         $columnValues[] = '<a href="' . SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/profile/profile.php', array('user_uuid' => $user->getValue('usr_uuid'))) . '">' . $htmlValue . '</a>';
                     } else {
-                        // within print mode no links should be set
-                        if ($getMode === 'print'
+                        // within print or Excel mode no links should be set
+                        if (($getMode === 'print' || $getMode === 'xlsx')
                             && ($gProfileFields->getPropertyById($usf_id, 'usf_type') === 'EMAIL'
                                 || $gProfileFields->getPropertyById($usf_id, 'usf_type') === 'PHONE'
                                 || $gProfileFields->getPropertyById($usf_id, 'usf_type') === 'URL')) {

--- a/modules/category-report/preferences.php
+++ b/modules/category-report/preferences.php
@@ -46,7 +46,7 @@ try {
         // ohne $report->saveConfigArray(); ansonsten würden 'name' und 'col_fields' ohne Daten gespeichert sein
     }
 
-    if ($getDelete > 0) {
+    if ($getDelete > 0 && isset($config[$getDelete - 1])) {
         $config[$getDelete - 1]['id'] = $config[$getDelete - 1]['id'] * (-1);                   // id negieren, als Kennzeichen für "Deleted"
         $config = $report->saveConfigArray($config);
     }


### PR DESCRIPTION
If a html link is included in the Excel export, the html tag is shown verbatim in Excel... We only want the email or web address exported as text, so no html-ification is needed or desired.

Also add some more array checks and fixes for the Category report.

Fixes #1853