### PR TITLE
Change strict equality to loose equality for hasRequiredInput method

### DIFF
--- a/src/ProfileFields/Entity/ProfileField.php
+++ b/src/ProfileFields/Entity/ProfileField.php
@@ -274,15 +274,15 @@ class ProfileField extends Entity
     {
         global $gCurrentUserId;
 
-        $requiredInput = $this->getValue('usf_required_input');
+        $requiredInput = (int)$this->getValue('usf_required_input');
 
-        if ($requiredInput == ProfileField::USER_FIELD_REQUIRED_INPUT_YES) {
+        if ($requiredInput === ProfileField::USER_FIELD_REQUIRED_INPUT_YES) {
             return true;
-        } elseif ($requiredInput == ProfileField::USER_FIELD_REQUIRED_INPUT_ONLY_REGISTRATION) {
+        } elseif ($requiredInput === ProfileField::USER_FIELD_REQUIRED_INPUT_ONLY_REGISTRATION) {
             if ($userId === $gCurrentUserId || $registration) {
                 return true;
             }
-        } elseif ($requiredInput == ProfileField::USER_FIELD_REQUIRED_INPUT_NOT_REGISTRATION && !$registration) {
+        } elseif ($requiredInput === ProfileField::USER_FIELD_REQUIRED_INPUT_NOT_REGISTRATION && !$registration) {
             return true;
         }
 


### PR DESCRIPTION
I came across this issue in version 4.3.x, and it's still here in version 5.0.0 Beta 2.

When you go to the registration page (profile_new.php), the required fields that are not hardcoded (i.e., username, password, etc) but defined as required (i.e., email) in the profile field configuration/database (usf_required_input) are not being made required in the HTML form. This is because the operator is too strict.

Making this change fixes the issue and displays the required fields in the registration page and when creating a contact as a logged-in user.