### PR TITLE
Change default tab of preferences

### DIFF
--- a/languages/en.xml
+++ b/languages/en.xml
@@ -220,11 +220,11 @@
   <string name="SYS_ADDITIONAL_CSS_FILE_DESC">The path to a .css file with additional style definitions. This file will be loaded last, even after the theme's admidio.css file. (default: empty)</string>
   <string name="SYS_ADDITIONAL_FILES">This list intends to provide an overview of files and folders not imported into the database yet. They can be added to the database. Access rights will be copied from selected folder.</string>
   <string name="SYS_ADDRESS">Address</string>
+  <string name="SYS_ADMIDIO">Admidio</string>
   <string name="SYS_ADMIDIO_DOWNLOAD_PAGE">Go to the Admidio download page</string>
   <string name="SYS_ADMIDIO_HEADLINE_DESC">The headline is displayed in the navigation bar of Admidio. Here you can also enter the name of a translation string. (default: SYS_ONLINE_MEMBERSHIP_ADMINISTRATION)</string>
   <string name="SYS_ADMIDIO_SHORT_DESC">The online management system for associations, groups and organizations</string>
   <string name="SYS_ADMIDIO_VERSION">Admidio version</string>
-  <string name="SYS_ADMIDIO_VERSION_BACKUP">Admidio version and backup</string>
   <string name="SYS_ADMINISTRATION">Administration</string>
   <string name="SYS_ADMINISTRATOR">Administrator</string>
   <string name="SYS_ADMINISTRATORS">Administrators</string>

--- a/modules/preferences.php
+++ b/modules/preferences.php
@@ -37,7 +37,7 @@ try {
             'defaultValue' => 'html',
             'validValues' => array('html', 'html_form', 'save', 'htaccess', 'test_email', 'backup', 'update_check')
         ));
-    $getPanel = admFuncVariableIsValid($_GET, 'panel', 'string');
+    $getPanel = admFuncVariableIsValid($_GET, 'panel', 'string', array('defaultValue' => 'system_information'));
 
     // only administrators are allowed to view, edit organization preferences or create new organizations
     if (!$gCurrentUser->isAdministrator()) {

--- a/src/UI/Presenter/PreferencesPresenter.php
+++ b/src/UI/Presenter/PreferencesPresenter.php
@@ -79,11 +79,11 @@ class PreferencesPresenter extends PagePresenter
                 'key'    => 'system',
                 'label'  => $gL10n->get('SYS_SYSTEM'),
                 'panels' => array(
+                    array('id'=>'system_information',   'title'=>$gL10n->get('SYS_INFORMATIONS'),           'icon'=>'bi-info-circle-fill',              'subcards'=>true),
                     array('id'=>'common',               'title'=>$gL10n->get('SYS_COMMON'),                 'icon'=>'bi-gear-fill',                     'subcards'=>false),
                     array('id'=>'design',               'title'=>$gL10n->get('SYS_DESIGN'),                 'icon'=>'bi-palette',                       'subcards'=>false),
                     array('id'=>'regional_settings',    'title'=>$gL10n->get('ORG_REGIONAL_SETTINGS'),      'icon'=>'bi-globe2',                        'subcards'=>false),
                     array('id'=>'changelog',            'title'=>$gL10n->get('SYS_CHANGE_HISTORY'),         'icon'=>'bi-clock-history',                 'subcards'=>false),
-                    array('id'=>'system_information',   'title'=>$gL10n->get('SYS_INFORMATIONS'),           'icon'=>'bi-info-circle-fill',              'subcards'=>true),
                 ),
             ),
 
@@ -2489,7 +2489,7 @@ class PreferencesPresenter extends PagePresenter
 
         //assign card titles and corresponding template files
         $cards = array(
-            array('title'=>$gL10n->get('SYS_ADMIDIO_VERSION_BACKUP'), 'icon'=>'bi-cloud-arrow-down-fill', 'templateFile'=>'preferences/preferences.admidio-update.tpl'),
+            array('title'=>$gL10n->get('SYS_ADMIDIO'), 'icon'=>'bi-cloud-arrow-down-fill', 'templateFile'=>'preferences/preferences.admidio-update.tpl'),
             array('title'=>$gL10n->get('SYS_SYSTEM_INFORMATION'),        'icon'=>'bi-info-circle-fill', 'templateFile'=>'preferences/preferences.system-information.tpl'),
             array('title'=>$gL10n->get('SYS_PHP'),                 'icon'=>'bi-filetype-php', 'templateFile'=>'preferences/preferences.php.tpl'),
         );

--- a/themes/simple/css/admidio.css
+++ b/themes/simple/css/admidio.css
@@ -380,6 +380,11 @@ label {
     }
 }
 
+.admidio-form-custom-content > div {
+    padding-top: calc(0.375rem + 1px);
+    padding-bottom: calc(0.375rem + 1px);
+}
+
 /***********************************/
 /* Cards */
 /***********************************/

--- a/themes/simple/templates/preferences/preferences.admidio-update.tpl
+++ b/themes/simple/templates/preferences/preferences.admidio-update.tpl
@@ -41,7 +41,7 @@
     <div class="col-sm-9">
         <div>
             <a id="donate" href="{$admidioHomepage}donate.php" target="_blank">
-                <i class="bi bi-heart-fill"></i>{$l10n->get('SYS_DONATE')}</a>
+                <i class="bi bi-heart-fill admidio-icon-chain"></i>{$l10n->get('SYS_DONATE')}</a>
             <div class="form-text">{$l10n->get('INS_SUPPORT_FURTHER_DEVELOPMENT')}</div>
         </div>
     </div>


### PR DESCRIPTION
Since we don't know what the user want to do in the preferences, I think it would be better to show him within the default the informations about the Admidio version instead of the common tab.

Also some small fixes to the layout of the information preferences fields.