### PR TITLE
Fix crash when adding member from different org (navigation URL stack was accessed with non-existing index)

### DIFF
--- a/src/Application/Navigation.php
+++ b/src/Application/Navigation.php
@@ -170,7 +170,11 @@ class Navigation
      */
     public function getStackEntryUrl(int $index): string
     {
-        return $this->urlStack[$index]['url'];
+        if (isset($this->urlStack[$index])) {
+            return $this->urlStack[$index]['url'];
+        } else {
+            return '';
+        }
     }
 
     /**


### PR DESCRIPTION
This patch merely adds checks to ignore accessing non-existing URL stack entries. The call that causes the crash is in roles.php:

```
        } elseif ($getNewUser) {
            $nextUrl = $gNavigation->getStackEntryUrl($gNavigation->count() - 3);
        } else {
```

The implicit assumption that the URL stack has at least 2 entries fails when searching for and adding an existing contact from a parent organization via the "Assign membership" button in the search results area of the create contact dialogbox.