### PR TITLE
DISCUSSION: First attempt at introducing an action/hooks interface for detailed customization of Admidio

### DIFF
--- a/install/installation.php
+++ b/install/installation.php
@@ -123,6 +123,7 @@ try {
      * call will use the default value of true and properly log changes...
      */
     Entity::setLoggingEnabled(false);
+    Entity::setHooksEnabled(false);
 
     // check if adm_my_files has "write" privileges and check some sub folders of adm_my_files
     \Admidio\InstallationUpdate\Service\Installation::checkFolderPermissions();

--- a/install/update.php
+++ b/install/update.php
@@ -47,7 +47,7 @@ try {
             $gL10n = new Language('en');
         }
 
-        $page = new InstallationPresenter('admidio-update-message', $gL10n->get('INS_UPDATE'));
+        $page = new InstallationPresenter('adm_update_message', $gL10n->get('INS_UPDATE'));
         $page->setUpdateModus();
         $page->showMessage(
             'error',
@@ -223,7 +223,7 @@ try {
         if (version_compare($installedDbVersion, ADMIDIO_VERSION_TEXT, '<')
             || (version_compare($installedDbVersion, ADMIDIO_VERSION_TEXT, '==') && $maxUpdateStep > $currentUpdateStep)) {
             // create a page with the notice that the installation must be configured on the next pages
-            $page = new InstallationPresenter('admidio-update', $gL10n->get('INS_UPDATE_VERSION', array(ADMIDIO_VERSION_TEXT)));
+            $page = new InstallationPresenter('adm_update', $gL10n->get('INS_UPDATE_VERSION', array(ADMIDIO_VERSION_TEXT)));
             $page->addTemplateFile('update.tpl');
             $page->setUpdateModus();
             $page->assignSmartyVariable('installedDbVersion', $installedDbVersion);
@@ -266,7 +266,7 @@ try {
             $page->show();
         } // if versions are equal > no update
         elseif (version_compare($installedDbVersion, ADMIDIO_VERSION_TEXT, '==') && $maxUpdateStep === $currentUpdateStep) {
-            $page = new InstallationPresenter('admidio-update-message', $gL10n->get('INS_UPDATE'));
+            $page = new InstallationPresenter('adm_update_message', $gL10n->get('INS_UPDATE'));
             $page->setUpdateModus();
             $page->showMessage(
                 'success',
@@ -279,7 +279,7 @@ try {
             // => EXIT
         } // if source version smaller than database -> show error
         else {
-            $page = new InstallationPresenter('admidio-update-message', $gL10n->get('INS_UPDATE'));
+            $page = new InstallationPresenter('adm_update_message', $gL10n->get('INS_UPDATE'));
             $page->setUpdateModus();
             $page->showMessage(
                 'error',
@@ -367,7 +367,7 @@ try {
         }
 
         // show notice that update was successful
-        $page = new InstallationPresenter('admidio-update-successful', $gL10n->get('INS_UPDATE'));
+        $page = new InstallationPresenter('adm_update_successful', $gL10n->get('INS_UPDATE'));
         $page->addTemplateFile('update.successful.tpl');
         $page->assignSmartyVariable('updateWarnings', $updateWarnings);
         $page->assignSmartyVariable('updateInfos', $updateInfos);

--- a/install/update.php
+++ b/install/update.php
@@ -128,6 +128,7 @@ try {
      * call will use the default value of true and properly log changes...
      */
     Entity::setLoggingEnabled(false);
+    Entity::setHooksEnabled(false);
 
     // get system user id
     $sql = 'SELECT usr_id FROM ' . TBL_USERS . ' WHERE usr_login_name = \'System\' ';

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -210,6 +210,7 @@
   <string name="SYS_64BIT">64bit</string>
   <string name="SYS_A_TO_Z">A to Z</string>
   <string name="SYS_ABR_NO" description="Abbreviation for Number">No.</string>
+  <string name="SYS_ACCOUNT_ACTIVATED">Account activated</string>
   <string name="SYS_ACTIVATE_ROLE">Activate role</string>
   <string name="SYS_ACTIVATE_ROLE_DESC">If you re-activate the role #VAR1_BOLD#, the role members are assigned again with permissions and the role is selectable in all lists.\n\nDo you want to re-activate the roles?</string>
   <string name="SYS_ACTIVE_CONTACTS">Active contacts</string>

--- a/modules/announcements.php
+++ b/modules/announcements.php
@@ -32,7 +32,7 @@ try {
     $getMode = admFuncVariableIsValid($_GET, 'mode', 'string',
         array(
             'defaultValue' => 'cards',
-            'validValues' => array('cards', 'list', 'edit', 'save', 'delete')
+            'validValues' => array('cards', 'edit', 'save', 'delete')
         )
     );
     $getAnnouncementUUID = admFuncVariableIsValid($_GET, 'announcement_uuid', 'uuid');
@@ -44,7 +44,7 @@ try {
     if ($gSettingsManager->getInt('announcements_module_enabled') === 0) {
         throw new Exception('SYS_MODULE_DISABLED');
     } elseif ($gSettingsManager->getInt('announcements_module_enabled') === 1
-        && !in_array($getMode, array('cards', 'list')) && !$gValidLogin) {
+        && !in_array($getMode, array('cards')) && !$gValidLogin) {
         require(__DIR__ . '/../system/login_valid.php');
     } elseif ($gSettingsManager->getInt('announcements_module_enabled') === 2 && !$gValidLogin) {
         require(__DIR__ . '/../system/login_valid.php');
@@ -54,13 +54,6 @@ try {
         case 'cards':
             $page = new AnnouncementsPresenter($getCategoryUUID, $getAnnouncementUUID);
             $page->createCards($getOffset);
-            $gNavigation->addStartUrl(CURRENT_URL, $page->getHeadline(), 'bi-chat-dots-fill');
-            $page->show();
-            break;
-
-        case 'list':
-            $page = new AnnouncementsPresenter($getCategoryUUID);
-            $page->createList();
             $gNavigation->addStartUrl(CURRENT_URL, $page->getHeadline(), 'bi-chat-dots-fill');
             $page->show();
             break;

--- a/modules/category-report/category_report.php
+++ b/modules/category-report/category_report.php
@@ -17,6 +17,7 @@
  * config            : the selected configuration
  ***********************************************************************************************
  */
+use Admidio\Components\Entity\Component;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
@@ -39,8 +40,8 @@ try {
         throw new Exception('SYS_MODULE_DISABLED');
     }
 
-    // user must have the permission "rol_all_lists_view"
-    if (!Hooks::applyFilters('category_report_permitted', $gCurrentUser->checkRolesRight('rol_all_lists_view'))) {
+    // user must have the permission "rol_all_lists_view", which is what the component says
+    if (!Component::isVisible('CATEGORY-REPORT')) {
         throw new Exception('SYS_NO_RIGHTS');
     }
 

--- a/modules/category-report/category_report.php
+++ b/modules/category-report/category_report.php
@@ -112,9 +112,16 @@ try {
     $columnCount = count($report->headerData);
 
     // define title (html) and headline
-    $title = Hooks::applyFilters('category_report_title', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
-    $headline = Hooks::applyFilters('category_report_headline', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
+    // Both are handed to the page below and read back filtered through getFilteredTitle() /
+    // getFilteredHeadline() (page_title / page_headline), because the export filename and the PDF
+    // header need the filtered text too and neither of them reaches PagePresenter::show().
     $subHeadline = $config[$report->getConfiguration()]['name'];
+
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_category_report');
+    $page->setTitle($gL10n->get('SYS_CATEGORY_REPORT'));
+    $page->setHeadline($gL10n->get('SYS_CATEGORY_REPORT'));
+    $title = $page->getFilteredTitle();
+    $headline = $page->getFilteredHeadline();
 
     $filename = $gCurrentOrganization->getValue('org_shortname') . '-' . $headline . '-' . $subHeadline;
 
@@ -123,14 +130,11 @@ try {
     }
 
     if ($getMode !== 'csv') {
-        $page = PagePresenter::withHtmlIDAndHeadline('adm_category_report');
         $smarty = $page->createSmartyObject();
         $smarty->assign('l10n', $gL10n);
         if ($getMode === 'print') {
             $page->setContentFullWidth();
             $page->setPrintMode();
-            $page->setTitle($title);
-            $page->setHeadline($headline);
             $page->addHtml('<h5 class="admidio-content-subheader">' . $subHeadline . '</h5>');
             $smarty->assign('classTable', $classTable);
         } elseif ($getMode === 'pdf') {
@@ -173,8 +177,6 @@ try {
         } elseif ($getMode === 'html') {
             // create html page object
             $page->setContentFullWidth();
-            $page->setTitle($title);
-            $page->setHeadline($headline);
 
             $page->addJavascript(
                 '

--- a/modules/category-report/category_report.php
+++ b/modules/category-report/category_report.php
@@ -29,23 +29,25 @@ use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Admidio\Hooks\Hooks;
 
 try {
     require_once(__DIR__ . '/../../system/common.php');
 
     // check if the module is enabled and disallow access if it's disabled
-    if (!$gSettingsManager->getBool('category_report_module_enabled')) {
+    if (!Hooks::apply_filters('category_report_enabled', $gSettingsManager->getBool('category_report_module_enabled'))) {
         throw new Exception('SYS_MODULE_DISABLED');
     }
 
     // user must have the permission "rol_all_lists_view"
-    if (!$gCurrentUser->checkRolesRight('rol_all_lists_view')) {
+    if (!Hooks::apply_filters('category_report_permitted', $gCurrentUser->checkRolesRight('rol_all_lists_view'))) {
         throw new Exception('SYS_NO_RIGHTS');
     }
 
     // Read in the configuration array
     $report = new CategoryReport();
     $config = $report->getConfigArray();
+    $config = Hooks::apply_filters('category_report_config', $config);
 
     $getCrtId = admFuncVariableIsValid($_GET, 'crt_id', 'int', array('defaultValue' => $gSettingsManager->get('category_report_default_configuration')));
     $getMode = admFuncVariableIsValid($_GET, 'mode', 'string', array('defaultValue' => 'html', 'validValues' => array('xlsx', 'csv-oo', 'html', 'print', 'pdf', 'pdfl')));
@@ -109,8 +111,8 @@ try {
     $columnCount = count($report->headerData);
 
     // define title (html) and headline
-    $title = $gL10n->get('SYS_CATEGORY_REPORT');
-    $headline = $gL10n->get('SYS_CATEGORY_REPORT');
+    $title = Hooks::apply_filters('category_report_title', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
+    $headline = Hooks::apply_filters('category_report_headline', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
     $subHeadline = $config[$report->getConfiguration()]['name'];
 
     $filename = $gCurrentOrganization->getValue('org_shortname') . '-' . $headline . '-' . $subHeadline;

--- a/modules/category-report/category_report.php
+++ b/modules/category-report/category_report.php
@@ -35,19 +35,19 @@ try {
     require_once(__DIR__ . '/../../system/common.php');
 
     // check if the module is enabled and disallow access if it's disabled
-    if (!Hooks::apply_filters('category_report_enabled', $gSettingsManager->getBool('category_report_module_enabled'))) {
+    if (!Hooks::applyFilters('category_report_enabled', $gSettingsManager->getBool('category_report_module_enabled'))) {
         throw new Exception('SYS_MODULE_DISABLED');
     }
 
     // user must have the permission "rol_all_lists_view"
-    if (!Hooks::apply_filters('category_report_permitted', $gCurrentUser->checkRolesRight('rol_all_lists_view'))) {
+    if (!Hooks::applyFilters('category_report_permitted', $gCurrentUser->checkRolesRight('rol_all_lists_view'))) {
         throw new Exception('SYS_NO_RIGHTS');
     }
 
     // Read in the configuration array
     $report = new CategoryReport();
     $config = $report->getConfigArray();
-    $config = Hooks::apply_filters('category_report_config', $config);
+    $config = Hooks::applyFilters('category_report_config', $config);
 
     $getCrtId = admFuncVariableIsValid($_GET, 'crt_id', 'int', array('defaultValue' => $gSettingsManager->get('category_report_default_configuration')));
     $getMode = admFuncVariableIsValid($_GET, 'mode', 'string', array('defaultValue' => 'html', 'validValues' => array('xlsx', 'csv-oo', 'html', 'print', 'pdf', 'pdfl')));
@@ -111,8 +111,8 @@ try {
     $columnCount = count($report->headerData);
 
     // define title (html) and headline
-    $title = Hooks::apply_filters('category_report_title', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
-    $headline = Hooks::apply_filters('category_report_headline', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
+    $title = Hooks::applyFilters('category_report_title', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
+    $headline = Hooks::applyFilters('category_report_headline', $gL10n->get('SYS_CATEGORY_REPORT'), $report);
     $subHeadline = $config[$report->getConfiguration()]['name'];
 
     $filename = $gCurrentOrganization->getValue('org_shortname') . '-' . $headline . '-' . $subHeadline;

--- a/modules/category-report/preferences.php
+++ b/modules/category-report/preferences.php
@@ -73,7 +73,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $gL10n->get('SYS_CONFIGURATIONS'));
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('plg-category-report-preferences', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_category_report_preferences', $headline);
     ChangelogService::displayHistoryButton($page, 'categoryreport', 'category_report');
 
     $javascriptCode = '';

--- a/modules/changelog/changelog.php
+++ b/modules/changelog/changelog.php
@@ -164,7 +164,7 @@ try {
 
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-history', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_changelog', $headline);
     $page->setContentFullWidth();
 
     // Logic for hiding certain columns:

--- a/modules/changelog/changelog.php
+++ b/modules/changelog/changelog.php
@@ -142,7 +142,7 @@ try {
             $headline = $gL10n->get('SYS_CHANGE_HISTORY_GENERIC2', [$objName, implode(', ', $tableTitles)]);
         }
     }
-    $headline =  Hooks::apply_filters('changelog_headline', $headline);
+    $headline =  Hooks::applyFilters('changelog_headline', $headline);
 
     // add page to navigation history
     $gNavigation->addUrl(CURRENT_URL, $headline);

--- a/modules/changelog/changelog.php
+++ b/modules/changelog/changelog.php
@@ -35,6 +35,7 @@ use Admidio\UI\Presenter\PagePresenter;
 use Admidio\Users\Entity\User;
 use Admidio\Changelog\Service\ChangelogService;
 use Admidio\Roles\Entity\Role;
+use Admidio\Hooks\Hooks;
 
 
 
@@ -141,6 +142,7 @@ try {
             $headline = $gL10n->get('SYS_CHANGE_HISTORY_GENERIC2', [$objName, implode(', ', $tableTitles)]);
         }
     }
+    $headline =  Hooks::apply_filters('changelog_headline', $headline);
 
     // add page to navigation history
     $gNavigation->addUrl(CURRENT_URL, $headline);

--- a/modules/changelog/changelog.php
+++ b/modules/changelog/changelog.php
@@ -35,9 +35,6 @@ use Admidio\UI\Presenter\PagePresenter;
 use Admidio\Users\Entity\User;
 use Admidio\Changelog\Service\ChangelogService;
 use Admidio\Roles\Entity\Role;
-use Admidio\Hooks\Hooks;
-
-
 
 require_once(__DIR__ . '/../../system/common.php');
 require(__DIR__ . '/../../system/login_valid.php');
@@ -142,8 +139,6 @@ try {
             $headline = $gL10n->get('SYS_CHANGE_HISTORY_GENERIC2', [$objName, implode(', ', $tableTitles)]);
         }
     }
-    $headline =  Hooks::applyFilters('changelog_headline', $headline);
-
     // add page to navigation history
     $gNavigation->addUrl(CURRENT_URL, $headline);
 

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -41,7 +41,7 @@ try {
     $_SESSION['contacts_list_configuration'] = $contactsListConfig;
 
     // Set a link to display all users or only members
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-contacts', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_contacts', $headline);
     $page->setContentFullWidth();
 
     if ($gCurrentUser->isAdministratorUsers() || $gCurrentUser->isAllowedToViewUsers()) {

--- a/modules/contacts/contacts.php
+++ b/modules/contacts/contacts.php
@@ -15,6 +15,7 @@
  *                   3  : Show active and inactive contacts for all organizations (only Admin)
  ***********************************************************************************************
  */
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Roles\Entity\ListConfiguration;
@@ -148,6 +149,17 @@ try {
     }
 
     $columnHeading[] = '&nbsp;';
+
+    // list_columns may relabel a column, but not add or remove one: contacts_data.php still builds
+    // each row by position, and there is no shared list/column pipeline yet to keep the two in step
+    // (see HOOKS_PLAN.md §2.7). A filter that changes the count would misalign every row silently,
+    // so the count is enforced here instead of trusted.
+    $filteredColumnHeading = Hooks::applyTypedFilters('list_columns', $columnHeading, 'contacts');
+    if (count($filteredColumnHeading) !== count($columnHeading)) {
+        throw new \UnexpectedValueException('A list_columns filter for "contacts" changed the number of columns.');
+    }
+    $columnHeading = $filteredColumnHeading;
+
     $columnAlignment = $contactsListConfig->getColumnAlignments();
     if (($getMembersShowFilter < 3) && $gCurrentUser->isAdministratorUsers()) {
         array_unshift($columnAlignment, 'center', 'start', 'start');

--- a/modules/contacts/contacts_assign.php
+++ b/modules/contacts/contacts_assign.php
@@ -28,7 +28,7 @@ try {
     $formValues = $contactsNewForm->validate($_POST);
 
     // create an HTML page object
-    $page = new ModuleContacts('admidio-registration-assign', $gL10n->get('SYS_ASSIGN_REGISTRATION'));
+    $page = new ModuleContacts('adm_contacts_assign', $gL10n->get('SYS_ASSIGN_REGISTRATION'));
     $newUser = new User($gDb, $gProfileFields);
     $newUser->setValue('LAST_NAME', $postLastname);
     $newUser->setValue('FIRST_NAME', $postFirstname);

--- a/modules/contacts/contacts_data.php
+++ b/modules/contacts/contacts_data.php
@@ -47,6 +47,7 @@
  ***********************************************************************************************
  */
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Organizations\Entity\Organization;
@@ -351,7 +352,12 @@ try {
 
     $jsonArray['data'] = array();
 
-    while ($row = $mglStatement->fetch(PDO::FETCH_BOTH)) {
+    while ($row = $mglStatement->fetch(PDO::FETCH_ASSOC)) {
+        // Filter the raw row before anything is formatted from it. Nothing here reads a numeric
+        // index, so FETCH_ASSOC keeps the array a plugin sees free of the duplicate numeric keys
+        // FETCH_BOTH would otherwise add.
+        $row = Hooks::applyTypedFilters('list_data', $row, 'contacts');
+
         ++$rowNumber;
         if (($getMembersShowFilter->value < ShowMembers::AllContactsAllOrganizations->value) && $gCurrentUser->isAdministratorUsers()) {
             $columnNumberJson = 3;
@@ -494,10 +500,11 @@ try {
             }
         }
 
+        $userAdministration = Hooks::applyTypedFilters('list_row_actions', $userAdministration, 'contacts', $row);
         $columnValues[(string)$columnNumberJson] = $userAdministration;
 
         // add current row to json array
-        $jsonArray['data'][] = $columnValues;
+        $jsonArray['data'][] = Hooks::applyTypedFilters('list_rendered_data', $columnValues, 'contacts', $row);
     }
 
 // set count of filtered records

--- a/modules/contacts/import.php
+++ b/modules/contacts/import.php
@@ -33,7 +33,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-members-import', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_contacts_import', $headline);
 
     // show form
     $form = new FormPresenter(

--- a/modules/contacts/import_column_config.php
+++ b/modules/contacts/import_column_config.php
@@ -31,7 +31,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-members-import-csv', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_contacts_import_column_config', $headline);
 
     // show form
     $form = new FormPresenter(

--- a/modules/events/events.php
+++ b/modules/events/events.php
@@ -96,7 +96,7 @@ try {
     }
 
     // create an HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-events', $events->getHeadline($gL10n->get('SYS_EVENTS')));
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_events', $events->getHeadline($gL10n->get('SYS_EVENTS')));
 
     // data array
     $data = array('headers' => array(), 'rows' => array(), 'column_align' => array(), 'column_width' => array());

--- a/modules/events/events_new.php
+++ b/modules/events/events_new.php
@@ -98,7 +98,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-events-edit', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_events_edit', $headline);
 
     $page->addJavascript('
     /**

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -377,7 +377,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-lists-show', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_groups_roles_lists_show', $headline);
     $page->setContentFullWidth();
     $page->setTitle($title);
     $smarty = $page->createSmartyObject();

--- a/modules/groups-roles/members_assignment.php
+++ b/modules/groups-roles/members_assignment.php
@@ -97,7 +97,7 @@ try {
         }
 
         // create html page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-members-assignement', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_groups_roles_members_assignment', $headline);
 
         if ($getMembersShowAll) {
             $javascriptCode .= '$("#mem_show_all").prop("checked", true);';

--- a/modules/groups-roles/mylist.php
+++ b/modules/groups-roles/mylist.php
@@ -85,7 +85,7 @@ try {
     }
 
     // create HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-mylist', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_groups_roles_mylist', $headline);
 
     ChangelogService::displayHistoryButton($page, 'lists', 'lists,list_columns', true, array('uuid' => $getListUuid));
 

--- a/modules/links/links.php
+++ b/modules/links/links.php
@@ -67,7 +67,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-weblinks', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_links', $headline);
 
     if ($gSettingsManager->getBool('enable_rss')) {
         $page->addRssFile(

--- a/modules/links/links_new.php
+++ b/modules/links/links_new.php
@@ -58,7 +58,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-weblinks-edit', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_links_edit', $headline);
 
     ChangelogService::displayHistoryButton($page, 'weblinks', 'links', !empty($getLinkUuid), array('uuid' => $getLinkUuid));
 

--- a/modules/links/links_redirect.php
+++ b/modules/links/links_redirect.php
@@ -49,7 +49,7 @@ try {
     // direct forwarding or show page with notice of redirection
     if ($gSettingsManager->getInt('weblinks_redirect_seconds') > 0) {
         // create html page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-weblinks-redirect', $gL10n->get('SYS_REDIRECT'));
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_links_redirect', $gL10n->get('SYS_REDIRECT'));
 
         // add special header for automatic redirection after x seconds
         $page->addHeader('<meta http-equiv="refresh" content="' . $gSettingsManager->getInt('weblinks_redirect_seconds') . '; url=' . $lnkUrl . '">');

--- a/modules/messages/messages.php
+++ b/modules/messages/messages.php
@@ -59,7 +59,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline, 'bi-envelope-fill');
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-messages', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_messages', $headline);
     $page->setContentFullWidth();
 
     // link to write new email

--- a/modules/messages/messages_write.php
+++ b/modules/messages/messages_write.php
@@ -203,7 +203,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-messages-write', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_messages_write', $headline);
 
     if ($getMsgType === Message::MESSAGE_TYPE_PM) {
         // show form

--- a/modules/overview.php
+++ b/modules/overview.php
@@ -27,7 +27,7 @@ try {
     $gNavigation->addStartUrl(CURRENT_URL, $headline, 'bi-house-door-fill');
 
     // create html page object and load template file
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-overview', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_overview', $headline);
     $page->setContentFullWidth();
 
     // get all overview plugins and add them to the template

--- a/modules/photos/photo_album_new.php
+++ b/modules/photos/photo_album_new.php
@@ -97,7 +97,7 @@ try {
     }//function
 
     // create HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-photo-album-edit', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_photos_album_edit', $headline);
 
     ChangelogService::displayHistoryButton($page, 'photos', 'photos', !empty($getPhotoUuid), array('uuid' => $getPhotoUuid));
 

--- a/modules/photos/photo_presenter.php
+++ b/modules/photos/photo_presenter.php
@@ -62,7 +62,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-photos-presenter', $photoAlbum->getValue('pho_name'));
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_photos_presenter', $photoAlbum->getValue('pho_name'));
 
     // show additional album information
     $datePeriod = $photoAlbum->getValue('pho_begin', $gSettingsManager->getString('system_date'));

--- a/modules/photos/photos.php
+++ b/modules/photos/photos.php
@@ -96,7 +96,7 @@ try {
     }
 
     // create an HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-photos', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_photos', $headline);
     $page->setContentFullWidth();
 
     // add rss feed to photos

--- a/modules/profile/profile.php
+++ b/modules/profile/profile.php
@@ -60,7 +60,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_profile', $headline);
     $page->addTemplateFile('modules/profile.view.tpl');
     $page->addJavascriptFile(ADMIDIO_URL . FOLDER_LIBS . '/zxcvbn/dist/zxcvbn.js');
     $page->addJavascriptFile(ADMIDIO_URL . FOLDER_MODULES . '/profile/profile.js');

--- a/modules/profile/profile_new.php
+++ b/modules/profile/profile_new.php
@@ -130,7 +130,7 @@ try {
             $gNavigation->addUrl(CURRENT_URL, $headline);
 
             // create an HTML page object
-            $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-edit', $headline);
+            $page = PagePresenter::withHtmlIDAndHeadline('adm_profile_edit', $headline);
 
             // show a link to view profile field change history
             ChangelogService::displayHistoryButton($page, 'profile', 'users,user_data,user_relations,members', !empty($users[0]['uuid']) && $gCurrentUser->hasRightEditProfile($users[0]['user']), array('uuid' => $users[0]['uuid']));
@@ -413,7 +413,7 @@ try {
             $gNavigation->addUrl(CURRENT_URL, $headline);
 
             // create an HTML page object
-            $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-edit-selection', $headline);
+            $page = PagePresenter::withHtmlIDAndHeadline('adm_profile_edit_selection', $headline);
 
             // create an HTML form
             $form = new FormPresenter(

--- a/modules/profile/profile_photo_edit.php
+++ b/modules/profile/profile_photo_edit.php
@@ -164,7 +164,7 @@ try {
         $gNavigation->addUrl(CURRENT_URL, $headline);
 
         // create html page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-photo-edit', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_profile_photo_edit', $headline);
 
         // show form
         $form = new FormPresenter(
@@ -262,7 +262,7 @@ try {
         }
 
         // create HTML page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-photo-edit', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_profile_photo_edit', $headline);
         $page->addTemplateFile('modules/profile.new-photo.tpl');
         $page->assignSmartyVariable('urlCurrentProfilePhoto', SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/profile/profile_photo_show.php', array('user_uuid' => $getUserUuid, 'timestamp' => $user->getValue('usr_timestamp_change', 'Y-m-d-H-i-s'))));
         $page->assignSmartyVariable('urlNewProfilePhoto', SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/profile/profile_photo_show.php', array('user_uuid' => $getUserUuid, 'new_photo' => 1)));

--- a/modules/profile/roles.php
+++ b/modules/profile/roles.php
@@ -60,7 +60,7 @@ try {
     }
 
     // we need a page object even in inline mode for the smarty engine
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-roles', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_profile_roles', $headline);
     $smarty = $page->createSmartyObject();
 
     $javascript = '
@@ -130,7 +130,7 @@ try {
         <div class="modal-body">';
     } else {
         // create html page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-roles', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_profile_roles', $headline);
         $page->addJavascript($javascript, true);
         $messageId = '';
 

--- a/modules/rooms/rooms.php
+++ b/modules/rooms/rooms.php
@@ -31,7 +31,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create an HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-rooms', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_rooms', $headline);
 
     // show a link to create new room
     $page->addPageFunctionsMenuItem(

--- a/modules/rooms/rooms_new.php
+++ b/modules/rooms/rooms_new.php
@@ -47,7 +47,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-rooms-edit', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_rooms_edit', $headline);
 
     ChangelogService::displayHistoryButton($page, 'rooms', 'rooms', !empty($getRoomUuid), array('uuid' => $getRoomUuid));
 

--- a/modules/userrelations/relationtypes.php
+++ b/modules/userrelations/relationtypes.php
@@ -32,7 +32,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-relationtypes', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_userrelations_types', $headline);
 
     // define link to create new category
     $page->addPageFunctionsMenuItem(

--- a/modules/userrelations/relationtypes_new.php
+++ b/modules/userrelations/relationtypes_new.php
@@ -46,7 +46,7 @@ try {
     }
 
     // create html page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-relationtypes-edit', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_userrelations_types_edit', $headline);
     $page->addJavascript('
         function checkRelationTypeNames() {
             $("#adm_button_save").prop("disabled", $("#urt_name").val() === $("#urt_name_inverse").val());

--- a/modules/userrelations/userrelations_new.php
+++ b/modules/userrelations/userrelations_new.php
@@ -60,7 +60,7 @@ try {
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
     // create an HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-userrelations-edit', $headline);
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_userrelations_edit', $headline);
 
     // show form
     $form = new FormPresenter(

--- a/src/Announcements/Entity/Announcement.php
+++ b/src/Announcements/Entity/Announcement.php
@@ -59,6 +59,15 @@ class Announcement extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'announcement';
+    }
+
+    /**
      * Get the value of a column of the database table.
      * If the value was manipulated before with **setValue** then the manipulated value is returned.
      * @param string $columnName The name of the database column whose value should be read

--- a/src/Categories/Entity/Category.php
+++ b/src/Categories/Entity/Category.php
@@ -65,6 +65,15 @@ class Category extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'category';
+    }
+
+    /**
      * Deletes the selected record of the table and all references in other tables.
      * After that the class will be initialized. The method throws exceptions if
      * the category couldn't be deleted.

--- a/src/Changelog/Service/ChangelogService.php
+++ b/src/Changelog/Service/ChangelogService.php
@@ -698,6 +698,7 @@ class ChangelogService {
             'usr_photo' =>                 'SYS_PROFILE_PHOTO',
             'usr_login_name' =>            'SYS_USERNAME',
             'usr_uuid' =>                  'SYS_UNIQUE_ID',
+            'usr_valid' =>                 array('name' => 'SYS_ACCOUNT_ACTIVATED', 'type' => 'BOOL'),
             'usr_timestamp_change' =>      'SYS_CHANGED_AT',
             'usr_usr_id_change' =>         'SYS_CHANGED_BY',
             'usr_usr_id_create' =>         'SYS_CREATED_AT',

--- a/src/Components/Entity/Component.php
+++ b/src/Components/Entity/Component.php
@@ -2,6 +2,7 @@
 namespace Admidio\Components\Entity;
 
 use Admidio\Changelog\Service\ChangelogService;
+use Admidio\Hooks\Hooks;
 use Admidio\Documents\Entity\Folder;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Database;
@@ -120,12 +121,33 @@ class Component extends Entity
     /**
      * This method checks if the current user is allowed to edit and administrate the component. Therefore,
      * special checks for each component were done.
+     *
+     * The answer passes through the **component_administrable** filter, which receives the answer and
+     * the name of the component. It is the one place that decides who may administrate a module, for
+     * the menu, for the modules themselves and for the CLI, so a plugin that adds a right of its own
+     * changes it here instead of in every module. It has to answer with a **bool**, which
+     * Hooks::applyTypedFilters() enforces: a permission must not be decided by whatever happens to be
+     * truthy. A filter can grant as well as revoke, so a callback that only wants to restrict has to
+     * return the answer it was given unless it means to widen it.
+     *
      * @param string $componentName The name of the component that is stored in the column com_name_intern e.g. GROUPS-ROLES
-     * @return bool Return true if the current user is allowed to view the component
+     * @return bool Return true if the current user is allowed to administrate the component
      * @throws \InvalidArgumentException
      * @throws \UnexpectedValueException|Exception
      */
     public static function isAdministrable(string $componentName): bool
+    {
+        return Hooks::applyTypedFilters('component_administrable', self::checkAdministrable($componentName), $componentName);
+    }
+
+    /**
+     * The rights of Admidio itself, without the hook. isAdministrable() is the answer everybody uses.
+     * @param string $componentName The name of the component.
+     * @return bool Return true if the current user is allowed to administrate the component
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException|Exception
+     */
+    private static function checkAdministrable(string $componentName): bool
     {
         global $gCurrentUser;
 
@@ -224,12 +246,30 @@ class Component extends Entity
     /**
      * This method checks if the current user is allowed to view the component. Therefore,
      * special checks for each component were done.
+     *
+     * The answer passes through the **component_visible** filter, which receives the answer and the
+     * name of the component. It decides which entries the menu shows, which modules may be opened and
+     * which commands the CLI offers, so it is a permission decision: the filter has to answer with a
+     * **bool** and it can grant as well as revoke. See isAdministrable() for the rest of the contract.
+     *
      * @param string $componentName The name of the component that is stored in the column com_name_intern e.g. GROUPS-ROLES
      * @return bool Return true if the current user is allowed to view the component
      * @throws \InvalidArgumentException
      * @throws \UnexpectedValueException|Exception
      */
     public static function isVisible(string $componentName): bool
+    {
+        return Hooks::applyTypedFilters('component_visible', self::checkVisible($componentName), $componentName);
+    }
+
+    /**
+     * The rights of Admidio itself, without the hook. isVisible() is the answer everybody uses.
+     * @param string $componentName The name of the component.
+     * @return bool Return true if the current user is allowed to view the component
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException|Exception
+     */
+    private static function checkVisible(string $componentName): bool
     {
         global $gValidLogin, $gCurrentUser, $gSettingsManager, $gDb;
 

--- a/src/Components/Entity/Component.php
+++ b/src/Components/Entity/Component.php
@@ -48,6 +48,15 @@ class Component extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'component';
+    }
+
+    /**
      * Check version of component in database against the version of the file system.
      * There will be different messages shown if versions aren't equal. If database has minor
      * version than a link to update the database will be shown. If filesystem has minor version

--- a/src/Components/Entity/Component.php
+++ b/src/Components/Entity/Component.php
@@ -289,7 +289,8 @@ class Component extends Entity
                 break;
 
             case 'CATEGORY-REPORT':
-                if ($gCurrentUser->checkRolesRight('rol_all_lists_view')) {
+                if ($gSettingsManager->getBool('category_report_module_enabled')
+                && $gCurrentUser->checkRolesRight('rol_all_lists_view')) {
                     return true;
                 }
                 break;

--- a/src/Documents/Entity/File.php
+++ b/src/Documents/Entity/File.php
@@ -39,6 +39,15 @@ class File extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'file';
+    }
+
+    /**
      * Check if the file extension of the current file format is allowed for upload and the
      * documents and files module.
      * @return bool Return true if the file extension is allowed to be used within Admidio.

--- a/src/Documents/Entity/Folder.php
+++ b/src/Documents/Entity/Folder.php
@@ -41,6 +41,15 @@ class Folder extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'folder';
+    }
+
+    /**
      * @param array<string,array<int,array<string,mixed>>> $completeFolder
      * @return array<string,array<int,array<string,mixed>>>
      * @throws Exception

--- a/src/Events/Entity/Event.php
+++ b/src/Events/Entity/Event.php
@@ -66,6 +66,15 @@ class Event extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'event';
+    }
+
+    /**
      * Check if the current user is allowed to participate in this event.
      * Therefore, we check if the user is member of a role that is assigned to
      * the right event_participation. This method will also return **true** if the deadline is exceeded

--- a/src/Events/Entity/Room.php
+++ b/src/Events/Entity/Room.php
@@ -28,6 +28,15 @@ class Room extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'room';
+    }
+
+    /**
      * Get the value of a column of the database table.
      * If the value was manipulated before with **setValue** than the manipulated value is returned.
      * @param string $columnName The name of the database column whose value should be read

--- a/src/Forum/Entity/Post.php
+++ b/src/Forum/Entity/Post.php
@@ -41,6 +41,15 @@ class Post extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'forum_post';
+    }
+
+    /**
      * Get the value of a column of the database table.
      * If the value was manipulated before with **setValue** than the manipulated value is returned.
      * @param string $columnName The name of the database column whose value should be read

--- a/src/Forum/Entity/Topic.php
+++ b/src/Forum/Entity/Topic.php
@@ -49,6 +49,15 @@ class Topic extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'forum_topic';
+    }
+
+    /**
      * Deletes the selected guestbook entry and all comments.
      * After that the class will be initialized.
      * @return bool **true** if no error occurred

--- a/src/Hooks/Hooks.php
+++ b/src/Hooks/Hooks.php
@@ -1,0 +1,256 @@
+<?php
+namespace Admidio\Hooks;
+
+/**
+ *  WordPress-like hooks system for Admidio.
+ *
+ * Features:
+ * - add_action / do_action
+ * - add_filter / apply_filters
+ * - remove_action / remove_filter
+ * - has_action / has_filter
+ *
+ * Notes:
+ * - Supports optional $id to overwrite/remove by ID later.
+ * - Lower $priority runs earlier (WordPress semantics).
+ */
+final class Hooks
+{
+    private static ?self $instance = null;
+
+    /** @var array<string, array<int, list<callable>>> */
+    private array $actions = [];
+    /** @var array<string, array<int, list<callable>>> */
+    private array $filters = [];
+
+    private function __construct() {}
+
+    private static function i(): self
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    // ---------- Registration ----------
+
+    /**
+     * WordPress-like signature.
+     * @param callable $callback function(...$args): void
+     */
+    public static function add_action(
+        string $name,
+        callable $callback,
+        int $priority = 10,
+        ?int $accepted_args = null,
+        ?string $id = null
+    ): void {
+        $i = self::i();
+
+        $wrapper = function (array $args) use ($callback, $accepted_args, $name): void {
+            try {
+                if ($accepted_args !== null) {
+                    $args = array_slice($args, 0, max(0, $accepted_args));
+                }
+                $callback(...$args);
+            } catch (\Throwable $t) {
+                global $gLogger;
+                $gLogger?->error('Action listener error', [
+                    'hook' => $name,
+                    'exception' => $t,
+                ]);
+            }
+        };
+
+        $key = $id ?? self::callableId($callback);
+        $i->actions[$name][$priority][$key] = $wrapper;
+    }
+
+
+    /**
+     * @param callable $callback function($value, ...$args): mixed
+     */
+    public static function add_filter(
+        string $name,
+        callable $callback,
+        int $priority = 10,
+        ?int $accepted_args = null,
+        ?string $id = null
+    ): void {
+        $i = self::i();
+
+        $wrapper = function (mixed $value, array $args) use ($callback, $accepted_args, $name): mixed {
+            try {
+                $callArgs = [$value, ...$args];
+                if ($accepted_args !== null) {
+                    $callArgs = array_slice($callArgs, 0, max(0, $accepted_args));
+                }
+                return $callback(...$callArgs);
+            } catch (\Throwable $t) {
+                global $gLogger;
+                $gLogger?->error('Filter listener error', [
+                    'hook' => $name,
+                    'exception' => $t,
+                ]);
+                return $value; // keep current value on failure
+            }
+        };
+
+        $key = $id ?? self::callableId($callback);
+        $i->filters[$name][$priority][$key] = $wrapper;
+    }
+
+        /**
+     * Remove by $id (preferred) or by $callback identity.
+     * If $priority is null, scans all priorities.
+     */
+    public static function remove_action(string $name, string|callable $idOrCallback, ?int $priority = null): bool
+    {
+        $i = self::i();
+        return self::removeFrom($i->actions, $name, $idOrCallback, $priority);
+    }
+        
+    /**
+     * Remove by $id (preferred) or by $callback identity.
+     * If $priority is null, scans all priorities.
+     */
+    public static function remove_filter(string $name, string|callable $idOrCallback, ?int $priority = null): bool
+    {
+        $i = self::i();
+        return self::removeFrom($i->filters, $name, $idOrCallback, $priority);
+    }
+
+    /**
+     * @param array<string, array<int, array<string, callable>>> $bucket
+     */
+    private static function removeFrom(array &$bucket, string $name, string|callable $idOrCallback, ?int $priority = null): bool
+    {
+        if (!isset($bucket[$name])) {
+            return false;
+        }
+
+        $needleId = is_string($idOrCallback) ? $idOrCallback : self::callableId($idOrCallback);
+        $found = false;
+
+        $priorities = $priority !== null ? [$priority] : array_keys($bucket[$name]);
+
+        foreach ($priorities as $prio) {
+            if (!isset($bucket[$name][$prio])) {
+                continue;
+            }
+
+            if (isset($bucket[$name][$prio][$needleId])) {
+                unset($bucket[$name][$prio][$needleId]);
+                $found = true;
+            }
+
+            if (empty($bucket[$name][$prio])) {
+                unset($bucket[$name][$prio]);
+            }
+        }
+
+        if (empty($bucket[$name])) {
+            unset($bucket[$name]);
+        }
+
+        return $found;
+    }
+
+
+    public static function has_action(string $name): bool
+    {
+        return !empty(self::i()->actions[$name]);
+    }
+
+    public static function has_filter(string $name): bool
+    {
+        return !empty(self::i()->filters[$name]);
+    }
+
+    // ---------- Dispatch ----------
+
+    /**
+     * do_action('user_created', $user, $actorId)
+     */
+    public static function do_action(string $name, mixed ...$args): void
+    {
+        $i = self::i();
+        foreach ($i->getListeners($i->actions, $name) as $listener) {
+            // $listener is the wrapper created in add_action
+            $listener($args);
+        }
+    }
+
+    /**
+     * $subject = apply_filters('mail_subject', $subject, $context);
+     */
+    public static function apply_filters(string $name, mixed $value, mixed ...$args): mixed
+    {
+        $i = self::i();
+        foreach ($i->getListeners($i->filters, $name) as $filter) {
+            // $filter is the wrapper created in add_filter
+            $value = $filter($value, $args);
+        }
+        return $value;
+    }
+
+
+    /**
+     * @param array<string, array<int, array<string, callable>>> $bucket
+     * @return iterable<callable>
+     */
+    private function getListeners(array $bucket, string $name): iterable
+    {
+        $byPriority = $bucket[$name] ?? [];
+        if (!$byPriority) {
+            return;
+        }
+
+        // WordPress semantics: lower priority runs earlier.
+        ksort($byPriority, SORT_NUMERIC);
+
+        foreach ($byPriority as $listenersById) {
+            foreach ($listenersById as $listener) {
+                yield $listener;
+            }
+        }
+    }
+
+    
+    // ---------- Helpers ----------
+
+    /**
+     * Creates a mostly-stable ID for a callable for overwrite/remove without explicitly passing $id.
+     * Not guaranteed unique across processes; good enough for request-lifetime hooks.
+     */
+    private static function callableId(callable $cb): string
+    {
+        // Closure
+        if ($cb instanceof \Closure) {
+            return 'closure:' . spl_object_hash($cb);
+        }
+
+        // ['Class', 'method'] or [$object, 'method']
+        if (is_array($cb) && count($cb) === 2) {
+            [$t, $m] = $cb;
+            if (is_object($t)) {
+                return 'obj:' . spl_object_hash($t) . '::' . (string)$m;
+            }
+            return 'cls:' . (string)$t . '::' . (string)$m;
+        }
+
+        // 'function_name'
+        if (is_string($cb)) {
+            return 'fn:' . $cb;
+        }
+
+        // invokable object
+        if (is_object($cb) && method_exists($cb, '__invoke')) {
+            return 'inv:' . spl_object_hash($cb);
+        }
+
+        // last resort
+        return 'cb:' . md5(serialize($cb));
+    }
+}

--- a/src/Hooks/Hooks.php
+++ b/src/Hooks/Hooks.php
@@ -246,6 +246,39 @@ final class Hooks
     }
 
     /**
+     * Pass a value through the filter and insist that what comes back still has the type of what
+     * went in. The value the dispatch site starts with defines the contract, so a filter of a
+     * **bool** has to answer with a **bool** and one of an **array** with an **array**.
+     *
+     * A wrongly typed result is a mistake in the callback, and at the sites where the result decides
+     * a permission, the recipients of a mail or the claims of a token it must not be coerced into
+     * something that happens to be truthy. The exception names the hook and the callback that is at
+     * fault, because the dispatch site is never the one that caused it.
+     *
+     * @param string $name Name of the hook.
+     * @param mixed $value The value that should be filtered. Its type is the required type.
+     * @param mixed ...$args Further arguments that the callbacks receive after the value.
+     * @return mixed Returns the value after the last callback.
+     */
+    public static function applyTypedFilters(string $name, mixed $value, mixed ...$args): mixed
+    {
+        $expectedType = get_debug_type($value);
+
+        foreach (self::getRegistrations(self::TYPE_FILTER, $name) as $registration) {
+            $value = self::call($registration, array($value, ...$args));
+
+            if (get_debug_type($value) !== $expectedType) {
+                throw new \UnexpectedValueException(
+                    'The callback "' . $registration['key'] . '" of the hook "' . $name . '" returned '
+                    . get_debug_type($value) . ' instead of ' . $expectedType . '.'
+                );
+            }
+        }
+
+        return $value;
+    }
+
+    /**
      * Ask the registered callbacks of the resolver for an answer until one of them has one.
      * @param string $name Name of the hook.
      * @param mixed $default The value that is returned if no callback has an answer.

--- a/src/Hooks/Hooks.php
+++ b/src/Hooks/Hooks.php
@@ -1,256 +1,471 @@
 <?php
 namespace Admidio\Hooks;
 
+use InvalidArgumentException;
+
 /**
- *  WordPress-like hooks system for Admidio.
+ * Generic extension points of Admidio. Three primitives are offered:
  *
- * Features:
- * - add_action / do_action
- * - add_filter / apply_filters
- * - remove_action / remove_filter
- * - has_action / has_filter
+ * - **Actions** notify that something is happening or has happened. Every callback is called, the
+ *   return values are ignored. A callback may throw to abort the operation, if the hook documents
+ *   that it may.
+ * - **Filters** transform a value. Every callback receives the result of the previous one, so the
+ *   value passes through the whole chain.
+ * - **Resolvers** ask for one answer. The callbacks are asked in priority order until one returns
+ *   something other than **null**; if none does, the default of the caller is returned. **false**,
+ *   **0**, empty string and empty array are answers and end the resolution.
  *
- * Notes:
- * - Supports optional $id to overwrite/remove by ID later.
- * - Lower $priority runs earlier (WordPress semantics).
+ * A lower priority runs earlier, registrations of the same priority run in registration order.
+ *
+ * A callback may be registered with an explicit ID, which is unique within one hook regardless of
+ * the priority: registering the same ID again replaces the previous registration. Without an ID the
+ * callback identifies itself, so that it can be removed again without remembering an ID.
+ *
+ * Exceptions of a callback are logged and rethrown. A hook is an extension point of the operation
+ * that dispatches it, so a failing extension has to fail that operation instead of leaving it half
+ * done. Only the dispatch sites of failure and diagnostic hooks use doActionCatchErrors(), so that
+ * a failing diagnostic cannot mask the failure it reports.
+ *
+ * **Code example**
+ * ```
+ * // transform a value
+ * Hooks::addFilter('entity_value', function (mixed $value, string $column) {
+ *     return ($column === 'usd_value') ? trim($value) : $value;
+ * });
+ * $value = Hooks::applyFilters('entity_value', $value, $columnName);
+ *
+ * // observe an event
+ * Hooks::addAction('user_created', array($myPlugin, 'onUserCreated'), 20);
+ * Hooks::doAction('user_created', $changeSet);
+ *
+ * // ask for one answer
+ * Hooks::addResolver('translation_missing', 'myTranslationProvider');
+ * $text = Hooks::resolve('translation_missing', $referenceText, $textId, $language);
+ * ```
  */
 final class Hooks
 {
-    private static ?self $instance = null;
+    public const TYPE_ACTION = 'action';
+    public const TYPE_FILTER = 'filter';
+    public const TYPE_RESOLVER = 'resolver';
 
-    /** @var array<string, array<int, list<callable>>> */
-    private array $actions = [];
-    /** @var array<string, array<int, list<callable>>> */
-    private array $filters = [];
-
-    private function __construct() {}
-
-    private static function i(): self
-    {
-        if (!self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
-
-    // ---------- Registration ----------
+    public const DEFAULT_PRIORITY = 10;
 
     /**
-     * WordPress-like signature.
-     * @param callable $callback function(...$args): void
+     * All registrations, as $registrations[$type][$hookName][$priority][$key], where $key is the
+     * explicit ID or the identity of the callback. One registration holds the callback, the number
+     * of arguments it accepts and the sequence number that keeps the registration order of one
+     * priority.
+     * @var array<string, array<string, array<int, array<string, array>>>>
      */
-    public static function add_action(
-        string $name,
-        callable $callback,
-        int $priority = 10,
-        ?int $accepted_args = null,
-        ?string $id = null
-    ): void {
-        $i = self::i();
+    private static array $registrations = array(
+        self::TYPE_ACTION => array(),
+        self::TYPE_FILTER => array(),
+        self::TYPE_RESOLVER => array()
+    );
 
-        $wrapper = function (array $args) use ($callback, $accepted_args, $name): void {
+    /**
+     * Counter that gives every registration its sequence number.
+     * @var int
+     */
+    private static int $sequence = 0;
+
+    /**
+     * The class only offers static methods and must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Register a callback that is notified when the action is dispatched. The return value of the
+     * callback is ignored.
+     * @param string $name Name of the hook, e.g. **user_created**.
+     * @param callable $callback The callback that should be called.
+     * @param int $priority Lower priorities run earlier.
+     * @param int|null $acceptedArgs Number of arguments the callback should receive. If **null**,
+     *                               it receives all arguments of the dispatch.
+     * @param string|null $id Explicit registration ID. Registering the same ID again replaces the
+     *                        previous registration of this hook.
+     * @return void
+     */
+    public static function addAction(string $name, callable $callback, int $priority = self::DEFAULT_PRIORITY, ?int $acceptedArgs = null, ?string $id = null): void
+    {
+        self::register(self::TYPE_ACTION, $name, $callback, $priority, $acceptedArgs, $id);
+    }
+
+    /**
+     * Register a callback that transforms the filtered value. It receives the value as its first
+     * argument and has to return the value that the next callback receives.
+     * @param string $name Name of the hook, e.g. **entity_value**.
+     * @param callable $callback The callback that should be called.
+     * @param int $priority Lower priorities run earlier.
+     * @param int|null $acceptedArgs Number of arguments the callback should receive, the filtered
+     *                               value included. If **null**, it receives all of them.
+     * @param string|null $id Explicit registration ID.
+     * @return void
+     */
+    public static function addFilter(string $name, callable $callback, int $priority = self::DEFAULT_PRIORITY, ?int $acceptedArgs = null, ?string $id = null): void
+    {
+        if ($acceptedArgs !== null && $acceptedArgs < 1) {
+            throw new InvalidArgumentException('A filter callback of the hook "' . $name . '" must accept at least the filtered value.');
+        }
+
+        self::register(self::TYPE_FILTER, $name, $callback, $priority, $acceptedArgs, $id);
+    }
+
+    /**
+     * Register a callback that is asked for the answer of the hook. It returns **null** if it has
+     * no answer, so that the next callback is asked, or the answer otherwise.
+     * @param string $name Name of the hook, e.g. **translation_missing**.
+     * @param callable $callback The callback that should be called.
+     * @param int $priority Lower priorities are asked earlier.
+     * @param int|null $acceptedArgs Number of arguments the callback should receive. If **null**,
+     *                               it receives all arguments of the dispatch.
+     * @param string|null $id Explicit registration ID.
+     * @return void
+     */
+    public static function addResolver(string $name, callable $callback, int $priority = self::DEFAULT_PRIORITY, ?int $acceptedArgs = null, ?string $id = null): void
+    {
+        self::register(self::TYPE_RESOLVER, $name, $callback, $priority, $acceptedArgs, $id);
+    }
+
+    /**
+     * Remove a registration of an action, by its explicit ID or by the callback that was registered.
+     * @param string $name Name of the hook.
+     * @param string|callable $idOrCallback The explicit registration ID or the registered callback.
+     * @return bool Returns **true** if a registration was removed.
+     */
+    public static function removeAction(string $name, string|callable $idOrCallback): bool
+    {
+        return self::remove(self::TYPE_ACTION, $name, $idOrCallback);
+    }
+
+    /**
+     * Remove a registration of a filter, by its explicit ID or by the callback that was registered.
+     * @param string $name Name of the hook.
+     * @param string|callable $idOrCallback The explicit registration ID or the registered callback.
+     * @return bool Returns **true** if a registration was removed.
+     */
+    public static function removeFilter(string $name, string|callable $idOrCallback): bool
+    {
+        return self::remove(self::TYPE_FILTER, $name, $idOrCallback);
+    }
+
+    /**
+     * Remove a registration of a resolver, by its explicit ID or by the callback that was registered.
+     * @param string $name Name of the hook.
+     * @param string|callable $idOrCallback The explicit registration ID or the registered callback.
+     * @return bool Returns **true** if a registration was removed.
+     */
+    public static function removeResolver(string $name, string|callable $idOrCallback): bool
+    {
+        return self::remove(self::TYPE_RESOLVER, $name, $idOrCallback);
+    }
+
+    /**
+     * Check whether at least one callback is registered for the action. A dispatch site uses this
+     * before it builds a context that it would not build otherwise.
+     * @param string $name Name of the hook.
+     * @return bool Returns **true** if at least one callback is registered.
+     */
+    public static function hasAction(string $name): bool
+    {
+        return !empty(self::$registrations[self::TYPE_ACTION][$name]);
+    }
+
+    /**
+     * Check whether at least one callback is registered for the filter.
+     * @param string $name Name of the hook.
+     * @return bool Returns **true** if at least one callback is registered.
+     */
+    public static function hasFilter(string $name): bool
+    {
+        return !empty(self::$registrations[self::TYPE_FILTER][$name]);
+    }
+
+    /**
+     * Check whether at least one callback is registered for the resolver.
+     * @param string $name Name of the hook.
+     * @return bool Returns **true** if at least one callback is registered.
+     */
+    public static function hasResolver(string $name): bool
+    {
+        return !empty(self::$registrations[self::TYPE_RESOLVER][$name]);
+    }
+
+    /**
+     * Dispatch an action to all registered callbacks. The return values are ignored, an exception
+     * of a callback is logged and rethrown, so that it aborts the operation that dispatched it.
+     * @param string $name Name of the hook.
+     * @param mixed ...$args The arguments that the callbacks receive.
+     * @return void
+     */
+    public static function doAction(string $name, mixed ...$args): void
+    {
+        foreach (self::getRegistrations(self::TYPE_ACTION, $name) as $registration) {
+            self::call($registration, $args);
+        }
+    }
+
+    /**
+     * Dispatch an action to all registered callbacks and log the exception of a callback instead of
+     * rethrowing it. Only the dispatch sites of failure and diagnostic hooks use this, where the
+     * original failure has to stay the one that Admidio reports and the remaining callbacks still
+     * have to get their chance to clean up.
+     * @param string $name Name of the hook.
+     * @param mixed ...$args The arguments that the callbacks receive.
+     * @return void
+     */
+    public static function doActionCatchErrors(string $name, mixed ...$args): void
+    {
+        foreach (self::getRegistrations(self::TYPE_ACTION, $name) as $registration) {
             try {
-                if ($accepted_args !== null) {
-                    $args = array_slice($args, 0, max(0, $accepted_args));
-                }
-                $callback(...$args);
-            } catch (\Throwable $t) {
-                global $gLogger;
-                $gLogger?->error('Action listener error', [
-                    'hook' => $name,
-                    'exception' => $t,
-                ]);
+                self::call($registration, $args);
+            } catch (\Throwable) {
+                // already logged in call(), the dispatch site must not be disturbed any further
             }
-        };
-
-        $key = $id ?? self::callableId($callback);
-        $i->actions[$name][$priority][$key] = $wrapper;
-    }
-
-
-    /**
-     * @param callable $callback function($value, ...$args): mixed
-     */
-    public static function add_filter(
-        string $name,
-        callable $callback,
-        int $priority = 10,
-        ?int $accepted_args = null,
-        ?string $id = null
-    ): void {
-        $i = self::i();
-
-        $wrapper = function (mixed $value, array $args) use ($callback, $accepted_args, $name): mixed {
-            try {
-                $callArgs = [$value, ...$args];
-                if ($accepted_args !== null) {
-                    $callArgs = array_slice($callArgs, 0, max(0, $accepted_args));
-                }
-                return $callback(...$callArgs);
-            } catch (\Throwable $t) {
-                global $gLogger;
-                $gLogger?->error('Filter listener error', [
-                    'hook' => $name,
-                    'exception' => $t,
-                ]);
-                return $value; // keep current value on failure
-            }
-        };
-
-        $key = $id ?? self::callableId($callback);
-        $i->filters[$name][$priority][$key] = $wrapper;
-    }
-
-        /**
-     * Remove by $id (preferred) or by $callback identity.
-     * If $priority is null, scans all priorities.
-     */
-    public static function remove_action(string $name, string|callable $idOrCallback, ?int $priority = null): bool
-    {
-        $i = self::i();
-        return self::removeFrom($i->actions, $name, $idOrCallback, $priority);
-    }
-        
-    /**
-     * Remove by $id (preferred) or by $callback identity.
-     * If $priority is null, scans all priorities.
-     */
-    public static function remove_filter(string $name, string|callable $idOrCallback, ?int $priority = null): bool
-    {
-        $i = self::i();
-        return self::removeFrom($i->filters, $name, $idOrCallback, $priority);
-    }
-
-    /**
-     * @param array<string, array<int, array<string, callable>>> $bucket
-     */
-    private static function removeFrom(array &$bucket, string $name, string|callable $idOrCallback, ?int $priority = null): bool
-    {
-        if (!isset($bucket[$name])) {
-            return false;
-        }
-
-        $needleId = is_string($idOrCallback) ? $idOrCallback : self::callableId($idOrCallback);
-        $found = false;
-
-        $priorities = $priority !== null ? [$priority] : array_keys($bucket[$name]);
-
-        foreach ($priorities as $prio) {
-            if (!isset($bucket[$name][$prio])) {
-                continue;
-            }
-
-            if (isset($bucket[$name][$prio][$needleId])) {
-                unset($bucket[$name][$prio][$needleId]);
-                $found = true;
-            }
-
-            if (empty($bucket[$name][$prio])) {
-                unset($bucket[$name][$prio]);
-            }
-        }
-
-        if (empty($bucket[$name])) {
-            unset($bucket[$name]);
-        }
-
-        return $found;
-    }
-
-
-    public static function has_action(string $name): bool
-    {
-        return !empty(self::i()->actions[$name]);
-    }
-
-    public static function has_filter(string $name): bool
-    {
-        return !empty(self::i()->filters[$name]);
-    }
-
-    // ---------- Dispatch ----------
-
-    /**
-     * do_action('user_created', $user, $actorId)
-     */
-    public static function do_action(string $name, mixed ...$args): void
-    {
-        $i = self::i();
-        foreach ($i->getListeners($i->actions, $name) as $listener) {
-            // $listener is the wrapper created in add_action
-            $listener($args);
         }
     }
 
     /**
-     * $subject = apply_filters('mail_subject', $subject, $context);
+     * Pass a value through all registered callbacks of the filter. Every callback receives the
+     * result of the previous one as its first argument.
+     * @param string $name Name of the hook.
+     * @param mixed $value The value that should be filtered.
+     * @param mixed ...$args Further arguments that the callbacks receive after the value.
+     * @return mixed Returns the value after the last callback.
      */
-    public static function apply_filters(string $name, mixed $value, mixed ...$args): mixed
+    public static function applyFilters(string $name, mixed $value, mixed ...$args): mixed
     {
-        $i = self::i();
-        foreach ($i->getListeners($i->filters, $name) as $filter) {
-            // $filter is the wrapper created in add_filter
-            $value = $filter($value, $args);
+        foreach (self::getRegistrations(self::TYPE_FILTER, $name) as $registration) {
+            $value = self::call($registration, array($value, ...$args));
         }
+
         return $value;
     }
 
-
     /**
-     * @param array<string, array<int, array<string, callable>>> $bucket
-     * @return iterable<callable>
+     * Ask the registered callbacks of the resolver for an answer until one of them has one.
+     * @param string $name Name of the hook.
+     * @param mixed $default The value that is returned if no callback has an answer.
+     * @param mixed ...$args The arguments that the callbacks receive.
+     * @return mixed Returns the first answer that is not **null**, otherwise the default.
      */
-    private function getListeners(array $bucket, string $name): iterable
+    public static function resolve(string $name, mixed $default = null, mixed ...$args): mixed
     {
-        $byPriority = $bucket[$name] ?? [];
-        if (!$byPriority) {
-            return;
+        foreach (self::getRegistrations(self::TYPE_RESOLVER, $name) as $registration) {
+            $answer = self::call($registration, $args);
+
+            if ($answer !== null) {
+                return $answer;
+            }
         }
 
-        // WordPress semantics: lower priority runs earlier.
-        ksort($byPriority, SORT_NUMERIC);
+        return $default;
+    }
 
-        foreach ($byPriority as $listenersById) {
-            foreach ($listenersById as $listener) {
-                yield $listener;
+    /**
+     * Remove all registrations. The registry is static and therefore outlives one test case or one
+     * iteration of a long-running CLI process.
+     * @param string $name Name of the hook that should be cleared. If empty, everything is cleared.
+     * @return void
+     */
+    public static function reset(string $name = ''): void
+    {
+        foreach (array_keys(self::$registrations) as $type) {
+            if ($name === '') {
+                self::$registrations[$type] = array();
+            } else {
+                unset(self::$registrations[$type][$name]);
             }
         }
     }
 
-    
-    // ---------- Helpers ----------
+    /**
+     * Store a registration and drop a previous registration of the same key, also if that one was
+     * registered with another priority.
+     * @param string $type One of the TYPE_... constants.
+     * @param string $name Name of the hook.
+     * @param callable $callback The callback that should be called.
+     * @param int $priority Lower priorities run earlier.
+     * @param int|null $acceptedArgs Number of arguments the callback should receive.
+     * @param string|null $id Explicit registration ID.
+     * @return void
+     */
+    private static function register(string $type, string $name, callable $callback, int $priority, ?int $acceptedArgs, ?string $id): void
+    {
+        if ($acceptedArgs !== null && $acceptedArgs < 0) {
+            throw new InvalidArgumentException('The number of accepted arguments must not be negative.');
+        }
+
+        $key = ($id === null) ? self::callableId($callback) : 'id:' . $id;
+
+        // An ID is unique within the hook and not within one priority, so a registration that moves
+        // to another priority must not leave its previous registration behind.
+        self::removeKey($type, $name, $key);
+
+        self::$registrations[$type][$name][$priority][$key] = array(
+            'callback' => $callback,
+            'acceptedArgs' => $acceptedArgs,
+            'sequence' => ++self::$sequence,
+            'name' => $name,
+            'key' => $key
+        );
+    }
 
     /**
-     * Creates a mostly-stable ID for a callable for overwrite/remove without explicitly passing $id.
-     * Not guaranteed unique across processes; good enough for request-lifetime hooks.
+     * Remove a registration by its explicit ID or by the callback that was registered. A string is
+     * ambiguous, because the name of a function is both a callback and a possible ID, so both are
+     * tried.
+     * @param string $type One of the TYPE_... constants.
+     * @param string $name Name of the hook.
+     * @param string|callable $idOrCallback The explicit registration ID or the registered callback.
+     * @return bool Returns **true** if a registration was removed.
      */
-    private static function callableId(callable $cb): string
+    private static function remove(string $type, string $name, string|callable $idOrCallback): bool
     {
-        // Closure
-        if ($cb instanceof \Closure) {
-            return 'closure:' . spl_object_hash($cb);
+        if (is_string($idOrCallback)) {
+            $keys = array('id:' . $idOrCallback, self::callableId($idOrCallback));
+        } else {
+            $keys = array(self::callableId($idOrCallback));
         }
 
-        // ['Class', 'method'] or [$object, 'method']
-        if (is_array($cb) && count($cb) === 2) {
-            [$t, $m] = $cb;
-            if (is_object($t)) {
-                return 'obj:' . spl_object_hash($t) . '::' . (string)$m;
+        $removed = false;
+        foreach ($keys as $key) {
+            $removed = self::removeKey($type, $name, $key) || $removed;
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Remove the registration of one key from every priority of the hook.
+     * @param string $type One of the TYPE_... constants.
+     * @param string $name Name of the hook.
+     * @param string $key The registration key.
+     * @return bool Returns **true** if a registration was removed.
+     */
+    private static function removeKey(string $type, string $name, string $key): bool
+    {
+        if (!isset(self::$registrations[$type][$name])) {
+            return false;
+        }
+
+        $removed = false;
+
+        foreach (self::$registrations[$type][$name] as $priority => $registrations) {
+            if (array_key_exists($key, $registrations)) {
+                unset(self::$registrations[$type][$name][$priority][$key]);
+                $removed = true;
             }
-            return 'cls:' . (string)$t . '::' . (string)$m;
+
+            if (empty(self::$registrations[$type][$name][$priority])) {
+                unset(self::$registrations[$type][$name][$priority]);
+            }
         }
 
-        // 'function_name'
-        if (is_string($cb)) {
-            return 'fn:' . $cb;
+        if (empty(self::$registrations[$type][$name])) {
+            unset(self::$registrations[$type][$name]);
         }
 
-        // invokable object
-        if (is_object($cb) && method_exists($cb, '__invoke')) {
-            return 'inv:' . spl_object_hash($cb);
+        return $removed;
+    }
+
+    /**
+     * All registrations of a hook in the order in which they have to be called. The returned array
+     * is a snapshot: a callback that registers or removes a callback of the same hook changes the
+     * following dispatches and not the one that is running.
+     * @param string $type One of the TYPE_... constants.
+     * @param string $name Name of the hook.
+     * @return array<int,array> Returns the registrations, ordered by priority and registration order.
+     */
+    private static function getRegistrations(string $type, string $name): array
+    {
+        if (empty(self::$registrations[$type][$name])) {
+            return array();
         }
 
-        // last resort
-        return 'cb:' . md5(serialize($cb));
+        $byPriority = self::$registrations[$type][$name];
+        ksort($byPriority, SORT_NUMERIC);
+
+        $ordered = array();
+        foreach ($byPriority as $registrations) {
+            uasort($registrations, function (array $left, array $right) {
+                return $left['sequence'] <=> $right['sequence'];
+            });
+
+            foreach ($registrations as $registration) {
+                $ordered[] = $registration;
+            }
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * Call one registered callback. An exception is logged with the hook it happened in and
+     * rethrown, so that the operation that dispatched the hook fails instead of continuing with a
+     * half-applied extension.
+     * @param array $registration The registration.
+     * @param array $args The arguments of the dispatch.
+     * @return mixed Returns the return value of the callback.
+     */
+    private static function call(array $registration, array $args): mixed
+    {
+        global $gLogger;
+
+        if ($registration['acceptedArgs'] !== null) {
+            $args = array_slice($args, 0, $registration['acceptedArgs']);
+        }
+
+        try {
+            return ($registration['callback'])(...$args);
+        } catch (\Throwable $exception) {
+            if ($gLogger instanceof \Psr\Log\LoggerInterface) {
+                $gLogger->error('Hook listener error', array(
+                    'hook' => $registration['name'],
+                    'listener' => $registration['key'],
+                    'exception' => $exception
+                ));
+            }
+            throw $exception;
+        }
+    }
+
+    /**
+     * The identity of a callback, so that it can be removed again without an explicit registration
+     * ID. It is stable as long as the callback is registered, because the registry holds the object
+     * or the closure itself and it can therefore not be freed and its handle not be reused.
+     * @param callable $callback The callback.
+     * @return string Returns the identity of the callback.
+     */
+    private static function callableId(callable $callback): string
+    {
+        if ($callback instanceof \Closure) {
+            return 'closure:' . spl_object_hash($callback);
+        }
+
+        if (is_array($callback) && count($callback) === 2) {
+            list($target, $method) = $callback;
+            if (is_object($target)) {
+                return 'obj:' . spl_object_hash($target) . '::' . (string)$method;
+            }
+            return 'cls:' . (string)$target . '::' . (string)$method;
+        }
+
+        if (is_string($callback)) {
+            // the string form of a static method is the same callback as its array form
+            if (str_contains($callback, '::')) {
+                return 'cls:' . $callback;
+            }
+            return 'fn:' . $callback;
+        }
+
+        if (is_object($callback)) {
+            return 'inv:' . spl_object_hash($callback);
+        }
+
+        return 'cb:' . md5(serialize($callback));
     }
 }

--- a/src/Hooks/Service/EntityHookQueue.php
+++ b/src/Hooks/Service/EntityHookQueue.php
@@ -1,0 +1,217 @@
+<?php
+namespace Admidio\Hooks\Service;
+
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Hooks\ValueObject\EntityFieldChange;
+use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Entity\Entity;
+
+/**
+ * Holds the committed persistence hooks of the entities until the change they describe is really in
+ * the database, and reduces the saves of one record within one transaction to the one change that
+ * happened as far as anybody outside can tell.
+ *
+ * Two problems are solved here that a hook dispatched straight from Entity::save() has:
+ *
+ * 1. **A post-action must mean committed.** Admidio counts nested transactions and only commits at
+ *    the outermost end, so a callback that runs inside Entity::save() can describe a change that is
+ *    rolled back afterwards. The queue hands the dispatch to Database::registerAfterCommit(), which
+ *    runs it at the commit and drops it when the transaction is lost.
+ * 2. **One logical operation must be one event.** modules/events/events_function.php saves an event,
+ *    creates its participation role and saves the event again; User::save() saves a registration
+ *    twice. A plugin that sends a webhook wants one event, not two, and it wants the change from
+ *    what the database held before the transaction to what it holds after it.
+ *
+ * The rules for putting two operations of one record together:
+ *
+ * | first  | second | result                                                   |
+ * |--------|--------|----------------------------------------------------------|
+ * | create | update | one create with the final values                          |
+ * | create | delete | nothing, the record never existed outside the transaction |
+ * | update | update | one update, oldest old value, newest new value            |
+ * | update | delete | one delete, against the state at the start                |
+ *
+ * A column that ends where it started is dropped, and an update that has nothing left is dropped
+ * with it. A create keeps all its columns, because the record itself is the news.
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+class EntityHookQueue
+{
+    /**
+     * @var array<string,array> The operations that are waiting, keyed by record, in the order in
+     *                          which the records were first written.
+     */
+    protected static array $pending = array();
+
+    /**
+     * @var bool Whether the flush is already registered with the database of the current transaction.
+     */
+    protected static bool $flushRegistered = false;
+
+    /**
+     * Queue the committed hooks of one operation. If no transaction is open, the statement was the
+     * commit and the hooks are dispatched right away.
+     *
+     * @param Entity $entity The entity that was written, used to tell two records apart when the
+     *                       table has no key column of its own.
+     * @param EntityChangeSet $changeSet What the operation changed.
+     * @param Database $database The database the operation ran on.
+     * @return void
+     */
+    public static function add(Entity $entity, EntityChangeSet $changeSet, Database $database): void
+    {
+        $key = self::keyOf($entity, $changeSet);
+
+        if (array_key_exists($key, self::$pending)) {
+            $merged = self::merge(self::$pending[$key]['changeSet'], $changeSet);
+
+            if ($merged === null) {
+                // created and deleted again within the transaction: nothing happened
+                unset(self::$pending[$key]);
+                return;
+            }
+
+            self::$pending[$key]['changeSet'] = $merged;
+        } else {
+            self::$pending[$key] = array('entity' => $entity, 'changeSet' => $changeSet);
+        }
+
+        if (!self::$flushRegistered) {
+            self::$flushRegistered = true;
+            $database->registerAfterCommit(function () {
+                self::flush();
+            });
+            $database->registerAfterRollback(function () {
+                self::discard();
+            });
+        }
+    }
+
+    /**
+     * Dispatch everything that was waiting. Called by the database at the outermost commit.
+     * @return void
+     */
+    public static function flush(): void
+    {
+        $pending = self::$pending;
+        self::reset();
+
+        foreach ($pending as $operation) {
+            $operation['entity']->dispatchCommittedHook($operation['changeSet']);
+        }
+    }
+
+    /**
+     * Drop everything that was waiting and let the failure hooks run instead. Called by the database
+     * when the transaction is rolled back, and at the end of a request that abandoned one.
+     * @return void
+     */
+    public static function discard(): void
+    {
+        $pending = self::$pending;
+        self::reset();
+
+        foreach ($pending as $operation) {
+            $operation['entity']->dispatchFailedHook($operation['changeSet']);
+        }
+    }
+
+    /**
+     * Forget everything without dispatching. For tests and for a CLI process that starts over.
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::$pending = array();
+        self::$flushRegistered = false;
+    }
+
+    /**
+     * @return int Returns the number of operations that are waiting for a commit.
+     */
+    public static function countPending(): int
+    {
+        return count(self::$pending);
+    }
+
+    /**
+     * What makes two operations belong to the same record. Normally the table and the key, so that
+     * two objects of one row are recognized as one record; a table without a key column falls back
+     * to the identity of the object.
+     * @param Entity $entity The entity that was written.
+     * @param EntityChangeSet $changeSet What the operation changed.
+     * @return string Returns the key of the record.
+     */
+    protected static function keyOf(Entity $entity, EntityChangeSet $changeSet): string
+    {
+        if ($changeSet->getId() !== null) {
+            return $changeSet->getTableName() . '#' . $changeSet->getId();
+        }
+
+        return $changeSet->getTableName() . '@' . spl_object_id($entity);
+    }
+
+    /**
+     * Put two operations of one record together, so that the outside world sees the one change that
+     * the transaction made. See the table in the class description for the rules.
+     * @param EntityChangeSet $first The operation that was queued before.
+     * @param EntityChangeSet $second The operation that just happened.
+     * @return EntityChangeSet|null Returns the one operation, or **null** if nothing is left of it.
+     */
+    protected static function merge(EntityChangeSet $first, EntityChangeSet $second): ?EntityChangeSet
+    {
+        if ($first->isCreate() && $second->isDelete()) {
+            return null;
+        }
+
+        // a record that was created in this transaction stays a creation, however often it is
+        // written afterwards
+        $operation = $first->isCreate() ? EntityChangeSet::OPERATION_CREATE : $second->getOperation();
+
+        $changes = $first->getChanges();
+        foreach ($second->getChanges() as $column => $change) {
+            if (array_key_exists($column, $changes)) {
+                // the value the database held is the one of the first operation, the value it holds
+                // now is the one of the last
+                $changes[$column] = new EntityFieldChange(
+                    $column,
+                    $changes[$column]->oldValue,
+                    $change->newValue,
+                    $change->type,
+                    $change->kind
+                );
+            } else {
+                $changes[$column] = $change;
+            }
+        }
+
+        if ($operation === EntityChangeSet::OPERATION_UPDATE) {
+            // a column that ends where it started did not change
+            $changes = array_filter($changes, function (EntityFieldChange $change) {
+                return $change->isRedacted() || $change->oldValue != $change->newValue;
+            });
+
+            if (count($changes) === 0) {
+                return null;
+            }
+        }
+
+        return new EntityChangeSet(
+            $second->getHookId(),
+            $second->getEntityClass(),
+            $second->getTableName(),
+            $second->getColumnPrefix(),
+            $second->getKeyColumnName(),
+            $second->getId() ?? $first->getId(),
+            $second->getUuid() ?? $first->getUuid(),
+            $operation,
+            $first->getOperationId(),
+            $changes,
+            // the state at the start of the transaction, which is what the change is measured from
+            $first->getSnapshot()
+        );
+    }
+}

--- a/src/Hooks/Service/EntityHookQueue.php
+++ b/src/Hooks/Service/EntityHookQueue.php
@@ -211,7 +211,9 @@ class EntityHookQueue
             $first->getOperationId(),
             $changes,
             // the state at the start of the transaction, which is what the change is measured from
-            $first->getSnapshot()
+            $first->getSnapshot(),
+            $second->getCauseHookId() ?? $first->getCauseHookId(),
+            $second->getCauseId() ?? $first->getCauseId()
         );
     }
 }

--- a/src/Hooks/ValueObject/EntityChangeSet.php
+++ b/src/Hooks/ValueObject/EntityChangeSet.php
@@ -58,6 +58,9 @@ final class EntityChangeSet
      * @param array<string,EntityFieldChange> $changes The changed columns, keyed by column name.
      * @param array<string,mixed> $snapshot The values the database held before the operation,
      *                                      empty for a creation, redacted columns withheld.
+     * @param string|null $causeHookId The hook ID of the record whose deletion removed this one,
+     *                                 **null** when the operation was asked for on its own.
+     * @param int|string|null $causeId The key of that record.
      */
     public function __construct(
         private readonly string $hookId,
@@ -70,7 +73,9 @@ final class EntityChangeSet
         private readonly string $operation,
         private readonly string $operationId,
         private readonly array $changes,
-        private readonly array $snapshot
+        private readonly array $snapshot,
+        private readonly ?string $causeHookId = null,
+        private readonly int|string|null $causeId = null
     ) {
     }
 
@@ -246,6 +251,38 @@ final class EntityChangeSet
     }
 
     /**
+     * The record whose deletion removed this one. A membership does not only disappear when it is
+     * ended, it also disappears when the role or the member is deleted, and a consumer usually has
+     * to treat the two differently: the first is news about that membership, the second is a detail
+     * of the news about the role or the person.
+     *
+     * @return string|null Returns the hook ID of the record that caused this operation, or **null**
+     *                     if the operation was asked for on its own.
+     */
+    public function getCauseHookId(): ?string
+    {
+        return $this->causeHookId;
+    }
+
+    /**
+     * @return int|string|null Returns the key of the record that caused this operation.
+     * @see EntityChangeSet#getCauseHookId
+     */
+    public function getCauseId(): int|string|null
+    {
+        return $this->causeId;
+    }
+
+    /**
+     * @return bool Returns **true** if this operation is a consequence of another one.
+     * @see EntityChangeSet#getCauseHookId
+     */
+    public function isCascade(): bool
+    {
+        return $this->causeHookId !== null;
+    }
+
+    /**
      * A copy of this change set that knows the key of the record. Entity::save() uses it after an
      * insert, because the database assigns the ID only when the record is written.
      * @param int|string|null $id The value of the key column.
@@ -265,7 +302,35 @@ final class EntityChangeSet
             $this->operation,
             $this->operationId,
             $this->changes,
-            $this->snapshot
+            $this->snapshot,
+            $this->causeHookId,
+            $this->causeId
+        );
+    }
+
+    /**
+     * A copy of this change set that names the record whose deletion removed this one.
+     * Entity::hookBulkDeletion() uses it for the records that go together with their owner.
+     * @param string|null $causeHookId The hook ID of the record that caused this operation.
+     * @param int|string|null $causeId The key of that record.
+     * @return self Returns a new change set, this one stays unchanged.
+     */
+    public function withCause(?string $causeHookId, int|string|null $causeId): self
+    {
+        return new self(
+            $this->hookId,
+            $this->entityClass,
+            $this->tableName,
+            $this->columnPrefix,
+            $this->keyColumnName,
+            $this->id,
+            $this->uuid,
+            $this->operation,
+            $this->operationId,
+            $this->changes,
+            $this->snapshot,
+            $causeHookId,
+            $causeId
         );
     }
 }

--- a/src/Hooks/ValueObject/EntityChangeSet.php
+++ b/src/Hooks/ValueObject/EntityChangeSet.php
@@ -1,0 +1,271 @@
+<?php
+namespace Admidio\Hooks\ValueObject;
+
+/**
+ * What one create, update or delete of an Entity did, as it is handed to a persistence hook.
+ *
+ * Admidio tracks the changed columns and the value the database holds for them anyway, so a hook
+ * callback does not have to read the record before the save to learn what changed. The change set
+ * is immutable: it describes the operation, and nothing a callback does to it can influence that
+ * operation. To transform a value use the **entity_value** filter, to reject an operation throw
+ * from the pre-action.
+ *
+ * The same shape is handed to the generic **entity_...** hooks and to the entity-specific
+ * hooks, so a callback can move from one to the other without being rewritten.
+ *
+ * For a creation the old values are **null** and the snapshot is empty, for a deletion the new
+ * values are **null** and the snapshot is what the record held. That snapshot is the reason this
+ * class exists at all: Entity::delete() clears the object, so a callback that runs afterwards can
+ * only learn what was deleted from here.
+ *
+ * **Code example**
+ * ```
+ * Hooks::addAction('event_updated', function (EntityChangeSet $changeSet) {
+ *     if ($changeSet->hasChanged('dat_begin')) {
+ *         myCalendarSync($changeSet->getUuid(), $changeSet->getNewValue('dat_begin'));
+ *     }
+ * });
+ * ```
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+final class EntityChangeSet
+{
+    public const OPERATION_CREATE = 'create';
+    public const OPERATION_UPDATE = 'update';
+    public const OPERATION_DELETE = 'delete';
+
+    /**
+     * The value that a redacted column reports instead of its own.
+     */
+    public const REDACTED_VALUE = '********';
+
+    /**
+     * @param string $hookId The stable public identifier of the entity, e.g. **oidc_client**.
+     * @param string $entityClass The PHP class of the entity. It may be renamed, so recognize the
+     *                            entity by its hook ID and not by this.
+     * @param string $tableName The database table, with the table prefix of the installation.
+     * @param string $columnPrefix The column prefix of that table, e.g. **usr**.
+     * @param string $keyColumnName The name of the key column, e.g. **usr_id**.
+     * @param int|string|null $id The value of the key column, **null** while a creation is still
+     *                            being written.
+     * @param string|null $uuid The UUID of the record if its table has one.
+     * @param string $operation One of the OPERATION_... constants.
+     * @param string $operationId Identifies this operation, so that a callback of a pre-action can
+     *                            recognize the matching post-action or failure action.
+     * @param array<string,EntityFieldChange> $changes The changed columns, keyed by column name.
+     * @param array<string,mixed> $snapshot The values the database held before the operation,
+     *                                      empty for a creation, redacted columns withheld.
+     */
+    public function __construct(
+        private readonly string $hookId,
+        private readonly string $entityClass,
+        private readonly string $tableName,
+        private readonly string $columnPrefix,
+        private readonly string $keyColumnName,
+        private readonly int|string|null $id,
+        private readonly ?string $uuid,
+        private readonly string $operation,
+        private readonly string $operationId,
+        private readonly array $changes,
+        private readonly array $snapshot
+    ) {
+    }
+
+    /**
+     * The stable public identifier of the entity, the same string the hook name is built from.
+     * @return string Returns the hook ID, e.g. **oidc_client**.
+     */
+    public function getHookId(): string
+    {
+        return $this->hookId;
+    }
+
+    /**
+     * @return string Returns the PHP class of the entity.
+     */
+    public function getEntityClass(): string
+    {
+        return $this->entityClass;
+    }
+
+    /**
+     * @return string Returns the database table, with the table prefix of the installation.
+     */
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    /**
+     * @return string Returns the column prefix of the table, e.g. **usr**.
+     */
+    public function getColumnPrefix(): string
+    {
+        return $this->columnPrefix;
+    }
+
+    /**
+     * @return string Returns the name of the key column, e.g. **usr_id**.
+     */
+    public function getKeyColumnName(): string
+    {
+        return $this->keyColumnName;
+    }
+
+    /**
+     * The value of the key column. A pre-create action does not have it yet, because the database
+     * assigns it; the matching post-create action does.
+     * @return int|string|null Returns the ID of the record or **null**.
+     */
+    public function getId(): int|string|null
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string|null Returns the UUID of the record, or **null** if the table has none.
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @return string Returns one of the OPERATION_... constants.
+     */
+    public function getOperation(): string
+    {
+        return $this->operation;
+    }
+
+    /**
+     * @return bool Returns **true** for a creation.
+     */
+    public function isCreate(): bool
+    {
+        return $this->operation === self::OPERATION_CREATE;
+    }
+
+    /**
+     * @return bool Returns **true** for an update.
+     */
+    public function isUpdate(): bool
+    {
+        return $this->operation === self::OPERATION_UPDATE;
+    }
+
+    /**
+     * @return bool Returns **true** for a deletion.
+     */
+    public function isDelete(): bool
+    {
+        return $this->operation === self::OPERATION_DELETE;
+    }
+
+    /**
+     * Identifies this operation. A callback that reserved something in the pre-action recognizes
+     * the matching post-action or failure action by this value.
+     * @return string Returns the ID of the operation.
+     */
+    public function getOperationId(): string
+    {
+        return $this->operationId;
+    }
+
+    /**
+     * All changed columns, the bookkeeping of the record included.
+     * @return array<string,EntityFieldChange> Returns the changes, keyed by column name.
+     */
+    public function getChanges(): array
+    {
+        return $this->changes;
+    }
+
+    /**
+     * The changed columns that are ordinary data of the record. A consumer that reacts to real
+     * changes wants these and not the creator, editor or counter columns.
+     * @return array<string,EntityFieldChange> Returns the changes, keyed by column name.
+     */
+    public function getBusinessChanges(): array
+    {
+        return array_filter($this->changes, function (EntityFieldChange $change) {
+            return $change->kind !== EntityFieldChange::KIND_TECHNICAL;
+        });
+    }
+
+    /**
+     * @param string $column Name of the database column.
+     * @return bool Returns **true** if the operation changed that column.
+     */
+    public function hasChanged(string $column): bool
+    {
+        return array_key_exists($column, $this->changes);
+    }
+
+    /**
+     * @param string $column Name of the database column.
+     * @return EntityFieldChange|null Returns the change of that column, or **null**.
+     */
+    public function getChange(string $column): ?EntityFieldChange
+    {
+        return $this->changes[$column] ?? null;
+    }
+
+    /**
+     * The value the database held for a column before the operation.
+     * @param string $column Name of the database column.
+     * @return mixed Returns the old value, or **null** if the column did not change.
+     */
+    public function getOldValue(string $column): mixed
+    {
+        return isset($this->changes[$column]) ? $this->changes[$column]->oldValue : null;
+    }
+
+    /**
+     * The value that was written to a column.
+     * @param string $column Name of the database column.
+     * @return mixed Returns the new value, or **null** if the column did not change.
+     */
+    public function getNewValue(string $column): mixed
+    {
+        return isset($this->changes[$column]) ? $this->changes[$column]->newValue : null;
+    }
+
+    /**
+     * The values the database held before the operation. It is empty for a creation and it is the
+     * only place a post-delete action can read the deleted record from, because Entity::delete()
+     * clears the object. Redacted columns are not part of it.
+     * @return array<string,mixed> Returns the values, keyed by column name.
+     */
+    public function getSnapshot(): array
+    {
+        return $this->snapshot;
+    }
+
+    /**
+     * A copy of this change set that knows the key of the record. Entity::save() uses it after an
+     * insert, because the database assigns the ID only when the record is written.
+     * @param int|string|null $id The value of the key column.
+     * @param string|null $uuid The UUID of the record.
+     * @return self Returns a new change set, this one stays unchanged.
+     */
+    public function withKey(int|string|null $id, ?string $uuid): self
+    {
+        return new self(
+            $this->hookId,
+            $this->entityClass,
+            $this->tableName,
+            $this->columnPrefix,
+            $this->keyColumnName,
+            $id,
+            $uuid,
+            $this->operation,
+            $this->operationId,
+            $this->changes,
+            $this->snapshot
+        );
+    }
+}

--- a/src/Hooks/ValueObject/EntityFieldChange.php
+++ b/src/Hooks/ValueObject/EntityFieldChange.php
@@ -1,0 +1,61 @@
+<?php
+namespace Admidio\Hooks\ValueObject;
+
+/**
+ * One changed column of an Entity, as it is handed to a persistence hook. The values are the raw
+ * values of the database column, not the formatted ones that Entity::getValue() returns, because a
+ * hook callback that synchronizes or forwards a change needs the value that was actually stored.
+ *
+ * The kind says how much the change is worth to a consumer:
+ *
+ * - **business** is ordinary data of the record;
+ * - **technical** is bookkeeping that the record keeps about itself, the creator and editor columns
+ *   and counters like the number of logins. A consumer that reacts to real changes should ignore
+ *   these, which is what EntityChangeSet::getBusinessChanges() does for it;
+ * - **redacted** is a column whose value must not leave the record, a password or a key. The change
+ *   is reported, the values are replaced by EntityChangeSet::REDACTED_VALUE.
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+final class EntityFieldChange
+{
+    public const KIND_BUSINESS = 'business';
+    public const KIND_TECHNICAL = 'technical';
+    public const KIND_REDACTED = 'redacted';
+
+    /**
+     * @param string $column Name of the database column, e.g. **usr_login_name**.
+     * @param mixed $oldValue The value the database held, **null** for a creation.
+     * @param mixed $newValue The value that was written, **null** for a deletion.
+     * @param string $type The type of the database column, e.g. **varchar**.
+     * @param string $kind One of the KIND_... constants.
+     */
+    public function __construct(
+        public readonly string $column,
+        public readonly mixed $oldValue,
+        public readonly mixed $newValue,
+        public readonly string $type,
+        public readonly string $kind
+    ) {
+    }
+
+    /**
+     * Whether this is ordinary data of the record and not bookkeeping.
+     * @return bool Returns **true** for a business change.
+     */
+    public function isBusiness(): bool
+    {
+        return $this->kind === self::KIND_BUSINESS;
+    }
+
+    /**
+     * Whether the values of this change were withheld.
+     * @return bool Returns **true** if the column is redacted.
+     */
+    public function isRedacted(): bool
+    {
+        return $this->kind === self::KIND_REDACTED;
+    }
+}

--- a/src/Infrastructure/ChangeNotification.php
+++ b/src/Infrastructure/ChangeNotification.php
@@ -554,8 +554,8 @@ class ChangeNotification
     }
 
     /**
-     * Tell everybody who is interested that the state of a user changed, once per user and request.
-     * The reasons say which of the three parts of a person changed - **user** for the record itself,
+     * Report everything that happened to one user in this request as one event, once per user. The
+     * reasons say which of the three parts of a person changed - **user** for the record itself,
      * **profile** for a profile field value, **membership** for a role membership - so that a
      * consumer which only cares about one of them can leave early. The counters of the login are not
      * a reason, they are bookkeeping of the record.
@@ -568,9 +568,9 @@ class ChangeNotification
      * @param int $userID The user for whom the action should be dispatched (0 for all).
      * @return void
      */
-    protected function dispatchStateChanges(int $userID = 0): void
+    protected function dispatchCumulatedChanges(int $userID = 0): void
     {
-        if (!Hooks::hasAction('user_state_changed')) {
+        if (!Hooks::hasAction('user_changes_cumulated')) {
             return;
         }
 
@@ -580,7 +580,7 @@ class ChangeNotification
             }
 
             $identity = $this->identity($userdata);
-            Hooks::doAction('user_state_changed', $identity['usr_uuid'], array_keys($userdata['reasons']));
+            Hooks::doAction('user_changes_cumulated', $identity['usr_uuid'], array_keys($userdata['reasons']));
         }
     }
 
@@ -628,7 +628,7 @@ class ChangeNotification
     {
         global $gSettingsManager, $gL10n, $gCurrentUser;
 
-        $this->dispatchStateChanges($userID);
+        $this->dispatchCumulatedChanges($userID);
 
         if ($gSettingsManager->has('system_notifications_profile_changes')
             && $gSettingsManager->getBool('system_notifications_profile_changes')

--- a/src/Infrastructure/ChangeNotification.php
+++ b/src/Infrastructure/ChangeNotification.php
@@ -1,42 +1,46 @@
 <?php
 namespace Admidio\Infrastructure;
 
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
 use Admidio\Infrastructure\Email;
 use Admidio\Infrastructure\Exception;
-use Admidio\ProfileFields\ValueObjects\ProfileFields;
-use Admidio\Roles\Entity\Membership;
-use Admidio\Users\Entity\User;
 use DateTime;
+use Throwable;
 
 /**
- * @brief Object to collect change notifications and optionally send a message to the administrator
+ * @brief Collects the changes to the users of this request and sends one notification mail per user
  *
- * This class can be used to log changes to profile fields and role
- * memberships. It stores all changes and at the end of the request,
- * sends one notification mail per modified user to the administrator, if
- * system notifications for profile field changes are enabled in the configuration of Admidio
+ * The class listens to the committed persistence hooks of the three tables a person consists of -
+ * **adm_users**, **adm_user_data** and **adm_members** - groups what it hears by the user it belongs
+ * to and sends one mail per affected user at the end of the request, if system notifications for
+ * profile changes are enabled in the configuration of Admidio.
  *
- * On startup, a global (singleton) object $gChangeNotifications is created
- * that is automatically used by the User and TableMembers classes to log
- * changes.
- * 
- * Functions provided:
- *   * logProfileChange(int $userID, int $fieldId, string $fieldName, string $old_value, string $new_value, string $old_value_db = '', string $new_value_db = '', string $action = "MODIFIED", $user = null)
- *   * logUserChange(int $userID, string $fieldName, string $old_value, string $new_value, User $user = null)
- *   * logRoleChange(int $userID, string $roleName, string $fieldName, string $old_value, string $new_value, string $action = "MODIFIED", User $user = null)
- *   * logUserCreation(int $userID, User $user = null)
- *   * logUserDeletion(int $userID, User $user = null)
- *   * logRoleCreation(int $userID, ....)
- *   * logRoleDeletion(int $userID, ....)
+ * Listening instead of being called by hand is what makes the mail describe what really happened:
  *
+ * - a value that was set on an object but never saved is not reported, because no hook fires;
+ * - a change whose transaction is lost is not reported, because the hooks wait for the commit;
+ * - a value that is written twice is one line, and a value that ends where it started is no line at
+ *   all;
+ * - a deleted user can still be described, because the change sets of the deletion carry the values
+ *   the record held.
+ *
+ * On startup, a global (singleton) object $gChangeNotification is created in system/common.php,
+ * which registers the listeners. Nothing else has to be done for a change to be reported.
+ *
+ * Two things are deliberately not reported. A membership of a role of the category **EVENTS** is a
+ * participation in an event and not a role of the person. And a profile value or a membership that
+ * disappears because the profile field or the role itself was deleted is a change of that field or
+ * role, not of the hundreds of people who happened to have a value in it - the change set names the
+ * record that caused the deletion, and only the person's own deletion counts as their change.
  *
  * **Code example**
  * ```
- * // log a change to a profile field (done automatically by the User class)
- * $gChangeNotifications->logProfileChange($usr_id, 123, 'first_name', 'Old Name', 'New Name');
+ * // send the pending notifications before the end of the request (they are sent at shutdown anyway)
+ * $gChangeNotification->sendNotifications();
  *
- * // Force sending the change notifications (if configured at all)
- * $gChangeNotifications->sendNotification();
+ * // keep the changes of one user out of the notification, for a registration for example
+ * $gChangeNotification->suppressUser($userId);
  * ```
  * @copyright The Admidio Team
  * @see https://www.admidio.org/
@@ -44,29 +48,58 @@ use DateTime;
  */
 class ChangeNotification
 {
-    /** @var array $changes Queued array of changes (user ID as key) made during this
-     *  php process. This data structure is meant to cache all changes and then
-     *  send out only one notification mail per user when PHP is finished.
-     *  The structure of each entry of this entry is:
+    /**
+     * The columns of adm_users that the notification reports, with their translation. Everything
+     * else in that table is either bookkeeping of the record or is kept out of a mail on purpose.
+     */
+    protected const USER_COLUMNS = array(
+        'usr_login_name' => 'SYS_USERNAME',
+        'usr_password' => 'SYS_PASSWORD',
+        'usr_photo' => 'SYS_PHOTO',
+        'usr_text' => 'SYS_TEXT'
+    );
+
+    /**
+     * The columns of adm_members that the notification reports, with their translation.
+     */
+    protected const MEMBERSHIP_COLUMNS = array(
+        'mem_begin' => 'SYS_MEMBERSHIP_START',
+        'mem_end' => 'SYS_MEMBERSHIP_END',
+        'mem_leader' => 'SYS_LEADER'
+    );
+
+    /**
+     * @var array $changes What the request changed, keyed by user ID and in the order in which the
+     *  users were first touched. One entry looks like this:
      *      uid => array(
-     *          'uid'=>123,
-     *          'usr_login_name'=>'',
-     *          'first_name'=>'',
-     *          'last_name'=>'',
+     *          'uid' => 123,
+     *          'usr_uuid' => '',
+     *          'usr_login_name' => '',
+     *          'usr_valid' => true,
+     *          'first_name' => '',
+     *          'last_name' => '',
      *          'created' => false,
      *          'deleted' => false,
+     *          'reasons' => array('user' => true, 'profile' => true, 'membership' => true),
      *          'profile_changes' => array(
-     *              field_id => array('Field Name', 'old_value', 'new_value'),
+     *              key => array('Field Name', 'old_value', 'new_value'),
      *          ),
      *          'role_changes' => array(
-     *              role_id => array('Role Name', 'fieldName', 'old_value', 'new_value'),
+     *              key => array('Role Name', 'Field Name', 'old_value', 'new_value'),
      *          )
      *      )
+     *  The changes are keyed by the field they belong to, so that a field which is written twice in
+     *  one request stays one line of the mail, from the value it had before to the value it has now.
      */
     protected array $changes = array();
 
-    /** @var string $format Whether to send mails as 'html' or 'text' (as configured)
-     */
+    /** @var array<int,bool> $suppressed The users whose changes must not be reported at all. */
+    protected array $suppressed = array();
+
+    /** @var array<int,array|null> $roles The name and category of a role, read at most once. */
+    protected array $roles = array();
+
+    /** @var string $format Whether to send mails as 'html' or 'text' (as configured) */
     protected string $format = 'html';
 
     /**
@@ -76,8 +109,10 @@ class ChangeNotification
     public function __construct()
     {
         global $gSettingsManager;
- 
+
         $this->format = $gSettingsManager->getBool('mail_html_registered_users') ? 'html' : 'text';
+
+        $this->registerListeners();
 
         // Register a shutdown function, which will be called when the whole PHP
         // script is finished, but before all global objects are destroyed
@@ -86,11 +121,41 @@ class ChangeNotification
     }
 
     /**
+     * Listen to the committed hooks of the three tables a person consists of. The registrations use
+     * an explicit ID, so that a second ChangeNotification object - the CLI builds one when a command
+     * runs outside a web request - replaces the listeners of the first instead of doubling them.
+     * @return void
+     */
+    protected function registerListeners(): void
+    {
+        foreach (array('created', 'updated', 'deleted') as $stage) {
+            Hooks::addAction('user_' . $stage, array($this, 'onUserChanged'), Hooks::DEFAULT_PRIORITY, 1, 'change_notification');
+            Hooks::addAction('user_data_' . $stage, array($this, 'onUserDataChanged'), Hooks::DEFAULT_PRIORITY, 1, 'change_notification');
+            Hooks::addAction('membership_' . $stage, array($this, 'onMembershipChanged'), Hooks::DEFAULT_PRIORITY, 1, 'change_notification');
+        }
+    }
+
+    /**
+     * Keep every change of a user out of the notification. User::save() calls it for a user whose
+     * change notification was switched off with User::disableChangeNotification(), a registration
+     * for example, which sends a notification of its own and must not send this one as well.
+     * @param int $userID The user whose changes must not be reported.
+     * @return void
+     */
+    public function suppressUser(int $userID): void
+    {
+        if ($userID > 0) {
+            $this->suppressed[$userID] = true;
+        }
+    }
+
+    /**
      * Clear the queue of all recorded changes. No notifications are sent out by
      * this method.
-     * @param int $userID The user for whom all recorded changes should be cleared (null for all users)
+     * @param int $userID The user for whom all recorded changes should be cleared (0 for all users)
+     * @return void
      */
-    public function clearChanges(int $userID = 0)
+    public function clearChanges(int $userID = 0): void
     {
         if ($userID > 0) {
             unset($this->changes[$userID]);
@@ -100,307 +165,470 @@ class ChangeNotification
     }
 
     /**
-     * Initialize the internal data structure to queue changes to a given user ID.
-     * @param int $userID The user for whom to prepare the internal data structure.
-     * @param User|null $user Optional the user object of the changed user could be set.
+     * A committed create, update or delete of a record of adm_users.
+     * @param EntityChangeSet $changeSet What the operation changed.
+     * @return void
      * @throws Exception
      */
-    public function prepareUserChanges(int $userID, ?User $user = null)
+    public function onUserChanged(EntityChangeSet $changeSet): void
     {
-        global $gDb, $gProfileFields;
-        if (!isset($this->changes[$userID])) {
-            if (is_null($user)) {
-                $user = new User($gDb, $gProfileFields, $userID);
+        global $gL10n;
+
+        $userID = (int)($changeSet->getId() ?? $this->valueOf($changeSet, 'usr_id'));
+        if ($userID === 0) {
+            return;
+        }
+
+        // A login writes nothing but the counters of the record, and that is not a change of the
+        // user. getBusinessChanges() drops them, because they are the columns the changelog ignores.
+        $businessChanges = $changeSet->getBusinessChanges();
+        if ($changeSet->isUpdate() && count($businessChanges) === 0) {
+            return;
+        }
+
+        $entry =& $this->entry($userID);
+        $entry['created'] = $entry['created'] || $changeSet->isCreate();
+        $entry['deleted'] = $entry['deleted'] || $changeSet->isDelete();
+        $entry['reasons']['user'] = true;
+
+        // The record is gone by the time the mail is written, so remember what identifies the user.
+        if ($changeSet->getUuid() !== null) {
+            $entry['usr_uuid'] = $changeSet->getUuid();
+        }
+        $loginName = $this->valueOf($changeSet, 'usr_login_name');
+        if ($loginName !== null && $loginName !== '') {
+            $entry['usr_login_name'] = (string)$loginName;
+        }
+        $entry['usr_valid'] = (bool)$this->valueOf($changeSet, 'usr_valid');
+
+        foreach (self::USER_COLUMNS as $column => $translationId) {
+            if (!$changeSet->hasChanged($column)) {
+                continue;
             }
-            $this->changes[$userID] = array(
-                'uid' => $userID,
-                'usr_login_name' => $user->getValue('usr_login_name'),
-                'first_name' => $user->getValue('FIRST_NAME'),
-                'last_name' => $user->getValue('LAST_NAME'),
-                'created' => false,
-                'deleted' => false,
-                'profile_changes' => array(),
-                'role_changes' => array(),
+
+            $this->recordChange(
+                $entry['profile_changes'],
+                'usr:' . $column,
+                array(
+                    $gL10n->get($translationId),
+                    $this->userValue($column, $changeSet->getOldValue($column)),
+                    $this->userValue($column, $changeSet->getNewValue($column))
+                ),
+                1,
+                2
             );
         }
     }
 
-    /** Returns the full name of the user for display  Internal function*/
-    function userDisplayName($userID, $user = null) {
-        global $gDb, $gProfileFields;
-        if (is_null($user)) {
-            $user = new User($gDb, $gProfileFields, $userID);
-        }
-        return $user->getValue('LAST_NAME') . ", " . $user->getValue('FIRST_NAME');
-    }
-
     /**
-     * Records a profile field change for the given user ID and the field ID.
-     * Both the old and the new values are stored in an array and sent via
-     * a system notification mail to the admin if configured.
-     * @param int $userID The user to whom the change applies
-     * @param int $fieldId The ID of the modified profile field.
-     * @param string $fieldName The human-readable name of the modified profile field.
-     * @param string $old_value The previous value of the field before the change
-     * @param string $new_value The new value of the field after the change
-     * @param string $old_value_db The previous value of the field before the change as stored in the database
-     * @param string $new_value_db The new value of the field after the change as stored in the database
+     * A committed create, update or delete of a record of adm_user_data, which is one profile field
+     * value of one user. Creating the record means the field was filled for the first time and
+     * deleting it means it was emptied, so all three operations are reported as one value change.
+     * @param EntityChangeSet $changeSet What the operation changed.
+     * @return void
      * @throws Exception
      */
-    public function logProfileChange(int $userID, int $fieldId, string $fieldName, ?string $old_value = null, ?string $new_value = null, string $old_value_db = '', string $new_value_db = '', string $reason = "MODIFIED", $user = null)
+    public function onUserDataChanged(EntityChangeSet $changeSet): void
     {
-        // Store the change to send out one change notification mail (after all modifications are done)
-        $this->prepareUserChanges($userID, $user);
-        $this->changes[$userID]['profile_changes'][] = array($fieldName, $old_value, $new_value);
-    }
+        global $gProfileFields;
 
-    /**
-     * Records a core user field change for the given user ID and the field ID.
-     * Both the old and the new values are stored in an array and sent via
-     * a system notification mail to the admin if configured.
-     * Some user fields are special cased (password, photo), others are ignored
-     * for irrelevance (internal fields).
-     * The change log ist kept in a separate table in the database from the user
-     * fields changes.
-     * @param int $userID The user to whom the change applies
-     * @param string $fieldName The ID of the modified profile field.
-     * @param string $old_value The previous value of the field before the change
-     * @param string $new_value The new value of the field after the change
-     * @param User|null $user Optional the object of the changed user.
-     * @throws Exception
-     */
-    public function logUserChange(int $userID, string $fieldName, ?string $old_value = null, ?string $new_value = null, string $action = "MODIFIED", ?User $user = null)
-    {
-        global $gSettingsManager, $gL10n, $gDb;
-
-        // User Profile fields are accessed by their field name, so we need to extract the identifier for translation
-        // Also, some fields need to be special cased (password replaced by *********, image by [...])
-        // Ignore all fields (internal logging about who and when a user was
-        // last changed) except explicitly handled (login, pwd, photo)
-        $ignore = false;
-        $fieldLabel = $fieldName;
-        $fieldTag = $fieldName;
-        switch ($fieldName) {
-            case 'usr_login_name':
-                $fieldTag = 'SYS_USERNAME';
-                $fieldLabel = $gL10n->get($fieldTag);
-                break;
-            case 'usr_password':
-                $fieldTag = 'SYS_PASSWORD';
-                $fieldLabel = $gL10n->get($fieldTag);
-                $old_value = $old_value ? '********' : $old_value;
-                $new_value = $new_value ? '********' : $new_value;
-                break;
-            case 'usr_photo':
-                $fieldTag = 'SYS_PHOTO';
-                $fieldLabel = $gL10n->get($fieldTag);
-                // Don't show photo data, replace with [...] if set
-                $old_value = $old_value ? '[...]' : $old_value;
-                $new_value = $new_value ? '[...]' : $new_value;
-                break;
-            case 'usr_text':
-                $fieldTag = 'SYS_TEXT';
-                $fieldLabel = $gL10n->get($fieldTag);
-                break;
-            default:
-                $ignore = true;
-        }
-
-        $this->prepareUserChanges($userID, $user);
-
-        if (!$ignore) {
-            $this->changes[$userID]['profile_changes'][] = array($fieldLabel, $old_value, $new_value);
-        }
-    }
-
-    /**
-     * Records a role membership change for the given user ID and the given role.
-     * Both the old and the new values are stored in an array and sent via
-     * a system notification mail to the admin if configured.
-     * @param Membership $membership The membership record that was changed
-     * @param string $fieldName The human-readable name of the modified profile field.
-     * @param string $old_value The previous value of the field before the change
-     * @param string $new_value The new value of the field after the change
-     */
-    public function logRoleChange(Membership $membership, string $fieldName, ?string $old_value = null, ?string $new_value = null)
-    {
-        global $gSettingsManager, $gL10n;
-        $userID = $membership->getValue("mem_usr_id");
-        // Don't log anything if no User ID is set yet (e.g. user not yet saved to the database!)
-        if ($userID == 0) {
+        if ($this->isForeignCascade($changeSet) || !is_object($gProfileFields)) {
             return;
         }
 
-        // Human-readable representation of the changed attribute (start, end, leadership)
-        // Also, ignore all other db table column changes...
-        $fieldLabel = $fieldName;
-        $ignore = false;
-        switch ($fieldName) {
-            case 'mem_begin':
-                $fieldLabel = $gL10n->get('SYS_MEMBERSHIP_START');
-                break;
-            case 'mem_end':
-                $fieldLabel = $gL10n->get('SYS_MEMBERSHIP_END');
-                break;
-            case 'mem_leader':
-                $fieldLabel = $gL10n->get('SYS_LEADER');
-                break;
-            default:
-                $ignore = true;
-                break;
+        $userID = (int)$this->valueOf($changeSet, 'usd_usr_id');
+        $fieldID = (int)$this->valueOf($changeSet, 'usd_usf_id');
+        if ($userID === 0 || $fieldID === 0) {
+            return;
         }
 
-        // Store the change to send out one change notification mail (after all modifications are done)
-        $this->prepareUserChanges($userID);
-        if (!$ignore) {
-            // if the format is not set to database, SecurityUtils::encodeHTML is used
-            $roleName = $membership->getValue('rol_name', 'database'); // TODO_RK: Check if this really works. First attempts indicate, it does not!
-            $this->changes[$userID]['role_changes'][] = array($roleName, $fieldLabel, $old_value, $new_value);
+        $fieldNameIntern = (string)$gProfileFields->getPropertyById($fieldID, 'usf_name_intern');
+        $oldValue = $this->profileValue($fieldNameIntern, $changeSet->getOldValue('usd_value'));
+        $newValue = $this->profileValue($fieldNameIntern, $changeSet->getNewValue('usd_value'));
+
+        $entry =& $this->entry($userID);
+
+        // The row is gone by the time the mail is written, so remember what identifies the user.
+        if ($fieldNameIntern === 'FIRST_NAME' || $fieldNameIntern === 'LAST_NAME') {
+            $key = ($fieldNameIntern === 'FIRST_NAME') ? 'first_name' : 'last_name';
+            $entry[$key] = ($newValue !== '') ? $newValue : $oldValue;
+        }
+
+        $changed = $this->recordChange(
+            $entry['profile_changes'],
+            'usf:' . $fieldID,
+            array(
+                (string)$gProfileFields->getPropertyById($fieldID, 'usf_name', $this->format),
+                $oldValue,
+                $newValue
+            ),
+            1,
+            2
+        );
+
+        if ($changed) {
+            $entry['reasons']['profile'] = true;
         }
     }
 
     /**
-     * Records a user creation with the given user ID. The user is assumed to be
-     * stored to the database already.
-     * All non-empty fields are added to the list of changes and queued for notification.
-     *
-     * @param int $userID The user to whom the change applies
-     * @param User|null $user (optional) The User object of the newly created user
+     * A committed create, update or delete of a record of adm_members, which is one membership of
+     * one user in one role.
+     * @param EntityChangeSet $changeSet What the operation changed.
+     * @return void
      * @throws Exception
      */
-    public function logUserCreation(int $userID, ?User $user = null)
+    public function onMembershipChanged(EntityChangeSet $changeSet): void
     {
-        global $gProfileFields, $gDb, $gSettingsManager;
+        global $gL10n;
 
-        // If user was never created in the DB, no need to log
-        if ($userID == 0) {
+        if ($this->isForeignCascade($changeSet)) {
             return;
         }
-        if (is_null($user)) {
-            $user = new User($gDb, $gProfileFields, $userID);
+
+        $userID = (int)$this->valueOf($changeSet, 'mem_usr_id');
+        $roleID = (int)$this->valueOf($changeSet, 'mem_rol_id');
+        if ($userID === 0 || $roleID === 0) {
+            return;
         }
 
-        // Prepare the admin notifications
-        $this->prepareUserChanges($userID, $user);
-        $this->changes[$userID]['created'] = true;
+        $role = $this->role($roleID);
+        if ($role === null || $role['category'] === 'EVENTS') {
+            // taking part in an event is not one of the roles of a person
+            return;
+        }
 
-        // Username and Passwords
-        foreach (array('usr_login_name', 'usr_password', 'usr_photo', 'usr_text') as $fieldName) {
-            $newValue = $user->getValue($fieldName, $this->format);
-            if ($newValue) {
-                $this->logUserChange($userID, $fieldName, null, $newValue, "CREATED", $user);
+        $entry =& $this->entry($userID);
+
+        foreach (self::MEMBERSHIP_COLUMNS as $column => $translationId) {
+            if (!$changeSet->hasChanged($column)) {
+                continue;
             }
-        }
-        // Loop through all profile fields and add all non-empty fields to the notification
-        if ($user->getProfileFieldsData() instanceof ProfileFields) {
-            foreach ($user->getProfileFieldsData()->getProfileFields() as $fieldName => $field) {
-                // Always use the text representation in the notification mail,
-                // as the HTML-representation might make use of css classes or
-                // image paths that are not available in a mail!
-                $newValue = $user->getValue($fieldName, 'text');
-                $newValue_db = $user->getValue($fieldName, 'database');
-                if ($newValue) {
-                    $fieldLabel = $field->getValue('usf_name', $this->format);
-                    $fieldID = $field->getValue('usf_id');
-                    $this->logProfileChange($userID, $fieldID, $fieldLabel, '', $newValue, '', $newValue_db, "CREATED", $user);
-                }
+
+            $changed = $this->recordChange(
+                $entry['role_changes'],
+                'mem:' . $roleID . ':' . $column,
+                array(
+                    $role['name'],
+                    $gL10n->get($translationId),
+                    $this->membershipValue($column, $changeSet->getOldValue($column)),
+                    $this->membershipValue($column, $changeSet->getNewValue($column))
+                ),
+                2,
+                3
+            );
+
+            if ($changed) {
+                $entry['reasons']['membership'] = true;
             }
         }
     }
 
     /**
-     * Records a user deletion for the given user ID.
-     * All non-empty fields are added to the list of changes and queued for notification.
-     * This function must be called before removing the user from the database.
-     *
-     * @param int $userID The user to whom the change applies
-     * @param User|null $user (optional) The User object of the user to be deleted
+     * Whether the operation only happened because another record was deleted, and that record is
+     * not the user themselves. Deleting a profile field or a role removes a value or a membership
+     * of everybody who had one, and that is news about the field or the role, not about the people.
+     * @param EntityChangeSet $changeSet The operation.
+     * @return bool Returns **true** if the operation must not be reported.
+     */
+    protected function isForeignCascade(EntityChangeSet $changeSet): bool
+    {
+        $cause = $changeSet->getCauseHookId();
+
+        return $cause !== null && $cause !== 'user';
+    }
+
+    /**
+     * The value a column has after the operation: the value that was written, the value the record
+     * held when it was deleted, or the value it holds unchanged.
+     * @param EntityChangeSet $changeSet The operation.
+     * @param string $column Name of the database column.
+     * @return mixed Returns the value, or **null** if the change set does not know the column.
+     */
+    protected function valueOf(EntityChangeSet $changeSet, string $column): mixed
+    {
+        if ($changeSet->hasChanged($column)) {
+            return $changeSet->getNewValue($column) ?? $changeSet->getOldValue($column);
+        }
+
+        return $changeSet->getSnapshot()[$column] ?? null;
+    }
+
+    /**
+     * The entry of one user, created on first use. It is returned by reference, so that a caller
+     * can write into it.
+     * @param int $userID The user.
+     * @return array Returns the entry of that user.
+     */
+    protected function &entry(int $userID): array
+    {
+        if (!array_key_exists($userID, $this->changes)) {
+            $this->changes[$userID] = array(
+                'uid' => $userID,
+                'usr_uuid' => null,
+                'usr_login_name' => null,
+                'usr_valid' => true,
+                'first_name' => null,
+                'last_name' => null,
+                'created' => false,
+                'deleted' => false,
+                'reasons' => array(),
+                'profile_changes' => array(),
+                'role_changes' => array()
+            );
+        }
+
+        return $this->changes[$userID];
+    }
+
+    /**
+     * Put one change into the list of a user. A field that is written a second time keeps the value
+     * it had before the request and gets the value it has now, and a field that ends where it
+     * started is dropped again - a request that sets a value and takes it back changed nothing.
+     * @param array $changes The list the change belongs to, by reference.
+     * @param string $key What makes two changes the same field.
+     * @param array $change The change, as the mail prints it.
+     * @param int $oldIndex Index of the previous value within the change.
+     * @param int $newIndex Index of the new value within the change.
+     * @return bool Returns **true** if a change is now in the list.
+     */
+    protected function recordChange(array &$changes, string $key, array $change, int $oldIndex, int $newIndex): bool
+    {
+        if (array_key_exists($key, $changes)) {
+            $change[$oldIndex] = $changes[$key][$oldIndex];
+        }
+
+        if ($change[$oldIndex] === $change[$newIndex]) {
+            unset($changes[$key]);
+            return false;
+        }
+
+        $changes[$key] = $change;
+
+        return true;
+    }
+
+    /**
+     * The value of a column of adm_users as the mail prints it. The password and the photo are
+     * withheld by the change set already; the photo is shown as the placeholder the change history
+     * uses for it, because '********' would suggest a secret.
+     * @param string $column Name of the database column.
+     * @param mixed $value The value of the change set.
+     * @return string Returns the value for the mail.
+     */
+    protected function userValue(string $column, mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        if ($column === 'usr_photo') {
+            return '[...]';
+        }
+
+        return (string)$value;
+    }
+
+    /**
+     * The value of a profile field as the mail prints it. The change set carries the value of the
+     * database column, so a date is Y-m-d and a dropdown is the number of its option; the mail
+     * always uses the text representation, because the HTML one may use CSS classes and image paths
+     * that do not exist in a mail.
+     * @param string $fieldNameIntern The **usf_name_intern** of the profile field.
+     * @param mixed $value The value of the change set.
+     * @return string Returns the value for the mail.
      * @throws Exception
      */
-    public function logUserDeletion(int $userID, ?User $user = null)
+    protected function profileValue(string $fieldNameIntern, mixed $value): string
     {
-        global $gProfileFields, $gL10n, $gDb, $gSettingsManager;
+        global $gProfileFields;
 
-        // If user wasn't yet created in the DB, no need to log anything
-        if ($userID == 0) {
-            return;
+        if ($value === null || $value === '') {
+            return '';
         }
 
-        // Prepare the admin notifications
-        $this->prepareUserChanges($userID, $user);
-        $this->changes[$userID]['deleted'] = true;
+        return (string)$gProfileFields->formatValue($fieldNameIntern, (string)$value, 'text');
+    }
 
-        $oldUser = new User($gDb, $gProfileFields, $userID);
+    /**
+     * The value of a column of adm_members as the mail prints it.
+     * @param string $column Name of the database column.
+     * @param mixed $value The value of the change set.
+     * @return string Returns the value for the mail.
+     * @throws Exception
+     */
+    protected function membershipValue(string $column, mixed $value): string
+    {
+        global $gSettingsManager;
 
-        // Username and Passwords
-        foreach (array('usr_login_name', 'usr_password', 'usr_photo', 'usr_text') as $fieldName) {
-            $oldValue = $oldUser->getValue($fieldName, $this->format);
-            if ($oldValue) {
-                $this->logUserChange($userID, $fieldName, $oldValue, '', "DELETED", $user);
-            }
-        }
-        // Loop through all profile fields and add all non-empty fields to the notification
-        if ($oldUser->getProfileFieldsData() instanceof ProfileFields) {
-            foreach (array_keys($oldUser->getProfileFieldsData()->getProfileFields()) as $fieldName) {
-                // Always use the text representation in the notification mail,
-                // as the HTML-representation might make use of css classes or
-                // image paths that are not available in a mail!
-                $oldValue = $oldUser->getValue($fieldName, 'text');
-                $oldValueDB = $oldUser->getValue($fieldName, 'database');
-                if ($oldValue) {
-                    $oldFieldId = $oldUser->getProfileFieldsData()->getProfileFields()[$fieldName]->getValue('usf_id');
-                    $oldFieldName = $oldUser->getProfileFieldsData()->getProfileFields()[$fieldName]->getValue('usf_name', $this->format);
-                    $this->logProfileChange($userID, $oldFieldId, $oldFieldName, $oldValue, '', $oldValueDB, '', "DELETE", $user);
-                }
-            }
+        if ($value === null || $value === '') {
+            return '';
         }
 
-        // Role memberships => For simplicity read directly from database
+        if ($column === 'mem_leader') {
+            return $value ? '1' : '';
+        }
+
+        try {
+            $date = new DateTime((string)$value);
+            return $date->format($gSettingsManager->getString('system_date'));
+        } catch (Throwable) {
+            // not a date, so keep the value of the column
+            return (string)$value;
+        }
+    }
+
+    /**
+     * The name and the category of a role, read at most once per request. A membership that was
+     * deleted can still be described this way, because the role itself is still there.
+     * @param int $roleID The role.
+     * @return array|null Returns **array('name', 'category')**, or **null** if the role is gone.
+     * @throws Exception
+     */
+    protected function role(int $roleID): ?array
+    {
         global $gDb;
-        $sql = 'SELECT *
-                  FROM '.TBL_MEMBERS.'
-            INNER JOIN '.TBL_ROLES.'
-                    ON rol_id = mem_rol_id
-            INNER JOIN '.TBL_CATEGORIES.'
-                    ON cat_id = rol_cat_id
-                 WHERE mem_usr_id  = ? -- $userID
-                   AND rol_valid   = true
-                   AND cat_name_intern <> \'EVENTS\'
-                 ORDER BY cat_org_id, cat_sequence, rol_name';
-        $query = $gDb->queryPrepared($sql, array($userID));
 
-        while ($row = $query->fetch()) {
-            $membership = new Membership($gDb, $row['mem_id']);
-            $memBegin = $row['mem_begin'];
-            $memEnd = $row['mem_end'];
+        if (!array_key_exists($roleID, $this->roles)) {
+            $sql = 'SELECT rol_name, cat_name_intern
+                      FROM ' . TBL_ROLES . '
+                INNER JOIN ' . TBL_CATEGORIES . '
+                        ON cat_id = rol_cat_id
+                     WHERE rol_id = ? -- $roleID';
+            $row = $gDb->queryPrepared($sql, array($roleID))->fetch(\PDO::FETCH_ASSOC);
 
-            $date =  new DateTime($memBegin);
-            if ($date !== false) {
-                $memBegin = $date->format($gSettingsManager->getString('system_date'));
-            }
-            $this->logRoleChange($membership, $row['rol_name'], $gL10n->get('SYS_MEMBERSHIP_START'), $memBegin, '', "DELETE", $user);
-            if ($memEnd) {
-                $date = new DateTime($memEnd);
-                if ($date !== false) {
-                    $memEnd = $date->format($gSettingsManager->getString('system_date'));
-                }
-                $this->logRoleChange($membership, $row['rol_name'], $gL10n->get('SYS_MEMBERSHIP_END'), $memEnd, '', "DELETE", $user);
-            }
-            if ($row['mem_leader']) {
-                $this->logRoleChange($membership, $row['rol_name'], $gL10n->get('SYS_LEADER'), $row['mem_leader'], '', "DELETE", $user);
+            $this->roles[$roleID] = ($row === false || $row === null)
+                ? null
+                : array('name' => $row['rol_name'], 'category' => $row['cat_name_intern']);
+        }
+
+        return $this->roles[$roleID];
+    }
+
+    /**
+     * What identifies a user in the mail. The change sets are asked first, because they are the only
+     * source left for a user that was deleted; everything they do not carry is read from the
+     * database in one query.
+     * @param array $userdata The entry of the user.
+     * @return array Returns the keys **usr_uuid**, **usr_login_name**, **first_name** and **last_name**.
+     * @throws Exception
+     */
+    protected function identity(array $userdata): array
+    {
+        global $gDb, $gProfileFields;
+
+        $identity = array(
+            'usr_uuid' => $userdata['usr_uuid'],
+            'usr_login_name' => $userdata['usr_login_name'],
+            'first_name' => $userdata['first_name'],
+            'last_name' => $userdata['last_name']
+        );
+
+        if (!in_array(null, $identity, true)) {
+            return $identity;
+        }
+
+        $sql = 'SELECT usr_uuid, usr_login_name,
+                       last_name.usd_value AS last_name, first_name.usd_value AS first_name
+                  FROM ' . TBL_USERS . '
+             LEFT JOIN ' . TBL_USER_DATA . ' AS last_name
+                    ON last_name.usd_usr_id = usr_id
+                   AND last_name.usd_usf_id = ? -- $gProfileFields->getProperty(\'LAST_NAME\', \'usf_id\')
+             LEFT JOIN ' . TBL_USER_DATA . ' AS first_name
+                    ON first_name.usd_usr_id = usr_id
+                   AND first_name.usd_usf_id = ? -- $gProfileFields->getProperty(\'FIRST_NAME\', \'usf_id\')
+                 WHERE usr_id = ? -- $userdata[\'uid\']';
+        $row = $gDb->queryPrepared($sql, array(
+            (int)$gProfileFields->getProperty('LAST_NAME', 'usf_id'),
+            (int)$gProfileFields->getProperty('FIRST_NAME', 'usf_id'),
+            $userdata['uid']
+        ))->fetch(\PDO::FETCH_ASSOC);
+
+        foreach ($identity as $column => $value) {
+            if ($value === null) {
+                $identity[$column] = ($row === false || $row === null) ? '' : (string)$row[$column];
             }
         }
+
+        return $identity;
+    }
+
+    /**
+     * Tell everybody who is interested that the state of a user changed, once per user and request.
+     * The reasons say which of the three parts of a person changed - **user** for the record itself,
+     * **profile** for a profile field value, **membership** for a role membership - so that a
+     * consumer which only cares about one of them can leave early. The counters of the login are not
+     * a reason, they are bookkeeping of the record.
+     *
+     * Whether the user was created or deleted is not part of this: a consumer that has to know
+     * listens to **user_created** and **user_deleted**, which carry the whole change set.
+     *
+     * It runs at the head of sendNotifications(), which is the one place where the collected changes
+     * of a user are used up, so a user is reported exactly once however the request ends.
+     * @param int $userID The user for whom the action should be dispatched (0 for all).
+     * @return void
+     */
+    protected function dispatchStateChanges(int $userID = 0): void
+    {
+        if (!Hooks::hasAction('user_state_changed')) {
+            return;
+        }
+
+        foreach ($this->scopedChanges($userID) as $userdata) {
+            if (count($userdata['reasons']) === 0) {
+                continue;
+            }
+
+            $identity = $this->identity($userdata);
+            Hooks::doAction('user_state_changed', $identity['usr_uuid'], array_keys($userdata['reasons']));
+        }
+    }
+
+    /**
+     * The collected changes of one user, or of everybody.
+     * @param int $userID The user, or 0 for everybody.
+     * @return array Returns the entries, keyed by user ID.
+     */
+    protected function scopedChanges(int $userID): array
+    {
+        if ($userID === 0) {
+            return $this->changes;
+        }
+
+        return array_key_exists($userID, $this->changes) ? array($userID => $this->changes[$userID]) : array();
+    }
+
+    /**
+     * Whether the changes of one user are worth a mail at all.
+     * @param array $userdata The entry of the user.
+     * @return bool Returns **true** if the user should get a notification.
+     */
+    protected function isReportable(array $userdata): bool
+    {
+        if (array_key_exists($userdata['uid'], $this->suppressed)) {
+            // a registration sends a notification of its own
+            return false;
+        }
+
+        if ($userdata['deleted'] && !$userdata['usr_valid']) {
+            // an account that was never activated is not worth a deletion notice
+            return false;
+        }
+
+        return true;
     }
 
     /**
      * Send out all queued change notifications, if the configuration has system
      * change notifications enabled at all.
-     * @param int $userID The user for whom the notification shall be sent (null for all queued notifications)
+     * @param int $userID The user for whom the notification shall be sent (0 for all queued notifications)
      * @throws Exception
      */
     public function sendNotifications(int $userID = 0)
     {
         global $gSettingsManager, $gL10n, $gCurrentUser;
+
+        $this->dispatchStateChanges($userID);
 
         if ($gSettingsManager->has('system_notifications_profile_changes')
             && $gSettingsManager->getBool('system_notifications_profile_changes')
@@ -422,12 +650,12 @@ class ChangeNotification
                 $table_end = "\n\n";
             }
 
-            $changes = $this->changes;
-            if ($userID > 0) {
-                $changes = array();
-                $changes[$userID] = $this->changes[$userID];
-            }
-            foreach ($changes as $userdata) {
+            foreach ($this->scopedChanges($userID) as $userdata) {
+                if (!$this->isReportable($userdata)) {
+                    continue;
+                }
+
+                $identity = $this->identity($userdata);
                 $notification = new Email();
                 $hasContent = false;
 
@@ -444,11 +672,11 @@ class ChangeNotification
 
                 $message = $gL10n->get(
                     $message,
-                    array($userdata['first_name'], $userdata['last_name'], $userdata['usr_login_name'], $currentName)
+                    array($identity['first_name'], $identity['last_name'], $identity['usr_login_name'], $currentName)
                 );
 
-                $changes = $userdata['profile_changes'];
-                if ($changes) {
+                $changesOfUser = $userdata['profile_changes'];
+                if ($changesOfUser) {
                     $hasContent = true;
                     $message .= $table_begin .
                         sprintf(
@@ -457,14 +685,14 @@ class ChangeNotification
                             $gL10n->get('SYS_PREVIOUS_VALUE'),
                             $gL10n->get('SYS_NEW_VALUE')
                         );
-                    foreach ($changes as $c) {
+                    foreach ($changesOfUser as $c) {
                         $message .= sprintf($format_row, $c[0], $c[1], $c[2]);
                     }
                     $message .= $table_end;
                 }
 
-                $changes = $userdata['role_changes'];
-                if ($changes) {
+                $changesOfUser = $userdata['role_changes'];
+                if ($changesOfUser) {
                     $hasContent = true;
                     $message .= $table_begin .
                         sprintf(
@@ -474,7 +702,7 @@ class ChangeNotification
                             $gL10n->get('SYS_PREVIOUS_VALUE'),
                             $gL10n->get('SYS_NEW_VALUE')
                         );
-                    foreach ($changes as $c) {
+                    foreach ($changesOfUser as $c) {
                         $message .= sprintf($format_rolrow, $c[0], $c[1], $c[2], $c[3]);
                     }
                     $message .= $table_end;
@@ -484,7 +712,7 @@ class ChangeNotification
                     $notification->sendNotification(
                         $gL10n->get(
                             $messageTitle,
-                            array($userdata['first_name'], $userdata['last_name'], $userdata['usr_login_name'])
+                            array($identity['first_name'], $identity['last_name'], $identity['usr_login_name'])
                         ),
                         $message
                     );
@@ -495,7 +723,6 @@ class ChangeNotification
         $this->clearChanges($userID);
     }
 
-
     /**
      * Shutdown function for cleanup: Send out all pending notification when the php processing is finished.
      */
@@ -503,7 +730,7 @@ class ChangeNotification
     {
         try {
             $this->sendNotifications();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             echo $e->getMessage();
         }
     }

--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -127,6 +127,14 @@ class Database
      */
     protected int $transactions = 0;
     /**
+     * @var array<int,callable> Work that may only run once the outermost transaction has committed.
+     */
+    protected array $afterCommitCallbacks = array();
+    /**
+     * @var array<int,callable> Work that has to run when the transaction did not commit.
+     */
+    protected array $afterRollbackCallbacks = array();
+    /**
      * @var array<string,array<string,array<string,mixed>>> Array with arrays of every table with their structure
      */
     protected array $dbStructure = array();
@@ -314,15 +322,119 @@ class Database
         $result = $this->pdo->commit();
 
         if (!$result) {
+            // showError() rolls back and runs the after-rollback callbacks
             $this->showError();
             // => EXIT
         }
 
         $this->transactions = 0;
 
+        // The change is in the database now, so the work that was waiting for it may run. It runs
+        // outside the transaction on purpose: it is allowed to fail without taking the change with
+        // it, and it may open a transaction of its own.
+        $this->runAfterCommitCallbacks();
+
         return $result;
     }
 
+
+    /**
+     * Register work that may only be done once the change is really in the database. If no
+     * transaction is open, the statement itself was the commit and the callback runs immediately;
+     * otherwise it runs when the outermost transaction is committed and never at all if that
+     * transaction is rolled back or abandoned.
+     *
+     * This is infrastructure for the persistence hooks and not an extension point of its own. A
+     * plugin does not register here, it listens to entity_created and its relatives, which use it.
+     *
+     * @param callable $callback The work that has to wait for the commit.
+     * @return void
+     * @see Database#registerAfterRollback
+     */
+    public function registerAfterCommit(callable $callback): void
+    {
+        if ($this->transactions === 0) {
+            $callback();
+            return;
+        }
+
+        $this->afterCommitCallbacks[] = $callback;
+    }
+
+    /**
+     * Register work that has to be done when the transaction does not reach the database: a
+     * rollback, a failed commit, or a request that ends while a transaction is still open. It is
+     * how the failure hooks get their chance to release what a pre-action reserved.
+     *
+     * @param callable $callback The work that has to run when the change is lost.
+     * @return void
+     * @see Database#registerAfterCommit
+     */
+    public function registerAfterRollback(callable $callback): void
+    {
+        $this->afterRollbackCallbacks[] = $callback;
+    }
+
+    /**
+     * Whether a transaction is currently open. A caller that has to know whether its change is
+     * already final asks this instead of counting its own start and end calls.
+     * @return bool Returns **true** while a transaction is open.
+     */
+    public function isInTransaction(): bool
+    {
+        return $this->transactions > 0;
+    }
+
+    /**
+     * Run and drop the callbacks that were waiting for the commit. A failing callback is logged and
+     * does not keep the remaining ones from running: the change is written, and the work that
+     * follows it has to be attempted as far as it can be.
+     * @return void
+     */
+    protected function runAfterCommitCallbacks(): void
+    {
+        global $gLogger;
+
+        $callbacks = $this->afterCommitCallbacks;
+        $this->afterCommitCallbacks = array();
+        $this->afterRollbackCallbacks = array();
+
+        foreach ($callbacks as $callback) {
+            try {
+                $callback();
+            } catch (\Throwable $exception) {
+                if ($gLogger instanceof \Psr\Log\LoggerInterface) {
+                    $gLogger->error('DATABASE: after-commit callback failed', array('exception' => $exception));
+                }
+                throw $exception;
+            }
+        }
+    }
+
+    /**
+     * Run and drop the callbacks of a transaction that did not reach the database. Their failure is
+     * logged and swallowed: they are cleanup, and the reason the transaction was lost has to stay
+     * the failure that Admidio reports.
+     * @return void
+     */
+    public function runAfterRollbackCallbacks(): void
+    {
+        global $gLogger;
+
+        $callbacks = $this->afterRollbackCallbacks;
+        $this->afterCommitCallbacks = array();
+        $this->afterRollbackCallbacks = array();
+
+        foreach ($callbacks as $callback) {
+            try {
+                $callback();
+            } catch (\Throwable $exception) {
+                if ($gLogger instanceof \Psr\Log\LoggerInterface) {
+                    $gLogger->error('DATABASE: after-rollback callback failed', array('exception' => $exception));
+                }
+            }
+        }
+    }
     /**
      * Escapes special characters within the input string.
      * Note: This method will add a high comma at the beginning and the end of the $string.
@@ -960,6 +1072,8 @@ class Database
 
         $this->transactions = 0;
 
+        $this->runAfterRollbackCallbacks();
+
         return true;
     }
 
@@ -1064,6 +1178,9 @@ class Database
             $this->pdo->rollBack();
             $this->transactions = 0;
         }
+
+        // Whether a transaction was open or not, nothing that was waiting for a commit may run now.
+        $this->runAfterRollbackCallbacks();
 
         $gLogger->critical($code . ': ' . $errorMessage);
 

--- a/src/Infrastructure/Email.php
+++ b/src/Infrastructure/Email.php
@@ -2,6 +2,7 @@
 
 namespace Admidio\Infrastructure;
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 use Admidio\Infrastructure\Utils\PhpIniUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
@@ -663,16 +664,53 @@ class Email extends PHPMailer
      */
     public function sendEmail(): bool
     {
-        global $gSettingsManager, $gCurrentOrganization, $gLogger, $gDebug, $gValidLogin, $gCurrentUser, $gL10n, $gDisableEmailSending;
-
-        $errorMessage = '';
-        $errorRecipients = array();
+        global $gDisableEmailSending;
 
         // If email sending is disabled in the config.php than don't send emails.
         // This should only be used for demo systems so the email UI should still be there.
         if (isset($gDisableEmailSending) && $gDisableEmailSending) {
             return true;
         }
+
+        // The recipients are decided here, once, before anything is sent, so that a callback which
+        // removes an address removes it from every package the delivery splits the mail into. It has
+        // to answer with an array of the same shape: one entry per recipient with the keys email,
+        // name, firstname and surname.
+        $this->emRecipientsArray = Hooks::applyTypedFilters('email_recipients', $this->emRecipientsArray, $this->Subject);
+        $recipientCount = count($this->emRecipientsArray);
+
+        try {
+            $this->deliver();
+        } catch (\Throwable $exception) {
+            Hooks::doActionCatchErrors('email_failed', $this->Subject, $recipientCount, $exception->getMessage());
+
+            throw $exception;
+        }
+
+        Hooks::doActionCatchErrors('email_sent', $this->Subject, $recipientCount);
+
+        return true;
+    }
+
+    /**
+     * Hand the message to PHPMailer, in as many packages as the configured number of recipients per
+     * mail requires.
+     *
+     * The two diagnostics of sendEmail() are given the subject, the number of recipients and, for a
+     * failure, the error - never this object. PHPMailer keeps the SMTP user name and password in
+     * public properties, so a callback that was handed the message would be handed the credentials of
+     * the installation with it.
+     *
+     * @return void
+     * @throws \Admidio\Infrastructure\Exception|Exception
+     */
+    private function deliver(): void
+    {
+        global $gSettingsManager, $gCurrentOrganization, $gLogger, $gDebug, $gValidLogin, $gCurrentUser, $gL10n;
+
+        $errorMessage = '';
+        $errorRecipients = array();
+
         // If sending mode is "SINGLE" every E-mail is sent on its own, so we do not need to check anything else here
         if ($this->sendingMode == Email::SENDINGMODE_SINGLE) {
             foreach ($this->emRecipientsArray as $recipient) {
@@ -779,8 +817,6 @@ class Email extends PHPMailer
         // initialize recipient addresses so same email could be sent to other recipients
         $this->emRecipientsNames = array();
         $this->clearAddresses();
-
-        return true;
     }
 
     /**

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -950,6 +950,15 @@ class Entity
             }
         }
 
+        // A caller may set columnsValueChanged for a change that belongs to a connected object and
+        // not to a column of this table, User::save() for its profile fields for example. If no
+        // column of this table changed, there is nothing to update, and an UPDATE without a SET
+        // clause would be a syntax error.
+        if (!$this->insertRecord && count($sqlSetArray) === 0) {
+            $this->columnsValueChanged = false;
+            return false;
+        }
+
         // Every log entry that is written by this save belongs to the same change: the creation
         // entry and the entries of the initial values of a new record, or all fields that this
         // save has modified. LogChanges stamps them with one UUID, so that they can be shown

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -1272,13 +1272,44 @@ class Entity
         }
 
         if ($this->valueChanged($columnName, $newValue)) {
-            $this->columnsInfos[$columnName]['previousValue'] = $this->dbColumns[$columnName];
-            $this->dbColumns[$columnName] = $newValue;
-            $this->columnsValueChanged = true;
-            $this->columnsInfos[$columnName]['changed'] = true;
+            if ($this->columnsInfos[$columnName]['changed'] && !$this->insertRecord
+                && !$this->valuesDiffer($columnName, $this->columnsInfos[$columnName]['previousValue'], $newValue)) {
+                // The field is back at the value that the database holds. It is not a change any
+                // more, so it must neither be written nor appear in the change history.
+                $this->dbColumns[$columnName] = $newValue;
+                $this->columnsInfos[$columnName]['changed'] = false;
+                $this->columnsInfos[$columnName]['previousValue'] = null;
+                $this->columnsValueChanged = $this->hasChangedColumns();
+            } else {
+                if (!$this->columnsInfos[$columnName]['changed']) {
+                    // Remember the value that the database holds. A field that is set more than once
+                    // before the save must still report the change from its persisted value and not
+                    // from the intermediate one.
+                    $this->columnsInfos[$columnName]['previousValue'] = $this->dbColumns[$columnName];
+                }
+                $this->dbColumns[$columnName] = $newValue;
+                $this->columnsValueChanged = true;
+                $this->columnsInfos[$columnName]['changed'] = true;
+            }
         }
 
         return true;
+    }
+
+    /**
+     * Check whether at least one column of the object still differs from the value that the
+     * database holds.
+     * @return bool Returns **true** if at least one column is marked as changed.
+     */
+    protected function hasChangedColumns(): bool
+    {
+        foreach ($this->columnsInfos as $columnInfo) {
+            if (!empty($columnInfo['changed'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1295,7 +1326,23 @@ class Entity
      */
     protected function valueChanged(string $columnName, ?string $newValue): bool
     {
-        $oldValue = isset($this->dbColumns[$columnName]) && !empty($this->dbColumns[$columnName]) ? $this->dbColumns[$columnName] : null;
+        return $this->valuesDiffer($columnName, $this->dbColumns[$columnName] ?? null, $newValue);
+    }
+
+    /**
+     * Check whether a new value differs from a given old value, considering the DB column type.
+     * valueChanged() compares against the value that the object currently holds; a change of the
+     * record has to be reported against the value that the database holds, which is the comparison
+     * this method also allows.
+     *
+     * @param string $columnName the database column name to check
+     * @param mixed $oldValue the value to compare against
+     * @param string|null $newValue the new value to set
+     * @return bool Whether the $newValue can be considered different from $oldValue
+     */
+    protected function valuesDiffer(string $columnName, mixed $oldValue, ?string $newValue): bool
+    {
+        $oldValue = !empty($oldValue) ? $oldValue : null;
 
         // certain data types need special handling to detect changes
         //   * bool: unset/null and 0 mean false

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -417,6 +417,91 @@ class Entity
     }
 
     /**
+     * Whether one of the three stages of a deletion has a listener, so that the record has to be
+     * described before it is removed.
+     * @return bool Returns **true** if a deletion of this entity has to be reported.
+     */
+    protected function hasDeletionHookListener(): bool
+    {
+        return $this->hasHookListener('deleting') || $this->hasHookListener('deleted')
+            || $this->hasHookListener('delete_failed');
+    }
+
+    /**
+     * The change set of the deletion of the record this object currently holds. A deletion reports
+     * every column of the own table as a change to **null**, so that hasChanged() and getOldValue()
+     * work the same way as for a create and an update, and the snapshot carries the record that the
+     * post-action can no longer read anywhere else.
+     * @return EntityChangeSet Returns what the deletion removes.
+     */
+    protected function buildDeletionChangeSet(): EntityChangeSet
+    {
+        $deletedColumns = array();
+        foreach ($this->dbColumns as $column => $value) {
+            if (str_starts_with($column, $this->columnPrefix . '_')) {
+                $deletedColumns[$column] = array('oldValue' => $value, 'newValue' => null);
+            }
+        }
+
+        return $this->buildChangeSet(
+            EntityChangeSet::OPERATION_DELETE,
+            (string)Uuid::uuid4(),
+            $deletedColumns
+        );
+    }
+
+    /**
+     * Queue the delete hooks of every record that the given condition selects. It is called by
+     * deleteDependentRecords() right before the records are removed, so that a record which is
+     * deleted together with the record it belongs to is reported like any other deletion. Without
+     * it the bulk DELETE would take those records out of the hook API without a trace, exactly as
+     * it would take them out of the changelog without logBulkDeletion().
+     *
+     * The records are read in one query and the values are put into this object one after the
+     * other, so a caller must not rely on what the object holds afterwards - it is cleared.
+     *
+     * @param string $sqlWhereCondition Condition that selects the records, without the leading
+     *                                  keyword WHERE. It may only use columns of the own table.
+     * @param array $queryParams Values of the prepared parameters of the condition.
+     * @param Entity|null $cause The record whose deletion removes these ones. Every change set
+     *                           names it, so that a listener can tell a membership that was ended
+     *                           from one that disappeared with its role.
+     * @return int Returns the number of deletions that were reported.
+     * @throws Exception
+     */
+    public function hookBulkDeletion(string $sqlWhereCondition, array $queryParams = array(), ?Entity $cause = null): int
+    {
+        if (!$this->hasDeletionHookListener()) {
+            return 0;
+        }
+
+        $sql = 'SELECT * FROM ' . $this->tableName . '
+                 WHERE ' . $sqlWhereCondition;
+        $statement = $this->db->queryPrepared($sql, $queryParams);
+        $reported = 0;
+
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $this->clear();
+            $this->assignRowToColumns($row);
+            $this->newRecord = false;
+            $this->insertRecord = false;
+
+            $changeSet = $this->buildDeletionChangeSet();
+            if ($cause !== null) {
+                list($causeId) = $cause->getHookKey();
+                $changeSet = $changeSet->withCause($cause->getHookId(), $causeId);
+            }
+            $this->dispatchHook('deleting', $changeSet, true);
+            EntityHookQueue::add($this, $changeSet, $this->db);
+            $reported++;
+        }
+
+        $this->clear();
+
+        return $reported;
+    }
+
+    /**
      * Build the change set of one operation from the change tracking that the object keeps anyway.
      * @param string $operation One of the EntityChangeSet::OPERATION_... constants.
      * @param string $operationId Identifies the operation across its stages.
@@ -698,19 +783,8 @@ class Entity
             // the object, so the snapshot it carries is the only thing a post-delete callback can
             // read the deleted record from.
             $changeSet = null;
-            if ($this->hasHookListener('deleting') || $this->hasHookListener('deleted')
-                || $this->hasHookListener('delete_failed')) {
-                $deletedColumns = array();
-                foreach ($this->dbColumns as $column => $value) {
-                    if (str_starts_with($column, $this->columnPrefix . '_')) {
-                        $deletedColumns[$column] = array('oldValue' => $value, 'newValue' => null);
-                    }
-                }
-                $changeSet = $this->buildChangeSet(
-                    EntityChangeSet::OPERATION_DELETE,
-                    (string)Uuid::uuid4(),
-                    $deletedColumns
-                );
+            if ($this->hasDeletionHookListener()) {
+                $changeSet = $this->buildDeletionChangeSet();
                 $this->dispatchHook('deleting', $changeSet, true);
             }
 
@@ -746,9 +820,10 @@ class Entity
     }
 
     /**
-     * Delete all records of a dependent table that belong to this record. Every record is read and
-     * deleted through its own Entity, so that each single deletion is written to the changelog. A
-     * bulk DELETE would remove the records from the audit trail without a trace, see the class
+     * Delete all records of a dependent table that belong to this record. The records are removed
+     * with one DELETE, but every one of them is described before that: logBulkDeletion() writes its
+     * changelog entry and hookBulkDeletion() queues its delete hooks. A plain bulk DELETE would take
+     * the records out of the audit trail and out of the hook API without a trace, see the class
      * documentation of ChangelogService.
      *
      * The identifying columns are named explicitly, because not every table has a single key
@@ -765,6 +840,7 @@ class Entity
     protected function deleteDependentRecords(Entity $object, array $identifyingColumns, string $sqlWhereCondition, array $queryParams = array()): int
     {
         $object->logBulkDeletion($identifyingColumns, $sqlWhereCondition, $queryParams);
+        $object->hookBulkDeletion($sqlWhereCondition, $queryParams, $this);
 
         $sql = 'DELETE FROM ' . $object->tableName . '
                  WHERE ' . $sqlWhereCondition;
@@ -1035,19 +1111,7 @@ class Entity
                 $this->insertRecord = false;
 
                 // move data to class column value array
-                foreach ($row as $key => $value) {
-                    if ($this->columnsInfos[$key]['type'] === 'boolean'
-                        || $this->columnsInfos[$key]['type'] === 'tinyint') {
-                        $this->dbColumns[$key] = (bool)$value;
-                    } elseif (($this->columnsInfos[$key]['type'] === 'integer'
-                            || $this->columnsInfos[$key]['type'] === 'smallint')
-                        && $value != '') {
-                        // only convert to int if it's not a null value
-                        $this->dbColumns[$key] = (int)$value;
-                    } else {
-                        $this->dbColumns[$key] = $value;
-                    }
-                }
+                $this->assignRowToColumns($row);
 
                 return true;
             }
@@ -1056,6 +1120,29 @@ class Entity
         }
 
         return false;
+    }
+
+    /**
+     * Move the columns of a database row into the value array of this object and convert them to
+     * the PHP type of their column, so that a boolean column is a bool and an id an int.
+     * @param array $row One row of the table, as the database returned it.
+     * @return void
+     */
+    protected function assignRowToColumns(array $row): void
+    {
+        foreach ($row as $key => $value) {
+            if ($this->columnsInfos[$key]['type'] === 'boolean'
+                || $this->columnsInfos[$key]['type'] === 'tinyint') {
+                $this->dbColumns[$key] = (bool)$value;
+            } elseif (($this->columnsInfos[$key]['type'] === 'integer'
+                    || $this->columnsInfos[$key]['type'] === 'smallint')
+                && $value != '') {
+                // only convert to int if it's not a null value
+                $this->dbColumns[$key] = (int)$value;
+            } else {
+                $this->dbColumns[$key] = $value;
+            }
+        }
     }
 
     /**

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -246,16 +246,40 @@ class Entity
     public function readableName(): string
     {
         if (array_key_exists($this->columnPrefix . '_name', $this->dbColumns)) {
-            return $this->dbColumns[$this->columnPrefix . '_name'] ?? '';
+            $name = $this->dbColumns[$this->columnPrefix . '_name'] ?? '';
         } elseif (array_key_exists($this->columnPrefix . '_title', $this->dbColumns)) {
-            return $this->dbColumns[$this->columnPrefix . '_title'] ?? '';
+            $name = $this->dbColumns[$this->columnPrefix . '_title'] ?? '';
         } elseif (array_key_exists($this->columnPrefix . '_headline', $this->dbColumns)) {
-            return $this->dbColumns[$this->columnPrefix . '_headline'] ?? '';
+            $name = $this->dbColumns[$this->columnPrefix . '_headline'] ?? '';
         } elseif (array_key_exists($this->columnPrefix . '_text', $this->dbColumns)) {
-            return $this->dbColumns[$this->columnPrefix . '_text'] ?? '';
+            $name = $this->dbColumns[$this->columnPrefix . '_text'] ?? '';
         } else {
-            return $this->dbColumns[$this->keyColumnName] ?? '';
+            $name = $this->dbColumns[$this->keyColumnName] ?? '';
         }
+
+        return $this->filterReadableName($name);
+    }
+
+    /**
+     * Pass the result of readableName() through entity_readable_name and, for an entity that names
+     * itself for the persistence hooks (see getHookId()), through <hookId>_readable_name as well.
+     * A subclass that overrides readableName() calls this on its own return value instead of
+     * dispatching the filter itself, so that one name reaches every entity regardless of how its
+     * readable name is built.
+     *
+     * @param string $name The readable name before filtering.
+     * @return string The readable name after both filters.
+     */
+    protected function filterReadableName(string $name): string
+    {
+        $name = Hooks::applyFilters('entity_readable_name', $name, $this);
+
+        $hookId = $this->getHookId();
+        if ($hookId !== null) {
+            $name = Hooks::applyFilters($hookId . '_readable_name', $name, $this);
+        }
+
+        return $name;
     }
 
     /**

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -9,6 +9,9 @@ use Admidio\Infrastructure\Utils\StringUtils;
 use Admidio\Users\Entity\User;
 use Admidio\Changelog\Entity\LogChanges;
 use Admidio\Changelog\Service\ChangelogService;
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Hooks\ValueObject\EntityFieldChange;
 use DateTime;
 use Ramsey\Uuid\Uuid;
 use Throwable;
@@ -94,6 +97,14 @@ class Entity
      * Setting this to false will disable logging in all cases, even with the preference set.
      */
     protected static bool $loggingEnabled = true;
+
+    /**
+     * Flag to enable/disable the persistence hooks of the entities.
+     * @var bool If this flag is set (default), every entity that has a hook ID dispatches its
+     * create, update and delete hooks. The installation and the update switch it off, because the
+     * schema and the core are not in a state a plugin could work with while they run.
+     */
+    protected static bool $hooksEnabled = true;
 
     /**
      * Constructor that will create an object of a recordset from the specified table.
@@ -267,6 +278,233 @@ class Entity
         self::$loggingEnabled = $enabled;
     }
 
+
+    /**
+     * Switch the persistence hooks of all entities on or off. The installation and the update
+     * switch them off: they write records of every kind while the schema and the core are still
+     * changing, and a plugin callback has nothing useful to do with that.
+     * @param bool $enabled **false** disables the hooks for the rest of the request.
+     * @return void
+     */
+    public static function setHooksEnabled(bool $enabled): void
+    {
+        self::$hooksEnabled = $enabled;
+    }
+
+    /**
+     * The stable public identifier of this entity in the hook API. It is the first half of the
+     * entity-specific hook names, so an entity with the hook ID **oidc_client** dispatches
+     * **oidc_client_created**, **oidc_client_updated** and **oidc_client_deleted**, next to the
+     * generic **entity_created**, **entity_updated** and **entity_deleted**.
+     *
+     * The identifier is a public API and is deliberately not derived from the PHP class name, so
+     * that a class can be renamed without breaking the plugins that listen to it.
+     *
+     * An entity that returns **null**, which is the default, dispatches nothing at all, the
+     * generic hooks included. That is how an entity opts out, and it is also why a new entity is
+     * silent until someone decides what its public name should be. Sessions, auto logins, the
+     * changelog itself and the OAuth tokens stay silent on purpose: they are written constantly,
+     * they hold infrastructure state or secrets, and a changelog entry that reports the writing of
+     * a changelog entry would not stop.
+     *
+     * @return string|null Returns the hook ID of this entity, or **null** if it has no hooks.
+     */
+    public function getHookId(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * The columns whose value must not be handed to a hook callback: secrets such as a password,
+     * a key or a token, and values that have no meaning outside the record, such as an image. The
+     * change set reports that these columns changed and replaces both values with
+     * EntityChangeSet::REDACTED_VALUE, and it leaves them out of its snapshot.
+     *
+     * This is deliberately not getIgnoredLogColumns(), which lists the columns that are noise in
+     * the change history. Noise and secrets are two different problems and an entity usually has
+     * different columns for each of them.
+     *
+     * @return array Returns the list of database columns whose value must not leave the record.
+     */
+    public function getSensitiveHookColumns(): array
+    {
+        return array();
+    }
+
+    /**
+     * Whether this entity dispatches persistence hooks at all and at least one callback is
+     * registered for the given stage. Building a change set reads the whole record, so nothing of
+     * it is built while nobody listens.
+     * @param string $suffix The stage, e.g. **updating** or **updated**.
+     * @return bool Returns **true** if the stage has to be dispatched.
+     */
+    protected function hasHookListener(string $suffix): bool
+    {
+        $hookId = $this->getHookId();
+
+        if (!self::$hooksEnabled || $hookId === null) {
+            return false;
+        }
+
+        return Hooks::hasAction('entity_' . $suffix) || Hooks::hasAction($hookId . '_' . $suffix);
+    }
+
+    /**
+     * Dispatch one stage of the persistence lifecycle, to the generic hook and to the hook of this
+     * entity. The order nests the two: before the operation the generic hook runs first, after it
+     * and on failure the entity-specific hook runs first, so that a callback of the generic layer
+     * encloses the callbacks of the specific one.
+     * @param string $suffix The stage, e.g. **updating** or **updated**.
+     * @param EntityChangeSet $changeSet What the operation changes or changed.
+     * @param bool $genericFirst **true** before the operation, **false** after it and on failure.
+     * @param bool $catchErrors **true** for the failure stages, where the original failure has to
+     *                          stay the one that Admidio reports.
+     * @return void
+     */
+    protected function dispatchHook(string $suffix, EntityChangeSet $changeSet, bool $genericFirst, bool $catchErrors = false): void
+    {
+        $names = array('entity_' . $suffix, $this->getHookId() . '_' . $suffix);
+
+        if (!$genericFirst) {
+            $names = array_reverse($names);
+        }
+
+        foreach ($names as $name) {
+            if ($catchErrors) {
+                Hooks::doActionCatchErrors($name, $changeSet);
+            } else {
+                Hooks::doAction($name, $changeSet);
+            }
+        }
+    }
+
+    /**
+     * Build the change set of one operation from the change tracking that the object keeps anyway.
+     * @param string $operation One of the EntityChangeSet::OPERATION_... constants.
+     * @param string $operationId Identifies the operation across its stages.
+     * @param array $changedColumns The changed columns as **column => array('oldValue', 'newValue')**.
+     *                              For a deletion this is empty, the snapshot describes the record.
+     * @return EntityChangeSet Returns what the operation changes or changed.
+     */
+    protected function buildChangeSet(string $operation, string $operationId, array $changedColumns): EntityChangeSet
+    {
+        $sensitiveColumns = $this->getSensitiveHookColumns();
+        $technicalColumns = $this->getIgnoredLogColumns();
+        $changes = array();
+
+        foreach ($changedColumns as $column => $values) {
+            if (in_array($column, $sensitiveColumns, true)) {
+                $kind = EntityFieldChange::KIND_REDACTED;
+                $oldValue = ($values['oldValue'] === null) ? null : EntityChangeSet::REDACTED_VALUE;
+                $newValue = ($values['newValue'] === null) ? null : EntityChangeSet::REDACTED_VALUE;
+            } else {
+                $kind = in_array($column, $technicalColumns, true)
+                    ? EntityFieldChange::KIND_TECHNICAL : EntityFieldChange::KIND_BUSINESS;
+                $oldValue = $values['oldValue'];
+                $newValue = $values['newValue'];
+            }
+
+            $changes[$column] = new EntityFieldChange(
+                $column,
+                $oldValue,
+                $newValue,
+                $this->columnsInfos[$column]['type'] ?? '',
+                $kind
+            );
+        }
+
+        // The snapshot is what the database holds. For an update the object already carries the
+        // new values, so the changed columns are put back to the value they are changed from.
+        $snapshot = array();
+        if ($operation !== EntityChangeSet::OPERATION_CREATE) {
+            foreach ($this->dbColumns as $column => $value) {
+                if (in_array($column, $sensitiveColumns, true)) {
+                    continue;
+                }
+                $snapshot[$column] = array_key_exists($column, $changedColumns)
+                    ? $changedColumns[$column]['oldValue'] : $value;
+            }
+        }
+
+        list($id, $uuid) = $this->getHookKey();
+
+        return new EntityChangeSet(
+            (string)$this->getHookId(),
+            static::class,
+            $this->tableName,
+            $this->columnPrefix,
+            $this->keyColumnName,
+            $id,
+            $uuid,
+            $operation,
+            $operationId,
+            $changes,
+            $snapshot
+        );
+    }
+
+    /**
+     * The key of the record as the hooks report it. Before an insert the database has not assigned
+     * the ID yet, so it is null there and known in the matching post-action.
+     * @return array Returns **array($id, $uuid)**, either of them **null** when it does not exist.
+     */
+    protected function getHookKey(): array
+    {
+        $uuidColumn = $this->columnPrefix . '_uuid';
+
+        $id = (isset($this->dbColumns[$this->keyColumnName]) && $this->dbColumns[$this->keyColumnName] !== '')
+            ? $this->dbColumns[$this->keyColumnName] : null;
+        $uuid = (array_key_exists($uuidColumn, $this->dbColumns) && $this->dbColumns[$uuidColumn] !== '')
+            ? (string)$this->dbColumns[$uuidColumn] : null;
+
+        return array($id, $uuid);
+    }
+
+    /**
+     * Let the filters transform a value that is about to be set. It runs before the type handling
+     * and the sanitizing of setValue(), so that everything a filter returns still goes through the
+     * normal checks of the column and nothing can bypass them.
+     *
+     * The key column, the UUID and the creator and editor columns are not filtered: they are the
+     * bookkeeping of the record and not data anyone should rewrite through a hook.
+     *
+     * A callback must not call setValue() on the entity it is filtering for, that would recurse.
+     *
+     * @param string $columnName The database column that is about to be set.
+     * @param mixed $newValue The proposed value.
+     * @return mixed Returns the value after the filters.
+     */
+    protected function applyValueFilters(string $columnName, mixed $newValue): mixed
+    {
+        $hookId = $this->getHookId();
+
+        if (!self::$hooksEnabled || $hookId === null) {
+            return $newValue;
+        }
+
+        $unfiltered = array(
+            $this->keyColumnName,
+            $this->columnPrefix . '_uuid',
+            $this->columnPrefix . '_usr_id_create',
+            $this->columnPrefix . '_timestamp_create',
+            $this->columnPrefix . '_usr_id_change',
+            $this->columnPrefix . '_timestamp_change'
+        );
+
+        if (in_array($columnName, $unfiltered, true)) {
+            return $newValue;
+        }
+
+        $oldValue = $this->dbColumns[$columnName] ?? null;
+
+        foreach (array('entity_value', $hookId . '_value') as $name) {
+            if (Hooks::hasFilter($name)) {
+                $newValue = Hooks::applyFilters($name, $newValue, $this, $columnName, $oldValue);
+            }
+        }
+
+        return $newValue;
+    }
     /**
      * Retrieve the list of database fields that are ignored for the changelog.
      * Some tables contain columns _usr_id_create, timestamp_create, etc. We do not want
@@ -418,6 +656,26 @@ class Entity
     public function delete(): bool
     {
         if (array_key_exists($this->keyColumnName, $this->dbColumns) && isset($this->dbColumns[$this->keyColumnName]) && $this->dbColumns[$this->keyColumnName] !== '') {
+            // The change set has to be built while the record still exists: clear() below empties
+            // the object, so the snapshot it carries is the only thing a post-delete callback can
+            // read the deleted record from.
+            $changeSet = null;
+            if ($this->hasHookListener('deleting') || $this->hasHookListener('deleted')
+                || $this->hasHookListener('delete_failed')) {
+                $deletedColumns = array();
+                foreach ($this->dbColumns as $column => $value) {
+                    if (str_starts_with($column, $this->columnPrefix . '_')) {
+                        $deletedColumns[$column] = array('oldValue' => $value, 'newValue' => null);
+                    }
+                }
+                $changeSet = $this->buildChangeSet(
+                    EntityChangeSet::OPERATION_DELETE,
+                    (string)Uuid::uuid4(),
+                    $deletedColumns
+                );
+                $this->dispatchHook('deleting', $changeSet, true);
+            }
+
             // Log record deletion, then delete. The deletion of the dependent records that a
             // derived delete() removes beforehand is a change of its own and is not part of this
             // change set.
@@ -427,7 +685,22 @@ class Entity
 
             $sql = 'DELETE FROM ' . $this->tableName . '
                      WHERE ' . $this->keyColumnName . ' = ? -- $this->dbColumns[$this->keyColumnName]';
-            $this->db->queryPrepared($sql, array($this->dbColumns[$this->keyColumnName]));
+            try {
+                $this->db->queryPrepared($sql, array($this->dbColumns[$this->keyColumnName]));
+            } catch (Throwable $exception) {
+                if ($changeSet !== null) {
+                    $this->dispatchHook('delete_failed', $changeSet, false, true);
+                }
+                throw $exception;
+            }
+
+            $this->clear();
+
+            if ($changeSet !== null) {
+                $this->dispatchHook('deleted', $changeSet, false);
+            }
+
+            return true;
         }
 
         $this->clear();
@@ -874,6 +1147,20 @@ class Entity
      * ```
      * Transactions are counted, so this is also safe when the caller is already within one.
      *
+     * An entity that has a hook ID dispatches its persistence hooks here: **entity_creating** and
+     * **&lt;entity&gt;_creating** before the statement, **&lt;entity&gt;_created** and
+     * **entity_created** after it, and the matching failure hooks when the statement fails. The
+     * pre-hooks run before anything of the object is modified, so a callback that throws to reject
+     * the operation leaves an object the caller can still save.
+     *
+     * Two things about the timing are not yet what they should be, and the transaction-aware
+     * dispatch is what fixes them:
+     *  - the post-hooks fire when the statement ran, not when the enclosing transaction committed,
+     *    so a callback can still describe a change that is rolled back afterwards;
+     *  - a logical operation that saves the same record more than once dispatches once per save.
+     *    User::save() does that for a registration, and events_function.php does it for an event
+     *    whose participation role is created.
+     *
      * @param bool $updateFingerPrint Default **true**. Will update the creator or editor of the recordset
      *                                if a table has columns like **usr_id_create** or **usr_id_change**
      * @return bool If an update or insert into the database was done, then return true, otherwise false.
@@ -916,6 +1203,46 @@ class Entity
         $returnCode = false;
 
         $logChanges = array();
+
+        // The hooks describe the same operation as the changelog, but they also report the
+        // bookkeeping columns and they need the value of the object and not the one that the
+        // PostgreSQL boolean conversion below produces. Nothing of this is collected while no
+        // callback is registered for any stage of this operation.
+        $operation = $this->insertRecord ? EntityChangeSet::OPERATION_CREATE : EntityChangeSet::OPERATION_UPDATE;
+        $hookStages = ($operation === EntityChangeSet::OPERATION_CREATE)
+            ? array('creating', 'created', 'create_failed')
+            : array('updating', 'updated', 'update_failed');
+        $collectHookChanges = false;
+        foreach ($hookStages as $hookStage) {
+            if ($this->hasHookListener($hookStage)) {
+                $collectHookChanges = true;
+                break;
+            }
+        }
+        // Collect them before the loop below, because that loop clears the changed flags as it
+        // builds the statement. A pre-action that vetoes the operation by throwing has to leave
+        // the object exactly as it found it, so that the caller can handle the rejection and save
+        // again.
+        $hookChanges = array();
+        if ($collectHookChanges) {
+            foreach ($this->dbColumns as $key => $value) {
+                if (str_starts_with($key, $this->columnPrefix . '_')
+                    && !$this->columnsInfos[$key]['serial'] && $this->columnsInfos[$key]['changed']) {
+                    $hookChanges[$key] = array(
+                        'oldValue' => ($operation === EntityChangeSet::OPERATION_CREATE)
+                            ? null : $this->columnsInfos[$key]['previousValue'],
+                        'newValue' => $value
+                    );
+                }
+            }
+        }
+
+        $changeSet = null;
+        if ($collectHookChanges
+            && ($operation === EntityChangeSet::OPERATION_CREATE || count($hookChanges) > 0)) {
+            $changeSet = $this->buildChangeSet($operation, (string)Uuid::uuid4(), $hookChanges);
+            $this->dispatchHook($hookStages[0], $changeSet, true);
+        }
 
         // Loop over all DB fields and add them to the update
         foreach ($this->dbColumns as $key => $value) {
@@ -965,37 +1292,53 @@ class Entity
         // together in the change history.
         $previousChangeSet = LogChanges::startChangeSet();
 
-        if ($this->insertRecord) {
-            // insert record and remember the new id
-            $sql = 'INSERT INTO ' . $this->tableName . '
-                           (' . implode(',', $sqlFieldArray) . ')
-                    VALUES (' . Database::getQmForValues($sqlFieldArray) . ')';
-            if ($this->db->queryPrepared($sql, $queryParams) !== false) {
-                $returnCode = true;
-                if ($this->keyColumnName !== '') {
-                    $this->dbColumns[$this->keyColumnName] = $this->db->lastInsertId();
+        try {
+            if ($this->insertRecord) {
+                // insert record and remember the new id
+                $sql = 'INSERT INTO ' . $this->tableName . '
+                               (' . implode(',', $sqlFieldArray) . ')
+                        VALUES (' . Database::getQmForValues($sqlFieldArray) . ')';
+                if ($this->db->queryPrepared($sql, $queryParams) !== false) {
+                    $returnCode = true;
+                    if ($this->keyColumnName !== '') {
+                        $this->dbColumns[$this->keyColumnName] = $this->db->lastInsertId();
+                    }
+                    // The result of the log writes is deliberately not evaluated, see the comment
+                    // about transactions in the description of this method.
+                    $this->logCreation();
+                    $this->logModifications($logChanges);
+                    $this->insertRecord = false;
                 }
-                // The result of the log writes is deliberately not evaluated, see the comment
-                // about transactions in the description of this method.
-                $this->logCreation();
-                $this->logModifications($logChanges);
-                $this->insertRecord = false;
+            } else {
+                $sql = 'UPDATE ' . $this->tableName . '
+                           SET ' . implode(', ', $sqlSetArray) . '
+                         WHERE ' . $this->keyColumnName . ' = ? -- $this->dbColumns[$this->keyColumnName]';
+                $queryParams[] = $this->dbColumns[$this->keyColumnName];
+                if ($this->db->queryPrepared($sql, $queryParams) !== false) {
+                    $returnCode = true;
+                    // Log record modification
+                    $this->logModifications($logChanges);
+                }
             }
-        } else {
-            $sql = 'UPDATE ' . $this->tableName . '
-                       SET ' . implode(', ', $sqlSetArray) . '
-                     WHERE ' . $this->keyColumnName . ' = ? -- $this->dbColumns[$this->keyColumnName]';
-            $queryParams[] = $this->dbColumns[$this->keyColumnName];
-            if ($this->db->queryPrepared($sql, $queryParams) !== false) {
-                $returnCode = true;
-                // Log record modification
-                $this->logModifications($logChanges);
+        } catch (Throwable $exception) {
+            if ($changeSet !== null) {
+                // cleanup for whoever prepared something in the pre-action, and the original
+                // failure stays the one that Admidio reports
+                $this->dispatchHook($hookStages[2], $changeSet, false, true);
             }
+            throw $exception;
         }
 
         LogChanges::endChangeSet($previousChangeSet);
 
         $this->columnsValueChanged = false;
+
+        if ($changeSet !== null && $returnCode) {
+            // an insert only learns its ID from the database, so the post-action gets the key that
+            // the pre-action could not know yet
+            list($id, $uuid) = $this->getHookKey();
+            $this->dispatchHook($hookStages[1], $changeSet->withKey($id, $uuid), false);
+        }
 
         return $returnCode;
     }
@@ -1142,6 +1485,9 @@ class Entity
 
         // normalize string values
         $newValue = is_string($newValue) ? trim($newValue) : $newValue;
+
+        // a filter may transform or reject the proposed value, the checks below then run on its result
+        $newValue = $this->applyValueFilters($columnName, $newValue);
 
         if ($checkValue) {
             if (!isset($newValue) || $newValue === '') {

--- a/src/Infrastructure/Entity/Entity.php
+++ b/src/Infrastructure/Entity/Entity.php
@@ -10,6 +10,7 @@ use Admidio\Users\Entity\User;
 use Admidio\Changelog\Entity\LogChanges;
 use Admidio\Changelog\Service\ChangelogService;
 use Admidio\Hooks\Hooks;
+use Admidio\Hooks\Service\EntityHookQueue;
 use Admidio\Hooks\ValueObject\EntityChangeSet;
 use Admidio\Hooks\ValueObject\EntityFieldChange;
 use DateTime;
@@ -379,6 +380,43 @@ class Entity
     }
 
     /**
+     * Dispatch the hooks of an operation that is now really in the database. The queue calls this
+     * at the commit of the outermost transaction, with the operations of one record already put
+     * together, so a plugin sees one event for one logical change and never one for a change that
+     * was rolled back.
+     * @param EntityChangeSet $changeSet What the transaction changed about this record.
+     * @return void
+     */
+    public function dispatchCommittedHook(EntityChangeSet $changeSet): void
+    {
+        $suffix = match ($changeSet->getOperation()) {
+            EntityChangeSet::OPERATION_CREATE => 'created',
+            EntityChangeSet::OPERATION_DELETE => 'deleted',
+            default => 'updated'
+        };
+
+        $this->dispatchHook($suffix, $changeSet, false);
+    }
+
+    /**
+     * Dispatch the failure hooks of an operation whose transaction never reached the database. The
+     * queue calls this on a rollback and at the end of a request that abandoned a transaction, so
+     * that a callback which reserved something in the pre-action can release it again.
+     * @param EntityChangeSet $changeSet What the operation would have changed.
+     * @return void
+     */
+    public function dispatchFailedHook(EntityChangeSet $changeSet): void
+    {
+        $suffix = match ($changeSet->getOperation()) {
+            EntityChangeSet::OPERATION_CREATE => 'create_failed',
+            EntityChangeSet::OPERATION_DELETE => 'delete_failed',
+            default => 'update_failed'
+        };
+
+        $this->dispatchHook($suffix, $changeSet, false, true);
+    }
+
+    /**
      * Build the change set of one operation from the change tracking that the object keeps anyway.
      * @param string $operation One of the EntityChangeSet::OPERATION_... constants.
      * @param string $operationId Identifies the operation across its stages.
@@ -688,8 +726,8 @@ class Entity
             try {
                 $this->db->queryPrepared($sql, array($this->dbColumns[$this->keyColumnName]));
             } catch (Throwable $exception) {
-                if ($changeSet !== null) {
-                    $this->dispatchHook('delete_failed', $changeSet, false, true);
+                if ($changeSet !== null && !$this->db->isInTransaction()) {
+                    $this->dispatchFailedHook($changeSet);
                 }
                 throw $exception;
             }
@@ -697,7 +735,7 @@ class Entity
             $this->clear();
 
             if ($changeSet !== null) {
-                $this->dispatchHook('deleted', $changeSet, false);
+                EntityHookQueue::add($this, $changeSet, $this->db);
             }
 
             return true;
@@ -1153,13 +1191,10 @@ class Entity
      * pre-hooks run before anything of the object is modified, so a callback that throws to reject
      * the operation leaves an object the caller can still save.
      *
-     * Two things about the timing are not yet what they should be, and the transaction-aware
-     * dispatch is what fixes them:
-     *  - the post-hooks fire when the statement ran, not when the enclosing transaction committed,
-     *    so a callback can still describe a change that is rolled back afterwards;
-     *  - a logical operation that saves the same record more than once dispatches once per save.
-     *    User::save() does that for a registration, and events_function.php does it for an event
-     *    whose participation role is created.
+     * The post-hooks do not fire here. EntityHookQueue holds them until the outermost transaction
+     * commits, and it reduces the saves of one record within that transaction to the one change
+     * that happened as far as anybody outside can tell. Without an open transaction the statement
+     * is the commit and they fire immediately.
      *
      * @param bool $updateFingerPrint Default **true**. Will update the creator or editor of the recordset
      *                                if a table has columns like **usr_id_create** or **usr_id_change**
@@ -1321,10 +1356,11 @@ class Entity
                 }
             }
         } catch (Throwable $exception) {
-            if ($changeSet !== null) {
-                // cleanup for whoever prepared something in the pre-action, and the original
-                // failure stays the one that Admidio reports
-                $this->dispatchHook($hookStages[2], $changeSet, false, true);
+            // cleanup for whoever prepared something in the pre-action, and the original failure
+            // stays the one that Admidio reports. Inside a transaction the database runs the
+            // failure hooks of everything the transaction did, this one included.
+            if ($changeSet !== null && !$this->db->isInTransaction()) {
+                $this->dispatchFailedHook($changeSet);
             }
             throw $exception;
         }
@@ -1337,7 +1373,7 @@ class Entity
             // an insert only learns its ID from the database, so the post-action gets the key that
             // the pre-action could not know yet
             list($id, $uuid) = $this->getHookKey();
-            $this->dispatchHook($hookStages[1], $changeSet->withKey($id, $uuid), false);
+            EntityHookQueue::add($this, $changeSet->withKey($id, $uuid), $this->db);
         }
 
         return $returnCode;

--- a/src/Infrastructure/Entity/Text.php
+++ b/src/Infrastructure/Entity/Text.php
@@ -85,14 +85,12 @@ class Text extends Entity
 //        $textLabel = Language::translateIfTranslationStrId($textLabels[$row['name']]);
         if (array_key_exists($this->columnPrefix.'_name', $this->dbColumns)) {
             $textLabel = $this->dbColumns[$this->columnPrefix.'_name'];
-            if (array_key_exists($textLabel, $textLabels)) {
-                return $textLabels[$textLabel];
-            } else {
-                return $textLabel;
-            }
+            $name = array_key_exists($textLabel, $textLabels) ? $textLabels[$textLabel] : $textLabel;
         } else {
-            return $this->dbColumns[$this->keyColumnName];
+            $name = $this->dbColumns[$this->keyColumnName];
         }
+
+        return $this->filterReadableName($name);
     }
     /**
      * Retrieve the list of database fields that are ignored for the changelog.

--- a/src/Infrastructure/Language.php
+++ b/src/Infrastructure/Language.php
@@ -1,6 +1,7 @@
 <?php
 namespace Admidio\Infrastructure;
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
 
@@ -248,11 +249,55 @@ class Language
             // Read language folders of the plugins. Maybe there was a new plugin installed.
             $this->addPluginLanguageFolderPaths();
 
-            // no text found then write #undefined text#
-            return '#' . $textId . '#';
+            $text = $this->resolveMissingText($textId);
+
+            if ($text === null) {
+                // no text found then write #undefined text#
+                return '#' . $textId . '#';
+            }
+        }
+
+        // The filter runs on every text and after the cache, because it is the only one of the
+        // translation hooks that may depend on more than the text id and the language - the page
+        // that is being built, or who is looking at it. It is skipped entirely while nobody listens,
+        // which is one array lookup per text.
+        if (Hooks::hasFilter('translation_text')) {
+            $text = Hooks::applyTypedFilters('translation_text', $text, $textId, $this->language);
         }
 
         return self::prepareTextPlaceholders($text, $params);
+    }
+
+    /**
+     * Ask the **translation_missing** resolver for a text that neither the language of the
+     * installation nor the reference language has, so that a plugin can supply the texts of its own
+     * without shipping an XML file for every language.
+     *
+     * The answer is put into the text cache, which lives in the session, so it is asked once per text
+     * and session and not once per request. A plugin whose texts change - because it was switched off,
+     * or because someone edited them - tells Admidio the same way the profile fields do, with
+     * Session::reloadAllSessions(); the next request of every session then rebuilds this object and
+     * its cache.
+     *
+     * When nobody has an answer, **translation_unresolved** is dispatched as a diagnostic. It is a
+     * diagnostic and must not be able to break the page, so it is dispatched with
+     * doActionCatchErrors().
+     *
+     * @param string $textId Unique text id of the text that was not found.
+     * @return string|null Returns the text, or **null** if nobody has one.
+     */
+    private function resolveMissingText(string $textId): ?string
+    {
+        $text = Hooks::resolve('translation_missing', null, $textId, $this->language);
+
+        if (is_string($text)) {
+            $this->textCache[$textId] = $text;
+            return $text;
+        }
+
+        Hooks::doActionCatchErrors('translation_unresolved', $textId, $this->language);
+
+        return null;
     }
 
     /**
@@ -414,7 +459,18 @@ class Language
                 // if text id wasn't found than search for it in reference language
                 try {
                     // search for text id in every \SimpleXMLElement (language file) of the object array
-                    return $this->searchTextIdInLangObject($this->xmlRefLanguageObjects, $this::REFERENCE_LANGUAGE, $textId);
+                    $text = $this->searchTextIdInLangObject($this->xmlRefLanguageObjects, $this::REFERENCE_LANGUAGE, $textId);
+
+                    // The text exists, but not in the language that was asked for. This is the only
+                    // place that knows it: searchLanguageText() writes the text into the cache without
+                    // its provenance, so every later request of the session is answered from the cache
+                    // and cannot tell the two apart. Once per text and session is what a translator
+                    // needs to collect what is missing.
+                    if ($this->language !== $this::REFERENCE_LANGUAGE) {
+                        Hooks::doActionCatchErrors('translation_fallback_used', $textId, $this->language, $this::REFERENCE_LANGUAGE);
+                    }
+
+                    return $text;
                 } catch (\OutOfBoundsException $exception) {
                     throw new \OutOfBoundsException($exception->getMessage());
                 }

--- a/src/Infrastructure/Service/RegistrationService.php
+++ b/src/Infrastructure/Service/RegistrationService.php
@@ -1,6 +1,7 @@
 <?php
 namespace Admidio\Infrastructure\Service;
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\SystemMail;
@@ -78,6 +79,13 @@ class RegistrationService
                 $user->assignDefaultRoles();
             }
             $this->db->endTransaction();
+
+            // The merge itself has already committed at this point - the mail below is a separate
+            // concern and its own catch block does not undo it, so the semantic event fires whether
+            // or not the mail succeeds.
+            $this->db->registerAfterCommit(function () use ($user) {
+                Hooks::doAction('user_registration_accepted', $user, UserRegistration::ACCEPTED_BY_ASSIGNMENT);
+            });
 
             if ($gSettingsManager->getBool('system_notifications_enabled')) {
                 // Send mail to the user to confirm the registration or the assignment to the new organization

--- a/src/InstallationUpdate/Service/Installation.php
+++ b/src/InstallationUpdate/Service/Installation.php
@@ -490,6 +490,7 @@ class Installation
          * changelog. Beside that the tables of the changelog don't exist before db.sql was executed.
          */
         Entity::setLoggingEnabled(false);
+        Entity::setHooksEnabled(false);
 
         $gL10n->setLanguage($config->language);
 

--- a/src/Inventory/Entity/Item.php
+++ b/src/Inventory/Entity/Item.php
@@ -168,7 +168,7 @@ class Item extends Entity
             $itemName = (string)$this->mItemsData->getValue('ITEMNAME', 'database');
         }
 
-        return $itemName;
+        return $this->filterReadableName($itemName);
     }
 
     /**

--- a/src/Inventory/Entity/Item.php
+++ b/src/Inventory/Entity/Item.php
@@ -76,6 +76,15 @@ class Item extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'inventory_item';
+    }
+
+    /**
      * Changes to user data could be sent as a notification email to a specific role if this
      * function is enabled in the settings. If you want to suppress this logic you can
      * explicit disable it with this method for this user. So no changes to this user object will

--- a/src/Inventory/Entity/ItemBorrowData.php
+++ b/src/Inventory/Entity/ItemBorrowData.php
@@ -48,6 +48,15 @@ class ItemBorrowData extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'inventory_item_borrow_data';
+    }
+
+    /**
      * Update the record ID of this entity.
      * This method is used when the record ID is generated outside of this entity,
      * for example, after inserting a new record into the database.

--- a/src/Inventory/Entity/ItemData.php
+++ b/src/Inventory/Entity/ItemData.php
@@ -50,6 +50,15 @@ class ItemData extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'inventory_item_data';
+    }
+
+    /**
      * Since creation means setting value from NULL to something, deletion mean setting the field to empty,
      * we need one generic change log function that is called on creation, deletion and modification.
      *

--- a/src/Inventory/Entity/ItemField.php
+++ b/src/Inventory/Entity/ItemField.php
@@ -46,6 +46,15 @@ class ItemField extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'inventory_field';
+    }
+
+    /**
      * Deletes the selected field and all references in other tables.
      * Also, the gap in sequence will be closed. After that the class will be initialized.
      * @return true true if no error occurred

--- a/src/Inventory/Entity/SelectOptions.php
+++ b/src/Inventory/Entity/SelectOptions.php
@@ -39,6 +39,15 @@ class SelectOptions extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'inventory_field_select_option';
+    }
+
+    /**
      * Read all options of the select field with the id $infId from the database and store them in the internal array $optionValues.
      * The values are stored in the array with their ID as key.
      * If no id is set than no data will be read.

--- a/src/Inventory/ValueObjects/ItemsData.php
+++ b/src/Inventory/ValueObjects/ItemsData.php
@@ -1173,22 +1173,31 @@ class ItemsData
 
         $item = new Item($this->mDb, $this, $this->mItemId);
 
-        // delete all item data. The values are logged before they are removed, a plain DELETE would
-        // take them out of the change history without a trace.
+        // delete all item data. The values are logged and reported to the persistence hooks before
+        // they are removed, a plain DELETE would take them out of the change history and out of the
+        // hook API without a trace - the same reason Entity::deleteDependentRecords() calls both.
+        // This class is not an Entity subclass, so it calls logBulkDeletion() and hookBulkDeletion()
+        // itself instead of going through that helper.
         $itemData = new ItemData($this->mDb, $this);
         $itemData->logBulkDeletion(array('ind_id'), 'ind_ini_id = ?', array($this->mItemId));
+        $itemData->hookBulkDeletion('ind_ini_id = ?', array($this->mItemId), $item);
         $sql = 'DELETE FROM ' . TBL_INVENTORY_ITEM_DATA . ' WHERE ind_ini_id = ?;';
         $this->mDb->queryPrepared($sql, array($this->mItemId));
 
         // delete all item borrow data
         $itemBorrowData = new ItemBorrowData($this->mDb, $this);
         $itemBorrowData->logBulkDeletion(array('inb_id'), 'inb_ini_id = ?', array($this->mItemId));
+        $itemBorrowData->hookBulkDeletion('inb_ini_id = ?', array($this->mItemId), $item);
         $sql = 'DELETE FROM ' . TBL_INVENTORY_ITEM_BORROW_DATA . ' WHERE inb_ini_id = ?;';
         $this->mDb->queryPrepared($sql, array($this->mItemId));
 
         // Log and delete the item itself last. The change history shows a change with the record it
         // is about, and it recognizes that record as the entry that a deletion logs last.
+        // hookBulkDeletion() is used instead of $item->delete() so that the exact WHERE condition -
+        // including the organization guard - is the one that decides what is actually deleted; it
+        // dispatches the same inventory_item_deleting / inventory_item_deleted as delete() would.
         $item->logDeletion();
+        $item->hookBulkDeletion('ini_id = ? AND (ini_org_id = ? OR ini_org_id IS NULL)', array($this->mItemId, $this->organizationId));
 
         $sql = 'DELETE FROM ' . TBL_INVENTORY_ITEMS . ' WHERE ini_id = ? AND (ini_org_id = ? OR ini_org_id IS NULL);';
         $this->mDb->queryPrepared($sql, array($this->mItemId, $this->organizationId));

--- a/src/Menu/Entity/MenuEntry.php
+++ b/src/Menu/Entity/MenuEntry.php
@@ -35,6 +35,15 @@ class MenuEntry extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'menu_entry';
+    }
+
+    /**
      * Deletes the selected menu entries.
      * After that the class will be initialized.
      * @return bool **true** if no error occurred

--- a/src/Messages/Entity/Message.php
+++ b/src/Messages/Entity/Message.php
@@ -56,6 +56,15 @@ class Message extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'message';
+    }
+
+    /**
      * Add an attachment from a path on the filesystem.
      * @param string $path        Path to the attachment
      * @param string $name        Overrides the attachment name

--- a/src/Messages/Entity/MessageContent.php
+++ b/src/Messages/Entity/MessageContent.php
@@ -29,6 +29,15 @@ class MessageContent extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'message_content';
+    }
+
+    /**
      * Get the value of a column of the database table.
      * If the value was manipulated before with **setValue** than the manipulated value is returned.
      * @param string $columnName The name of the database column whose value should be read

--- a/src/Organizations/Entity/Organization.php
+++ b/src/Organizations/Entity/Organization.php
@@ -998,9 +998,11 @@ class Organization extends Entity
     public function readableName(): string
     {
         if (array_key_exists($this->columnPrefix.'_longname', $this->dbColumns)) {
-            return $this->dbColumns[$this->columnPrefix.'_longname'];
+            $name = $this->dbColumns[$this->columnPrefix.'_longname'];
         } else {
-            return $this->dbColumns[$this->keyColumnName];
+            $name = $this->dbColumns[$this->keyColumnName];
         }
+
+        return $this->filterReadableName($name);
     }
 }

--- a/src/Organizations/Entity/Organization.php
+++ b/src/Organizations/Entity/Organization.php
@@ -85,6 +85,15 @@ class Organization extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'organization';
+    }
+
+    /**
      * Initialize all necessary data of this object.
      * @return void
      * @throws Exception

--- a/src/Photos/Entity/Album.php
+++ b/src/Photos/Entity/Album.php
@@ -40,6 +40,15 @@ class Album extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'photo_album';
+    }
+
+    /**
      * Initialize all necessary data of this object.
      * @return void
      * @throws Exception

--- a/src/ProfileFields/Entity/ProfileField.php
+++ b/src/ProfileFields/Entity/ProfileField.php
@@ -55,6 +55,15 @@ class ProfileField extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'profile_field';
+    }
+
+    /**
      * Additional to the parent method visible roles array and flag will be initialized.
      * @throws Exception
      */

--- a/src/ProfileFields/Entity/SelectOptions.php
+++ b/src/ProfileFields/Entity/SelectOptions.php
@@ -39,6 +39,15 @@ class SelectOptions extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'profile_field_select_option';
+    }
+
+    /**
      * Read all options of the select field with the id $usfId from the database and store them in the internal array $optionValues.
      * The values are stored in the array with their ID as key.
      * If no id is set than no data will be read.

--- a/src/ProfileFields/ValueObjects/ProfileFields.php
+++ b/src/ProfileFields/ValueObjects/ProfileFields.php
@@ -448,7 +448,36 @@ class ProfileFields
             if ($format === 'database') {
                 return $value;
             }
+        }
 
+        return $this->formatValue($fieldNameIntern, $value, $format);
+    }
+
+    /**
+     * Format the raw value of a profile field the way getValue() formats the value of the loaded
+     * user: a date in the date format of the installation, a dropdown, radio button or multiselect
+     * as the text of its options, a country as the name of the country, and the whole thing as HTML
+     * when that format is asked for.
+     *
+     * It is the transformation of getValue(), factored out of it so that a value which does not come
+     * from the loaded user can be shown the same way - a value out of a change set of the hooks, out
+     * of the changelog or out of a query of its own.
+     *
+     * @param string $fieldNameIntern Expects the **usf_name_intern** of the profile field.
+     * @param mixed $value The value as the column **usd_value** holds it.
+     * @param string $format Description of the formatted output. **database** returns the value
+     *                       unchanged, **text**, **html** and an empty format use the settings of
+     *                       the installation, any other value is a date format for a date field.
+     * @return mixed Returns the formatted value.
+     * @throws Exception
+     */
+    public function formatValue(string $fieldNameIntern, mixed $value, string $format = ''): mixed
+    {
+        if ($format === 'database') {
+            return $value;
+        }
+
+        if (array_key_exists($fieldNameIntern, $this->mProfileFields)) {
             if ($fieldNameIntern === 'COUNTRY') {
                 if ($value !== '') {
                     // read the language name of the country

--- a/src/Roles/Entity/ListColumns.php
+++ b/src/Roles/Entity/ListColumns.php
@@ -38,6 +38,15 @@ use Admidio\ProfileFields\Entity\ProfileField;
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'list_column';
+    }
+
+    /**
      * Logs creation of the DB record
      * 
      * @return true Returns **true** if no error occurred

--- a/src/Roles/Entity/ListConfiguration.php
+++ b/src/Roles/Entity/ListConfiguration.php
@@ -86,6 +86,15 @@ class ListConfiguration extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'list_configuration';
+    }
+
+    /**
      * Add new column to a column array. The number of the column will be the maximum number of the current
      * array plus one. The special fields must be part from the list of allowed columns. Also, the special field
      * usr_uuid could only be added by users with the right to edit all users.

--- a/src/Roles/Entity/Membership.php
+++ b/src/Roles/Entity/Membership.php
@@ -51,6 +51,15 @@ class Membership extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'membership';
+    }
+
+    /**
      * Set a new value for a column of the database table. The value is only saved in the object.
      * You must call the method **save** to store the new value to the database. If the unique key
      * column is set to 0, then this record will be a new record and all other columns are marked as changed.

--- a/src/Roles/Entity/Membership.php
+++ b/src/Roles/Entity/Membership.php
@@ -10,7 +10,6 @@ use Admidio\Changelog\Entity\LogChanges;
 use Admidio\Changelog\Service\ChangelogService;
 use Admidio\Users\Entity\User;
 use DateTime;
-use Throwable;
 
 /**
  * @brief Handle memberships of roles and manage it in the database table adm_members
@@ -60,52 +59,6 @@ class Membership extends Entity
     }
 
     /**
-     * Set a new value for a column of the database table. The value is only saved in the object.
-     * You must call the method **save** to store the new value to the database. If the unique key
-     * column is set to 0, then this record will be a new record and all other columns are marked as changed.
-     * This method also queues the changes to the field for admin notification
-     * messages. Apart from this, the parent's **setValue** is used to set the new value.
-     * @param string $columnName The name of the database column whose value should get a new value
-     * @param mixed $newValue The new value that should be stored in the database field
-     * @param bool $checkValue The value will be checked if it's valid. If set to **false** then the value will not be checked.
-     * @return bool Returns **true** if the value is stored in the current object and **false** if a check failed
-     * @throws Exception
-     * @see Entity#getValue
-     */
-    public function setValue(string $columnName, mixed $newValue, bool $checkValue = true): bool
-    {
-        global $gChangeNotification, $gCurrentSession, $gSettingsManager;
-
-        // New records will be logged in save, because their ID is only generated during first save
-        if (!$this->newRecord && isset($gCurrentSession)) {
-            if (in_array($columnName, array('mem_begin', 'mem_end'))) {
-                $oldValue = $this->getValue($columnName, $gSettingsManager->getString('system_date'));
-            } else {
-                $oldValue = $this->getValue($columnName);
-            }
-            // format the new value in system date format for logging and notification
-            $newValueLogging = $newValue;
-            try {
-                $date = new DateTime($newValue);
-                $newValueLogging = $date->format($gSettingsManager->getString('system_date'));
-            } catch (Throwable) {
-                // not a date, so keep original value
-            }
-            if ($oldValue != $newValueLogging) {
-                $memId = $this->getValue('mem_id');
-                $obj = new self($this->db, $memId);
-                $gChangeNotification->logRoleChange(
-                    $obj,
-                    $columnName,
-                    (string)$oldValue,
-                    (string)$newValueLogging
-                );
-            }
-        }
-        return parent::setValue($columnName, $newValue, $checkValue);
-    }
-
-    /**
      * Deletes a membership for the assigned role and user. In opposite to removeMembership
      * this method will delete the entry, and you can't see any history assignment.
      * If the user is the current user, then initiate a refresh of his role cache.
@@ -138,42 +91,13 @@ class Membership extends Entity
     }
 
     /**
-     * Deletes the selected record of the table and optionally sends an admin notification if configured
+     * Deletes the selected record of the table and renews the user object of the affected user
      * @return true Returns **true** if no error occurred
      * @throws Exception
      */
     public function delete(): bool
     {
-        // Queue admin notification about membership deletion
-        global $gChangeNotification, $gCurrentSession, $gSettingsManager;
-
-        // If this is a new record that hasn't been written to the database, simply ignore it
-        if (!$this->newRecord && is_object($gChangeNotification)) {
-            $memId = $this->getValue('mem_id');
-            $obj = new self($this->db, $memId);
-
-            // Log begin, end and leader as changed (set to NULL)
-            $gChangeNotification->logRoleChange(
-                $obj,
-                'mem_begin',
-                $this->getValue('mem_begin', $gSettingsManager->getString('system_date')),
-                ''
-            );
-            $gChangeNotification->logRoleChange(
-                $obj,
-                'mem_end',
-                $this->getValue('mem_end', $gSettingsManager->getString('system_date')),
-                ''
-            );
-            if ($this->getValue('mem_leader')) {
-                $gChangeNotification->logRoleChange(
-                    $obj,
-                    'mem_leader',
-                    $this->getValue('mem_leader'),
-                    ''
-                );
-            }
-        }
+        global $gCurrentSession;
 
         if (isset($gCurrentSession)) {
             // renew a user object of the affected user because of edited role assignment
@@ -194,7 +118,7 @@ class Membership extends Entity
      */
     public function save(bool $updateFingerPrint = true): bool
     {
-        global $gCurrentSession, $gChangeNotification, $gCurrentUser, $gSettingsManager;
+        global $gCurrentSession, $gCurrentUser;
 
         // if a role is administrator than only administrator can add new user,
         // but don't change their own membership, because there must be at least one administrator
@@ -202,45 +126,11 @@ class Membership extends Entity
             throw new Exception('SYS_NO_RIGHTS');
         }
 
-        $newRecord = $this->newRecord;
-
         $returnStatus = parent::save($updateFingerPrint);
 
         if ($returnStatus && isset($gCurrentSession)) {
             // renew a user object of the affected user because of edited role assignment
             $gCurrentSession->reload((int)$this->getValue('mem_usr_id'));
-        }
-
-        if ($newRecord && is_object($gChangeNotification)) {
-            // Queue admin notification about membership deletion
-
-            // storing a record for the first time does NOT update the fields from
-            // the role table => need to create a new object that loads the
-            // role name from the database too!
-            $memId = $this->getValue('mem_id');
-            $obj = new self($this->db, $memId);
-
-            // Log begin, end and leader as changed (set to NULL)
-            $gChangeNotification->logRoleChange(
-                $obj,
-                'mem_begin',
-                '',
-                $obj->getValue('mem_begin', $gSettingsManager->getString('system_date'))
-            );
-            $gChangeNotification->logRoleChange(
-                $obj,
-                'mem_end',
-                '',
-                $obj->getValue('mem_end', $gSettingsManager->getString('system_date'))
-            );
-            if ($obj->getValue('mem_leader')) {
-                $gChangeNotification->logRoleChange(
-                    $obj,
-                    'mem_leader',
-                    '',
-                    $obj->getValue('mem_leader')
-                );
-            }
         }
 
         return $returnStatus;

--- a/src/Roles/Entity/Role.php
+++ b/src/Roles/Entity/Role.php
@@ -78,6 +78,15 @@ class Role extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'role';
+    }
+
+    /**
      * Set the current role active.
      * Event roles could not be set active.
      * @throws Exception

--- a/src/Roles/Entity/RolesDependencies.php
+++ b/src/Roles/Entity/RolesDependencies.php
@@ -50,12 +50,19 @@ class RolesDependencies extends Entity
         if (array_key_exists('rld_rol_id_parent', $this->dbColumns) && $this->dbColumns['rld_rol_id_parent'] !== '' &&
             array_key_exists('rld_rol_id_child', $this->dbColumns) && $this->dbColumns['rld_rol_id_child'] !== ''
         ) {
-            // Log record deletion, then delete
+            // The composite key means this cannot go through the base Entity::delete(), so the
+            // change set is logged and reported to the persistence hooks by hand, the same way it
+            // does it for itself - hookBulkDeletion() reads $this->dbColumns before clearing them,
+            // so the two ids are captured first.
+            $parentId = $this->dbColumns['rld_rol_id_parent'];
+            $childId = $this->dbColumns['rld_rol_id_child'];
+
             $this->logDeletion();
+            $this->hookBulkDeletion('rld_rol_id_parent = ? AND rld_rol_id_child = ?', array($parentId, $childId));
             $sql = 'DELETE FROM '.$this->tableName.'
-                     WHERE rld_rol_id_parent = ? -- $this->dbColumns[\'rld_rol_id_parent\']
-                     AND rld_rol_id_child = ? -- $this->dbColumns[\'rld_rol_id_child\']';
-            $this->db->queryPrepared($sql, array($this->dbColumns['rld_rol_id_parent'], $this->dbColumns['rld_rol_id_child']));
+                     WHERE rld_rol_id_parent = ? -- $parentId
+                     AND rld_rol_id_child = ? -- $childId';
+            $this->db->queryPrepared($sql, array($parentId, $childId));
         }
 
         $this->clear();

--- a/src/Roles/Entity/RolesDependencies.php
+++ b/src/Roles/Entity/RolesDependencies.php
@@ -26,6 +26,15 @@ class RolesDependencies extends Entity
     {
         parent::__construct($database, TBL_ROLE_DEPENDENCIES, 'rld');
     }
+
+    /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'role_dependency';
+    }
    
     /**
      * Deletes the selected record of the table and initializes the class

--- a/src/Roles/Entity/RolesRights.php
+++ b/src/Roles/Entity/RolesRights.php
@@ -75,6 +75,15 @@ class RolesRights extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'role_right';
+    }
+
+    /**
      * Add all roles of the parameter array to the current roles rights object.
      * @param array<int,int> $roleIds Array with all role ids that should be added.
      * @throws Exception

--- a/src/Roles/Entity/RolesRightsData.php
+++ b/src/Roles/Entity/RolesRightsData.php
@@ -49,7 +49,7 @@ class RolesRightsData extends Entity
      */
     public function getHookId(): ?string
     {
-        return 'role_right_data';
+        return 'role_right_assignment';
     }
 
     /**

--- a/src/Roles/Entity/RolesRightsData.php
+++ b/src/Roles/Entity/RolesRightsData.php
@@ -44,6 +44,15 @@ class RolesRightsData extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'role_right_data';
+    }
+
+    /**
      * Logs creation of the DB record
      * 
      * @return true Returns **true** if no error occurred

--- a/src/SSO/Entity/Key.php
+++ b/src/SSO/Entity/Key.php
@@ -14,6 +14,24 @@ class Key extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'sso_key';
+    }
+
+    /**
+     * @return array Returns the columns whose value must not be handed to a hook callback.
+     * @see Entity::getSensitiveHookColumns()
+     */
+    public function getSensitiveHookColumns(): array
+    {
+        return array('key_private');
+    }
+
+    /**
      * Retrieve the list of database fields that are ignored for the changelog.
      * In addition to the default ignored columns, don't log fot_views
      *

--- a/src/SSO/Entity/OIDCClient.php
+++ b/src/SSO/Entity/OIDCClient.php
@@ -14,6 +14,24 @@ class OIDCClient extends SSOClient implements ClientEntityInterface
         }
     }
 
+    /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'oidc_client';
+    }
+
+    /**
+     * @return array Returns the columns whose value must not be handed to a hook callback.
+     * @see Entity::getSensitiveHookColumns()
+     */
+    public function getSensitiveHookColumns(): array
+    {
+        return array('ocl_client_secret');
+    }
+
     public function getRedirectUri(): string
     {
         return $this->getValue($this->columnPrefix . '_redirect_uri', 'database')??'';

--- a/src/SSO/Entity/SAMLClient.php
+++ b/src/SSO/Entity/SAMLClient.php
@@ -9,4 +9,13 @@ class SAMLClient extends SSOClient
         parent::__construct($database, 'saml', TBL_SAML_CLIENTS, 'smc', $client_id);
     }
 
+    /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'saml_client';
+    }
+
 }

--- a/src/SSO/Entity/SSOClient.php
+++ b/src/SSO/Entity/SSOClient.php
@@ -312,7 +312,7 @@ class SSOClient extends Entity
      */
     public function readableName(): string
     {
-        return $this->dbColumns[$this->columnPrefix . '_client_name']??'';
+        return $this->filterReadableName($this->dbColumns[$this->columnPrefix . '_client_name']??'');
     }
 
 

--- a/src/SSO/Service/SSOService.php
+++ b/src/SSO/Service/SSOService.php
@@ -242,7 +242,7 @@ class SSOService {
         $gNavigation->addUrl(CURRENT_URL, $headline);
 
         // create html page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-login', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_login', $headline);
         if (!empty($message)) {
             $page->addHtml($message);
         }

--- a/src/Session/Entity/Session.php
+++ b/src/Session/Entity/Session.php
@@ -113,6 +113,10 @@ class Session extends Entity
      */
     public function addFormObject(FormPresenter $form): bool
     {
+        // the form that is stored has to be the one that was rendered, so that validate() judges the
+        // POST against the elements the browser was shown
+        $form->finalize();
+
         if (!array_key_exists($form->getCsrfToken(), $this->mFormObjects)) {
             $this->mFormObjects[$form->getCsrfToken()] = $form;
             return true;

--- a/src/UI/Component/Message.php
+++ b/src/UI/Component/Message.php
@@ -145,7 +145,7 @@ class Message
 
         if (!isset($page) || !$this->inline) {
             // create html page object
-            $page = PagePresenter::withHtmlIDAndHeadline('admidio-message', $headline);
+            $page = PagePresenter::withHtmlIDAndHeadline('adm_message', $headline);
             $page->hideBackLink();
 
             if (!$this->includeThemeBody) {

--- a/src/UI/Presenter/AnnouncementsPresenter.php
+++ b/src/UI/Presenter/AnnouncementsPresenter.php
@@ -71,7 +71,7 @@ class AnnouncementsPresenter extends PagePresenter
     /**
      * Create content that is used on several pages and could be called in other methods. It will
      * create a functions menu and a filter navbar.
-     * @param string $view Name of the view that should be created. This could be 'cards' or 'list'.
+     * @param string $view Name of the view that should be created. This should be 'cards'.
      * @return void
      * @throws Exception
      */
@@ -276,39 +276,6 @@ class AnnouncementsPresenter extends PagePresenter
         $gCurrentSession->addFormObject($form);
     }
 
-    /**
-     * Read all available forum topics from the database and an HTML list with all topics.
-     * @param int $offset Offset of the first record that should be returned.
-     * @throws Exception
-     * @throws \DateMalformedStringException
-     */
-    public function createList(int $offset = 0): void
-    {
-        global $gL10n, $gSettingsManager, $gDb;
-
-        $baseUrl = SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/forum.php', array('mode' => 'cards', 'cat_uuid' => $this->categoryUUID));
-
-        $this->prepareData($offset);
-        $categoryService = new ForumService($gDb, $this->categoryUUID);
-
-        $this->setHtmlID('adm_forum_cards');
-        $this->createSharedHeader('list');
-
-        if (count($this->categories->getVisibleCategories()) > 1) {
-            $this->smarty->assign('showCategories', true);
-        } else {
-            $this->smarty->assign('showCategories', false);
-        }
-
-        $this->smarty->assign('list', $this->templateData);
-        $this->smarty->assign('l10n', $gL10n);
-        $this->smarty->assign('pagination', admFuncGeneratePagination($baseUrl, $categoryService->getTopicCount(), $gSettingsManager->getInt('forum_topics_per_page'), $offset, true, 'offset'));
-        try {
-            $this->pageContent .= $this->smarty->fetch('modules/forum.list.tpl');
-        } catch (\Smarty\Exception $e) {
-            throw new Exception($e->getMessage());
-        }
-    }
 
     /**
      * @param int $offset Offset of the first record that should be returned.

--- a/src/UI/Presenter/FormPresenter.php
+++ b/src/UI/Presenter/FormPresenter.php
@@ -1296,6 +1296,9 @@ class FormPresenter
      *                          of selections that could be done. If this limit is reached the user can't add another entry to the selectbox.
      *                        - **valueAttributes**: An array which contain the same ids as the value array. The value of this array will be
      *                          another array with the combination of attributes name and attributes value.
+     *                        - **allowCustomValues** : If set to **true** the validation of the form accepts a value that is
+     *                          not one of the entries above. Set it for a select box whose select2 is created with **tags**,
+     *                          where the user may enter an entry of their own.
      *                        - **helpTextId** : A unique text id from the translation xml files that should be shown
      *                          e.g. SYS_DATA_CATEGORY_GLOBAL. The text will be shown under the form control.
      *                          If you need an additional parameter for the text you can add an array. The first entry
@@ -1326,6 +1329,7 @@ class FormPresenter
             'placeholder' => '',
             'maximumSelectionNumber' => 0,
             'valueAttributes' => '',
+            'allowCustomValues' => false,
             'toggleable' => false
         ), $options));
         $attributes = array('name' => $id);
@@ -2197,6 +2201,10 @@ class FormPresenter
                 // remove html from every input value
                 $validFieldValues[$element['id']] = StringUtils::strStripTags($fieldValues[$element['id']]);
 
+                // a value that the form did not offer must not be accepted, no matter whether the
+                // control submits one value or a list of them
+                $this->validateOfferedValues($element, $validFieldValues[$element['id']]);
+
                 // check value depending on the field type
                 if (!is_array($fieldValues[$element['id']]) && strlen($fieldValues[$element['id']]) > 0) {
                     switch ($element['type']) {
@@ -2228,11 +2236,6 @@ class FormPresenter
                                 throw new Exception('SYS_FIELD_INVALID_INPUT', array($element['label']));
                             }
                             break;
-                        case 'select':
-                            if (!in_array($fieldValues[$element['id']], array_column($element['values'], 'id'))) {
-                                throw new Exception('SYS_FIELD_INVALID_INPUT', array($element['label']));
-                            }
-                            break;
                         case 'url':
                             if (!StringUtils::strValidCharacters($fieldValues[$element['id']], 'url')) {
                                 throw new Exception('SYS_URL_INVALID_CHAR', array($element['label']));
@@ -2248,6 +2251,54 @@ class FormPresenter
             }
         }
         return $validFieldValues;
+    }
+
+    /**
+     * Check the submitted value or values of a control that offers a fixed set of entries against
+     * that set. The set of an element is the one the form was built with, and the form is stored in
+     * the session, so a value that the user was never offered is rejected here even if the browser
+     * submitted it.
+     * @param array $element The form element that should be checked.
+     * @param mixed $value The submitted value, an array for a control that allows several entries.
+     * @return void
+     * @throws Exception SYS_FIELD_INVALID_INPUT
+     */
+    protected function validateOfferedValues(array $element, mixed $value): void
+    {
+        if (!empty($element['allowCustomValues'])) {
+            // the control lets the user enter an entry of their own, e.g. a select2 with tags
+            return;
+        }
+
+        switch ($element['type']) {
+            case 'select':
+            case 'button-group.radio':
+                // the entries were reorganized into an array of id and visible value
+                $offeredValues = array_column($element['values'], 'id');
+                break;
+
+            case 'radio':
+                // the entries were kept as they were given, the key of an entry is its value
+                $offeredValues = array_keys($element['values']);
+                if (!empty($element['showNoValueButton'])) {
+                    $offeredValues[] = '0';
+                }
+                break;
+
+            default:
+                return;
+        }
+
+        // an empty value means that nothing was selected, which the required check has covered
+        foreach ((is_array($value) ? $value : array($value)) as $singleValue) {
+            if ((string)$singleValue === '') {
+                continue;
+            }
+
+            if (!in_array((string)$singleValue, array_map('strval', $offeredValues), true)) {
+                throw new Exception('SYS_FIELD_INVALID_INPUT', array($element['label']));
+            }
+        }
     }
 
     /**

--- a/src/UI/Presenter/FormPresenter.php
+++ b/src/UI/Presenter/FormPresenter.php
@@ -114,6 +114,13 @@ class FormPresenter
     protected bool $finalized = false;
 
     /**
+     * The element types whose offered entries validate() checks the submitted value against. Only
+     * these are handed to the **form_select_options** filter, because only for these does taking an
+     * entry away also mean that it is not accepted any more.
+     */
+    protected const TYPES_WITH_OFFERED_VALUES = array('select', 'radio', 'button-group.radio');
+
+    /**
      * Constructor creates the form element
      * @param string $id ID of the form
      * @param string $action Action attribute of the form
@@ -2067,6 +2074,48 @@ class FormPresenter
         $this->finalized = true;
 
         Hooks::doAction('form_built', $this);
+
+        // after form_built, so that a select which a callback has just added is filtered as well
+        $this->filterOfferedValues();
+    }
+
+    /**
+     * Let the **form_select_options** filter change the entries that a select box, a radio group or a
+     * button group offers. It is called once per form, at the end of finalize(), and only for the
+     * element types whose entries validate() enforces - taking an entry away here also means that a
+     * request which submits it is refused, which is the whole point of the hook.
+     *
+     * The callback is handed the entries, the ID of the element, its type and the form. The entries
+     * have the shape the element type uses and must keep it: a **select** and a **button-group.radio**
+     * carry a list of **array('id' => ..., 'value' => ...)**, a **radio** an array of value to label.
+     * The filter has to answer with an array.
+     *
+     * An element that was built with **allowCustomValues** - the borrower of an inventory item is the
+     * one in the core - is filtered like any other, but its entries are not enforced, because that
+     * control deliberately accepts an entry the user typed.
+     *
+     * @return void
+     */
+    protected function filterOfferedValues(): void
+    {
+        if (!Hooks::hasFilter('form_select_options')) {
+            return;
+        }
+
+        foreach ($this->elements as $elementId => $element) {
+            if (!in_array($element['type'] ?? '', self::TYPES_WITH_OFFERED_VALUES, true)
+                || !array_key_exists('values', $element)) {
+                continue;
+            }
+
+            $this->elements[$elementId]['values'] = Hooks::applyTypedFilters(
+                'form_select_options',
+                $element['values'],
+                $elementId,
+                $element['type'],
+                $this
+            );
+        }
     }
 
     /**
@@ -2274,6 +2323,11 @@ class FormPresenter
     public function validate(array $fieldValues, bool $editSelection = false): array
     {
         global $gSettingsManager;
+
+        // the POST is judged against the finished form. A form that comes out of the session was
+        // finished before it was stored; one that is validated right after it was built is finished
+        // here, so that both are judged against the same elements.
+        $this->finalize();
 
         $validFieldValues = array();
         $selectedFields = array();

--- a/src/UI/Presenter/FormPresenter.php
+++ b/src/UI/Presenter/FormPresenter.php
@@ -2,6 +2,7 @@
 
 namespace Admidio\UI\Presenter;
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Language;
 use Admidio\Infrastructure\Database;
@@ -107,6 +108,10 @@ class FormPresenter
      * @var array Array with all elements of the form and their attributes as array
      */
     protected array $elements = array();
+    /**
+     * @var bool Whether the form is finished and form_built has been dispatched for it.
+     */
+    protected bool $finalized = false;
 
     /**
      * Constructor creates the form element
@@ -212,7 +217,7 @@ class FormPresenter
             $gLogger->debug('FORM: sleep/serialize!');
         }
 
-        return array('flagRequiredFields', 'showRequiredFields', 'javascript', 'type', 'id', 'csrfToken', 'template', 'attributes', 'elements');
+        return array('flagRequiredFields', 'showRequiredFields', 'javascript', 'type', 'id', 'csrfToken', 'template', 'attributes', 'elements', 'finalized');
     }
 
     /**
@@ -1890,6 +1895,8 @@ class FormPresenter
      */
     public function addToHtmlPage(bool $ajaxSubmit = true): void
     {
+        $this->finalize();
+
         try {
             if (isset($this->htmlPage)) {
                 if ($this->type === 'navbar') {
@@ -1921,6 +1928,8 @@ class FormPresenter
     public function addToSmarty(Smarty $smarty): void
     {
         global $gL10n, $gSettingsManager;
+
+        $this->finalize();
 
         $smarty->assign('urlAdmidio', ADMIDIO_URL);
         $smarty->assign('l10n', $gL10n);
@@ -1954,6 +1963,8 @@ class FormPresenter
     public function appendToSmarty(Smarty $smarty): void
     {
         global $gL10n, $gSettingsManager;
+
+        $this->finalize();
 
         if (!isset($smarty->tpl_vars['urlAdmidio'])) {
             $smarty->assign('urlAdmidio', ADMIDIO_URL);
@@ -2028,20 +2039,152 @@ class FormPresenter
     }
 
     /**
-     * This method returns the attributes array.
+     * The form is finished: everything that builds it has run, and what it holds now is what is
+     * rendered and what the POST of it is validated against. The **form_built** action is dispatched
+     * here, so a callback can add, remove or replace an element through hasElement(), getElement(),
+     * insertElement(), replaceElement() and removeElement(), and the change reaches both the browser
+     * and the validation.
+     *
+     * It runs at most once per form. Every way of reading a finished form calls it - addToHtmlPage(),
+     * addToSmarty(), appendToSmarty(), getAttributes(), getElements() - and so does
+     * Session::addFormObject(), for a form that is stored without being rendered. Code that is still
+     * building a form must therefore not call any of those; getElement() is the way to look at a
+     * single element in between, and it does not finalize.
+     *
+     * A callback must not put a closure into an element: FormPresenter is serialized into the session
+     * and a closure cannot be. The form is passed rather than the elements, because getElements()
+     * returns a copy.
+     *
+     * @return void
+     */
+    public function finalize(): void
+    {
+        if ($this->finalized) {
+            return;
+        }
+
+        // set before the dispatch, so that a callback which reads the form does not recurse
+        $this->finalized = true;
+
+        Hooks::doAction('form_built', $this);
+    }
+
+    /**
+     * @return string Returns the ID of the form, which is also the HTML id of the form element.
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Whether the form has an element with that ID. It does not finalize the form, so it may be used
+     * while the form is still being built.
+     * @param string $id ID of the element.
+     * @return bool Returns **true** if the form has that element.
+     */
+    public function hasElement(string $id): bool
+    {
+        return array_key_exists($id, $this->elements);
+    }
+
+    /**
+     * One element of the form. It does not finalize the form, so it may be used while the form is
+     * still being built, which is what a presenter that looks at an element before it adds the next
+     * one needs.
+     * @param string $id ID of the element.
+     * @return array|null Returns the element, or **null** if the form has no element with that ID.
+     */
+    public function getElement(string $id): ?array
+    {
+        return $this->elements[$id] ?? null;
+    }
+
+    /**
+     * Replace one element of the form, keeping its position.
+     * @param string $id ID of the element that should be replaced.
+     * @param array $element The element that takes its place.
+     * @return bool Returns **true** if the element was replaced.
+     */
+    public function replaceElement(string $id, array $element): bool
+    {
+        if (!array_key_exists($id, $this->elements)) {
+            return false;
+        }
+
+        $this->elements[$id] = $element;
+
+        return true;
+    }
+
+    /**
+     * Remove one element from the form. It is then neither rendered nor accepted by validate().
+     * @param string $id ID of the element that should be removed.
+     * @return bool Returns **true** if the element was removed.
+     */
+    public function removeElement(string $id): bool
+    {
+        if (!array_key_exists($id, $this->elements)) {
+            return false;
+        }
+
+        unset($this->elements[$id]);
+
+        return true;
+    }
+
+    /**
+     * Put an element into the form at a given position. The order of the elements is the order in
+     * which the form is rendered, so an element that is appended ends up after the buttons unless a
+     * position is named.
+     * @param string $id ID of the new element.
+     * @param array $element The element.
+     * @param string|null $beforeId ID of the element it should precede. If it is **null** or the form
+     *                              has no element with that ID, the element is appended.
+     * @return void
+     */
+    public function insertElement(string $id, array $element, ?string $beforeId = null): void
+    {
+        if ($beforeId === null || !array_key_exists($beforeId, $this->elements)) {
+            $this->elements[$id] = $element;
+            return;
+        }
+
+        $reordered = array();
+        foreach ($this->elements as $elementId => $existing) {
+            if ($elementId === $beforeId) {
+                $reordered[$id] = $element;
+            }
+            if ($elementId !== $id) {
+                $reordered[$elementId] = $existing;
+            }
+        }
+
+        $this->elements = $reordered;
+    }
+
+    /**
+     * This method returns the attributes array. Reading the finished form finalizes it.
      * @return array Returns all attributes of the form.
+     * @throws Exception
      */
     public function getAttributes(): array
     {
+        $this->finalize();
+
         return $this->attributes;
     }
 
     /**
-     * This method returns the elements array.
+     * This method returns the elements array. Reading the finished form finalizes it, so a presenter
+     * that is still building the form has to use getElement() or hasElement() instead.
      * @return array Returns all elements of the form.
+     * @throws Exception
      */
     public function getElements(): array
     {
+        $this->finalize();
+
         return $this->elements;
     }
 

--- a/src/UI/Presenter/InstallationPresenter.php
+++ b/src/UI/Presenter/InstallationPresenter.php
@@ -18,7 +18,7 @@ use Throwable;
  * **Code example**
  * ```
  * // create a simple html page with some text
- * $page = new InstallationPresenter('admidio-example');
+ * $page = new InstallationPresenter('adm_example');
  * $page->addTemplateFile('update.tpl');
  * $page->setUpdateModus();
  * $page->addHtml('<strong>This is a simple Html page!</strong>');

--- a/src/UI/Presenter/InventoryItemPresenter.php
+++ b/src/UI/Presenter/InventoryItemPresenter.php
@@ -901,7 +901,10 @@ class InventoryItemPresenter extends PagePresenter
                                 'helpTextId' => $helpId,
                                 'icon' => $items->getProperty($infNameIntern, 'inf_icon', 'database'),
                                 'defaultValue' => $items->getValue($infNameIntern),
-                                'multiselect' => false
+                                'multiselect' => false,
+                                // the select2 below is created with tags, so the receiver may be a
+                                // name that is not among the users of the organization
+                                'allowCustomValues' => true
                             )
                         );
 

--- a/src/UI/Presenter/InventoryItemPresenter.php
+++ b/src/UI/Presenter/InventoryItemPresenter.php
@@ -290,7 +290,7 @@ class InventoryItemPresenter extends PagePresenter
         }
 
         if ($getCopy) {
-            if ($form->getElements()['INF-CATEGORY']['type'] === 'text') {
+            if ($form->getElement('INF-CATEGORY')['type'] === 'text') {
                 // when copying an item and the user is not allowed to change the category, we cannot create copies
                 $form->addSubmitButton(
                     'adm_button_save',

--- a/src/UI/Presenter/PagePresenter.php
+++ b/src/UI/Presenter/PagePresenter.php
@@ -19,7 +19,7 @@ use Smarty\Smarty;
  * **Code example**
  * ```
  * // create a simple HTML page with some text
- * $page = PagePresenter::withHtmlIDAndHeadline('admidio-example');
+ * $page = PagePresenter::withHtmlIDAndHeadline('adm_example');
  * $page->addJavascriptFile(ADMIDIO_URL . FOLDER_LIBS . '/jquery/jquery.min.js');
  * $page->setHeadline('A simple HTML page');
  * $page->addHtml('<strong>This is a simple HTML page!</strong>');

--- a/src/UI/Presenter/PagePresenter.php
+++ b/src/UI/Presenter/PagePresenter.php
@@ -1,6 +1,7 @@
 <?php
 namespace Admidio\UI\Presenter;
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Language;
 use Admidio\Menu\ValueObject\MenuNode;
@@ -548,13 +549,29 @@ class PagePresenter
 
 
     /**
-     * Set the HTML ID of the current HTML page.
+     * Set the HTML ID of the current HTML page. It is written into the **id** attribute of the body
+     * element and it is the stable name of the page for the **page_before_render** hook.
+     *
+     * The value is handed to the template here, the same way setHeadline() does it: the basic
+     * variables are assigned in the constructor, and every caller sets the ID afterwards.
      * @param string $htmlID The HTML ID of the current page.
      * @return void
      */
     public function setHtmlID(string $htmlID): void
     {
         $this->id = $htmlID;
+
+        if (isset($this->smarty)) {
+            $this->smarty->assign('id', $this->id);
+        }
+    }
+
+    /**
+     * @return string Returns the HTML ID of the page, its stable name in the page hooks.
+     */
+    public function getHtmlID(): string
+    {
+        return $this->id;
     }
 
     /** If set to true, then a page without a header menu and sidebar menu will be created.
@@ -606,6 +623,17 @@ class PagePresenter
     public function show(): void
     {
         global $gSettingsManager, $gLayoutReduced, $gMenu, $gNavigation;
+
+        // The page is finished. The two texts that name it can still be changed, and
+        // page_before_render is the last point at which anything can be added to it; everything the
+        // three of them touch is handed to the template below, so nothing has to be assigned twice.
+        $this->title = Hooks::applyTypedFilters('page_title', $this->title, $this);
+        $this->headline = Hooks::applyTypedFilters('page_headline', $this->headline, $this);
+        Hooks::doAction('page_before_render', $this);
+
+        $this->smarty->assign('id', $this->id);
+        $this->smarty->assign('title', $this->title);
+        $this->smarty->assign('headline', $this->headline);
 
         $hasPreviousUrl = false;
 

--- a/src/UI/Presenter/PagePresenter.php
+++ b/src/UI/Presenter/PagePresenter.php
@@ -104,6 +104,13 @@ class PagePresenter
      * @var bool The Flag that will be responsible for a back button with the url to the previous page will be shown.
      */
     protected bool $showBackLink = false;
+    /**
+     * @var bool Whether page_title and page_headline have already been dispatched. A caller that
+     * needs the filtered text before show() runs - to build an export filename or an embedded
+     * document's title, for example - asks through getFilteredTitle()/getFilteredHeadline() instead
+     * of reading the raw text, and show() then finds the work already done instead of doing it again.
+     */
+    protected bool $textFiltered = false;
 
     /**
      * Static method which will return an instance of the PagePresenter. The HTML ID of the page will be set and
@@ -507,6 +514,46 @@ class PagePresenter
     }
 
     /**
+     * Dispatch page_title and page_headline exactly once, however many times this is called and
+     * whether it runs before or after show(): the same guarantee finalize() gives a form's elements.
+     * @return void
+     */
+    private function filterText(): void
+    {
+        if ($this->textFiltered) {
+            return;
+        }
+        $this->textFiltered = true;
+
+        $this->title = Hooks::applyTypedFilters('page_title', $this->title, $this);
+        $this->headline = Hooks::applyTypedFilters('page_headline', $this->headline, $this);
+    }
+
+    /**
+     * Returns the title of the page after page_title has run. Call this instead of getTitle() when
+     * the filtered text is needed before show() - to build an export filename or the title of an
+     * embedded document, for example.
+     * @return string Returns the filtered title of the HTML page.
+     */
+    public function getFilteredTitle(): string
+    {
+        $this->filterText();
+
+        return $this->title;
+    }
+
+    /**
+     * Returns the headline of the page after page_headline has run. See getFilteredTitle().
+     * @return string Returns the filtered headline of the HTML page.
+     */
+    public function getFilteredHeadline(): string
+    {
+        $this->filterText();
+
+        return $this->headline;
+    }
+
+    /**
      * If this method is called than the backlink to the previous page will not be shown.
      */
     public function hideBackLink(): void
@@ -627,8 +674,7 @@ class PagePresenter
         // The page is finished. The two texts that name it can still be changed, and
         // page_before_render is the last point at which anything can be added to it; everything the
         // three of them touch is handed to the template below, so nothing has to be assigned twice.
-        $this->title = Hooks::applyTypedFilters('page_title', $this->title, $this);
-        $this->headline = Hooks::applyTypedFilters('page_headline', $this->headline, $this);
+        $this->filterText();
         Hooks::doAction('page_before_render', $this);
 
         $this->smarty->assign('id', $this->id);

--- a/src/UI/Presenter/PluginsPresenter.php
+++ b/src/UI/Presenter/PluginsPresenter.php
@@ -177,6 +177,7 @@ class PluginsPresenter extends PagePresenter
 
             if ($interface != null) {
                 $templateRow['id'] = ($interface->getComponentId() !== 0) ? $interface->getComponentId() : $pluginName;
+                $templateRow['uuid'] = $templateRow['id'];
                 $templateRow['name'] = Language::translateIfTranslationStrId($interface->getName());
                 $templateRow['description'] = Language::translateIfTranslationStrId($interface->getMetadata()['description'] ?? '');
                 $templateRow['icon'] = $interface->getMetadata()['icon'] ?? '';

--- a/src/UI/Presenter/SSOClientPresenter.php
+++ b/src/UI/Presenter/SSOClientPresenter.php
@@ -182,7 +182,7 @@ class SSOClientPresenter extends PagePresenter
         } else {
             $this->setHeadline($gL10n->get('SYS_CREATE_VAR', array($gL10n->get('SYS_SSO_CLIENT_SAML'))));
         }
-        $this->setHtmlID('admidio-saml-client-edit');
+        $this->setHtmlID('adm_sso_client_saml_edit');
 
         $roleAccessSet = array();
         if ($this->objectUUID !== '') {
@@ -527,7 +527,7 @@ class SSOClientPresenter extends PagePresenter
         } else {
             $this->setHeadline($gL10n->get('SYS_CREATE_VAR', array($gL10n->get('SYS_SSO_CLIENT_OIDC'))));
         }
-        $this->setHtmlID('admidio-oidc-client-edit');
+        $this->setHtmlID('adm_sso_client_oidc_edit');
 
         $allRolesSet = $this->getAvailableRoles();
         if ($this->objectUUID !== '') {

--- a/src/UI/Presenter/SSOKeyPresenter.php
+++ b/src/UI/Presenter/SSOKeyPresenter.php
@@ -133,7 +133,7 @@ class SSOKeyPresenter extends PagePresenter
         } else {
             $this->setHeadline($gL10n->get('SYS_CREATE_VAR', array($gL10n->get('SYS_SSO_KEY'))));
         }
-        $this->setHtmlID('admidio-saml-client-edit');
+        $this->setHtmlID('adm_sso_key_edit');
 
         ChangelogService::displayHistoryButton($this, 'sso-key', 'sso_keys', !empty($this->keyUUID), array('uuid' => $this->keyUUID));
 

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -1963,13 +1963,15 @@ class User extends Entity
             // Register all non-empty fields for the notification
             $gChangeNotification->logUserCreation($usrId, $this);
         }
-        if ($newRecord) {
-            Hooks::do_action('user_created', $this, $gCurrentUser);
-
-        }
-
         LogChanges::endChangeSet($previousChangeSet);
         $this->db->endTransaction();
+
+        // After the transaction of this method, so that a creation that was rolled back here is not
+        // reported. A transaction of the caller still encloses it, so this is not yet the commit
+        // boundary that a committed-change hook needs.
+        if ($newRecord) {
+            Hooks::doAction('user_created', $this, $gCurrentUser);
+        }
 
         return $returnValue;
     }

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -19,6 +19,7 @@ use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
 use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\Changelog\Entity\LogChanges;
+use Admidio\Hooks\Hooks;
 use RobThree\Auth\TwoFactorAuth;
 use RobThree\Auth\Providers\Qr\QRServerProvider;
 
@@ -1962,6 +1963,10 @@ class User extends Entity
             // Register all non-empty fields for the notification
             $gChangeNotification->logUserCreation($usrId, $this);
         }
+        if ($newRecord) {
+            Hooks::do_action('user_created', $this, $gCurrentUser);
+
+        }
 
         LogChanges::endChangeSet($previousChangeSet);
         $this->db->endTransaction();
@@ -2379,7 +2384,8 @@ class User extends Entity
      */
     public function readableName(): string
     {
-        return $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME');
+        return Hooks::apply_filters('user_readable_name', $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME'), $this);
+        //return $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME');
     }
 
     /**

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -2384,8 +2384,7 @@ class User extends Entity
      */
     public function readableName(): string
     {
-        return Hooks::apply_filters('user_readable_name', $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME'), $this);
-        //return $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME');
+        return Hooks::applyFilters('user_readable_name', $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME'), $this);
     }
 
     /**

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -137,6 +137,24 @@ class User extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'user';
+    }
+
+    /**
+     * @return array Returns the columns whose value must not be handed to a hook callback.
+     * @see Entity::getSensitiveHookColumns()
+     */
+    public function getSensitiveHookColumns(): array
+    {
+        return array('usr_password', 'usr_tfa_secret', 'usr_photo');
+    }
+
+    /**
      * Checks if the current user is allowed to edit a profile field of the user from the parameter.
      * @param User $user User object of the user that should be checked if the current user can view his profile field.
      * @param string $fieldNameIntern Expects the **usf_name_intern** of the field that should be checked.

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -1984,13 +1984,6 @@ class User extends Entity
         LogChanges::endChangeSet($previousChangeSet);
         $this->db->endTransaction();
 
-        // After the transaction of this method, so that a creation that was rolled back here is not
-        // reported. A transaction of the caller still encloses it, so this is not yet the commit
-        // boundary that a committed-change hook needs.
-        if ($newRecord) {
-            Hooks::doAction('user_created', $this, $gCurrentUser);
-        }
-
         return $returnValue;
     }
 

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -134,6 +134,27 @@ class User extends Entity
         $this->organizationId = $GLOBALS['gCurrentOrgId'];
 
         parent::__construct($database, TBL_USERS, 'usr', $userId);
+
+        if ($this->newRecord) {
+            $this->initializeNewRecord();
+        }
+    }
+
+    /**
+     * The values a user record gets because it is being created. An account is active; the one
+     * exception is a registration, which sets **usr_valid** itself in UserRegistration::save() and
+     * is activated later by UserRegistration::acceptRegistration().
+     *
+     * This deliberately does not happen in clear(). clear() is also the step that empties the object
+     * before an existing record is read into it, and a value that is set there stays marked as
+     * changed, so every user that was read from the database carried a pending change of
+     * **usr_valid** that nobody asked for; see finding 86.
+     * @return void
+     * @throws Exception
+     */
+    protected function initializeNewRecord(): void
+    {
+        $this->setValue('usr_valid', 1);
     }
 
     /**
@@ -574,10 +595,6 @@ class User extends Entity
     public function clear(): void
     {
         parent::clear();
-
-        // new user should be valid (except registration)
-        $this->setValue('usr_valid', 1);
-        $this->columnsValueChanged = false;
 
         if (isset($this->mProfileFieldsData)) {
             // data of all profile fields will be deleted, the internal structure will not be destroyed
@@ -2324,7 +2341,7 @@ class User extends Entity
 
     /**
      * Retrieve the list of database fields that are ignored for the changelog.
-     * For the users table, we also ignore usr_valid, usr_*_login, etc.
+     * For the users table, we also ignore the login counters, the password reset token, etc.
      *
      * @return array Returns the list of database columns to be ignored for logging.
      */
@@ -2339,7 +2356,6 @@ class User extends Entity
         $ignored[] = 'usr_number_login';
         $ignored[] = 'usr_date_invalid';
         $ignored[] = 'usr_number_invalid';
-        $ignored[] = 'usr_valid';
         return $ignored;
     }
 

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -594,22 +594,13 @@ class User extends Entity
 
     /**
      * Deletes the selected user of the table and all the many references in other tables.
-     * Also, a notification that the user was deleted will be sent if notification is enabled.
      * After that the class will be initialized.
      * @return bool **true** if no error occurred
      * @throws Exception
      */
     public function delete(): bool
     {
-        global $gChangeNotification;
-
         $usrId = $this->getValue('usr_id');
-
-        // only send notification if a valid user will be deleted
-        if (is_object($gChangeNotification) && $this->getValue('usr_valid')) {
-            // Register all non-empty fields for the notification
-            $gChangeNotification->logUserDeletion($usrId, $this);
-        }
 
         // first delete send messages from the user
         $sql = 'SELECT msg_id FROM ' . TBL_MESSAGES . ' WHERE msg_usr_id_sender = ? -- $usrId';
@@ -829,8 +820,9 @@ class User extends Entity
     /**
      * Changes to user data could be sent as a notification email to a specific role if this
      * function is enabled in the settings. If you want to suppress this logic you can
-     * explicit disable it with this method for this user. So no changes to this user object will
-     * result in a notification email.
+     * explicit disable it with this method for this user. So no change of this user will result in
+     * a notification email, whether it is made through this object or not: save() names the user to
+     * ChangeNotification::suppressUser() as soon as the record has an id.
      * @return void
      */
     public function disableChangeNotification()
@@ -1953,8 +1945,6 @@ class User extends Entity
             $this->columnsValueChanged = true;
         }
 
-        $newRecord = $this->newRecord;
-
         $returnValue = parent::save($updateFingerPrint);
         $usrId = (int)$this->getValue('usr_id'); // if a new user was created get the new id
 
@@ -1975,11 +1965,11 @@ class User extends Entity
             // because he has new data and maybe new rights
             $gCurrentSession->reload($usrId);
         }
-        // The record is a new record, which was just stored to the database
-        // for the first time => record it as a user creation now
-        if ($newRecord && $this->changeNotificationEnabled && is_object($gChangeNotification)) {
-            // Register all non-empty fields for the notification
-            $gChangeNotification->logUserCreation($usrId, $this);
+        // The change notification listens to the hooks of adm_users, adm_user_data and adm_members,
+        // so a user whose notification is switched off has to be named once, now that the record has
+        // an id. Everything else about that user follows from the hooks alone.
+        if (!$this->changeNotificationEnabled && is_object($gChangeNotification)) {
+            $gChangeNotification->suppressUser($usrId);
         }
         LogChanges::endChangeSet($previousChangeSet);
         $this->db->endTransaction();
@@ -2143,19 +2133,9 @@ class User extends Entity
      */
     public function setPassword(string $newPassword, bool $doHashing = true): bool
     {
-        global $gSettingsManager, $gPasswordHashAlgorithm, $gChangeNotification;
+        global $gSettingsManager, $gPasswordHashAlgorithm;
 
         if (!$doHashing) {
-            if ($this->changeNotificationEnabled && is_object($gChangeNotification)) {
-                $gChangeNotification->logUserChange(
-                    (int)$this->getValue('usr_id'),
-                    'usr_password',
-                    $this->getValue('usr_password'),
-                    $newPassword,
-                    "MODIFIED",
-                    $this
-                );
-            }
             return parent::setValue('usr_password', $newPassword, false);
         }
 
@@ -2171,16 +2151,6 @@ class User extends Entity
             return false;
         }
 
-        if ($this->changeNotificationEnabled && is_object($gChangeNotification)) {
-            $gChangeNotification->logUserChange(
-                (int)$this->getValue('usr_id'),
-                'usr_password',
-                $this->getValue('usr_password'),
-                $newPasswordHash,
-                "MODIFIED",
-                $this
-            );
-        }
         if (parent::setValue('usr_password', $newPasswordHash, false)) {
             // for security reasons remove all sessions and auto login of the user
             return $this->invalidateAllOtherLogins();
@@ -2198,18 +2168,6 @@ class User extends Entity
      */
     public function setSecondFactorSecret(string|null $newSecret): bool
     {
-        global $gChangeNotification;
-
-        if ($this->changeNotificationEnabled && is_object($gChangeNotification)) {
-            $gChangeNotification->logUserChange(
-                (int)$this->getValue('usr_id'),
-                'usr_tfa_secret',
-                $this->getValue('usr_tfa_secret'),
-                $newSecret || 'null',
-                "MODIFIED",
-                $this
-            );
-        }
         if (parent::setValue('usr_tfa_secret', $newSecret, false)) {
             // for security reasons remove all sessions and auto login of the user
             return $this->invalidateAllOtherLogins();
@@ -2257,7 +2215,7 @@ class User extends Entity
      */
     public function setValue(string $columnName, mixed $newValue, bool $checkValue = true): bool
     {
-        global $gSettingsManager, $gChangeNotification;
+        global $gSettingsManager;
 
         // users data from adm_users table
         if (str_starts_with($columnName, 'usr_')) {
@@ -2274,21 +2232,6 @@ class User extends Entity
             // only update if value has changed
             if ($this->getValue($columnName, 'database') == $newValue) {
                 return true;
-            }
-
-            // For new records, do not immediately queue all changes for notification,
-            // as the record might never be saved to the database (e.g. when
-            // doing a check for an existing user)! => For new records,
-            // log the changes only when $this->save is called!
-            if (!$this->newRecord && $this->changeNotificationEnabled && is_object($gChangeNotification)) {
-                $gChangeNotification->logUserChange(
-                    $this->getValue('usr_id'),
-                    $columnName,
-                    (string)$this->getValue($columnName),
-                    (string)$newValue,
-                    "MODIFIED",
-                    $this
-                );
             }
 
             return parent::setValue($columnName, $newValue, $checkValue);
@@ -2338,27 +2281,6 @@ class User extends Entity
             || $this->saveChangesWithoutRights === true
         ) {
             $returnCode = $this->mProfileFieldsData->setValue($columnName, $newValue);
-        }
-
-        // Not all changes are logged. Exceptions:
-        // Fields starting with usr_ (special case above)
-        // Fields that have not changed (check above)
-        // If usr_id is 0 (the user is newly created; this is already documented) (check in logProfileChange)
-
-        if ($returnCode && !$this->newRecord && is_object($gChangeNotification)) {
-            $gChangeNotification->logProfileChange(
-                $this->getValue('usr_id'),
-                $this->mProfileFieldsData->getProperty($columnName, 'usf_id'),
-                $columnName, // TODO: is $columnName the internal name or the human-readable?
-                // Old and new values in human-readable version:
-                (string)$oldFieldValue,
-                (string)$this->mProfileFieldsData->getValue($columnName),
-                // Old and new values in raw database:
-                (string)$oldFieldValue_db,
-                (string)$newValue,
-                "MODIFIED",
-                $this
-            );
         }
 
         return $returnCode;

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -19,7 +19,6 @@ use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
 use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\Changelog\Entity\LogChanges;
-use Admidio\Hooks\Hooks;
 use RobThree\Auth\TwoFactorAuth;
 use RobThree\Auth\Providers\Qr\QRServerProvider;
 
@@ -2336,7 +2335,7 @@ class User extends Entity
      */
     public function readableName(): string
     {
-        return Hooks::applyFilters('user_readable_name', $this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME'), $this);
+        return $this->filterReadableName($this->mProfileFieldsData->getValue('LAST_NAME') . ', ' . $this->mProfileFieldsData->getValue('FIRST_NAME'));
     }
 
     /**

--- a/src/Users/Entity/UserData.php
+++ b/src/Users/Entity/UserData.php
@@ -41,6 +41,15 @@ class UserData extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'user_data';
+    }
+
+    /**
      * Since creation means setting value from NULL to something, deletion mean setting the field to empty,
      * we need one generic change log function that is called on creation, deletion and modification.
      * 

--- a/src/Users/Entity/UserImport.php
+++ b/src/Users/Entity/UserImport.php
@@ -122,6 +122,7 @@ class UserImport extends User
             } elseif ($this->importMode === self::USER_IMPORT_DUPLICATE) {
                 // save as new user
                 $this->clear();
+                $this->initializeNewRecord();
             }
         }
 
@@ -150,6 +151,7 @@ class UserImport extends User
                 } elseif ($this->importMode === self::USER_IMPORT_DUPLICATE) {
                     // save as new user
                     $this->clear();
+                    $this->initializeNewRecord();
                 }
             }
         }

--- a/src/Users/Entity/UserRegistration.php
+++ b/src/Users/Entity/UserRegistration.php
@@ -1,6 +1,7 @@
 <?php
 namespace Admidio\Users\Entity;
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Entity\Entity;
 use Admidio\Infrastructure\Exception;
@@ -42,6 +43,17 @@ use Admidio\ProfileFields\ValueObjects\ProfileFields;
  */
 class UserRegistration extends User
 {
+    /**
+     * How user_registration_accepted was reached: an administrator approved the pending
+     * registration on the account it created.
+     */
+    public const ACCEPTED_BY_APPROVAL = 'approval';
+    /**
+     * How user_registration_accepted was reached: the registration was matched to an existing
+     * account and merged into it instead of staying a record of its own.
+     */
+    public const ACCEPTED_BY_ASSIGNMENT = 'assignment';
+
     /**
      * @var bool Flag if the object will send a SystemMail if registration is accepted or deleted.
      */
@@ -104,6 +116,14 @@ class UserRegistration extends User
         $this->assignDefaultRoles();
 
         $this->db->endTransaction();
+
+        // A registration record disappearing and a user becoming valid look like two unrelated
+        // entity changes to a listener; this one semantic event says what actually happened, once
+        // the whole thing has really committed - registerAfterCommit() fires immediately if this
+        // was the outermost transaction, or waits for the caller's if it was not.
+        $this->db->registerAfterCommit(function () {
+            Hooks::doAction('user_registration_accepted', $this, self::ACCEPTED_BY_APPROVAL);
+        });
 
         // update registration count in menu
         if (isset($gMenu)) {

--- a/src/Users/Entity/UserRelation.php
+++ b/src/Users/Entity/UserRelation.php
@@ -28,6 +28,15 @@ class UserRelation extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'user_relation';
+    }
+
+    /**
      * Returns the inverse relation.
      * @return null|self Returns the inverse relation
      * @throws Exception

--- a/src/Users/Entity/UserRelationType.php
+++ b/src/Users/Entity/UserRelationType.php
@@ -34,6 +34,15 @@ class UserRelationType extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'user_relation_type';
+    }
+
+    /**
      * Returns the inverse relation type.
      * @return null|self Returns the inverse relation type
      * @throws Exception

--- a/src/Weblinks/Entity/Weblink.php
+++ b/src/Weblinks/Entity/Weblink.php
@@ -37,6 +37,15 @@ class Weblink extends Entity
     }
 
     /**
+     * @return string|null Returns the hook ID of this entity.
+     * @see Entity::getHookId()
+     */
+    public function getHookId(): ?string
+    {
+        return 'weblink';
+    }
+
+    /**
      * Get the value of a column of the database table.
      * If the value was manipulated before with **setValue** then the manipulated value is returned.
      * @param string $columnName The name of the database column whose value should be read

--- a/system/bootstrap/cli-installation.php
+++ b/system/bootstrap/cli-installation.php
@@ -77,6 +77,7 @@ $gL10n = new Language(isset($cliLanguage) && $cliLanguage !== '' ? $cliLanguage 
  * changelog. Beside that the tables of the changelog only exist after the schema was created.
  */
 Entity::setLoggingEnabled(false);
+Entity::setHooksEnabled(false);
 
 $gValidLogin = false;
 $gCurrentUserId = 0;

--- a/system/bootstrap/function.php
+++ b/system/bootstrap/function.php
@@ -9,6 +9,7 @@
  ***********************************************************************************************
  */
 
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
@@ -31,6 +32,10 @@ if (basename($_SERVER['SCRIPT_FILENAME']) === 'function.php') {
 function handleException(Throwable $e, bool $jsonResponse = false, bool $inlineResponse = false): void
 {
     global $gDebug, $gMessage, $gHtmlPurifierFilter;
+
+    // The request ends here. A listener may report the exception, but it must not be able to replace
+    // it with one of its own, so this is a doActionCatchErrors() site.
+    Hooks::doActionCatchErrors('exception_terminating', $e, $jsonResponse);
 
     $message = $gHtmlPurifierFilter->purify($e->getMessage());
 

--- a/system/bootstrap/shutdown.php
+++ b/system/bootstrap/shutdown.php
@@ -9,6 +9,7 @@
  ***********************************************************************************************
  */
 
+use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 
 if (basename($_SERVER['SCRIPT_FILENAME']) === 'shutdown.php') {
@@ -17,7 +18,15 @@ if (basename($_SERVER['SCRIPT_FILENAME']) === 'shutdown.php') {
 
 function admShutdown()
 {
-    global $gLogger;
+    global $gLogger, $gDb;
+
+    // A transaction that is still open here never reaches the database: PDO rolls it back when the
+    // connection closes. Admidio itself calls rollback() nowhere, an exception simply leaves the
+    // transaction behind, so this is where the work that was waiting for that commit is told that
+    // it will not come.
+    if ($gDb instanceof Database && $gDb->isInTransaction()) {
+        $gDb->runAfterRollbackCallbacks();
+    }
 
     $gLogger->info('SHUTDOWN', array(
         'execution_time' => getExecutionTime(SCRIPT_START_TIME),

--- a/system/classes/HtmlPage.php
+++ b/system/classes/HtmlPage.php
@@ -18,7 +18,7 @@ use Smarty\Smarty;
  * **Code example**
  * ```
  * // create a simple html page with some text
- * $page = PagePresenter::withHtmlIDAndHeadline('admidio-example');
+ * $page = PagePresenter::withHtmlIDAndHeadline('adm_example');
  * $page->addJavascriptFile(ADMIDIO_URL . FOLDER_LIBS . '/jquery/jquery.min.js');
  * $page->setHeadline('A simple Html page');
  * $page->addHtml('<strong>This is a simple Html page!</strong>');

--- a/system/classes/ModuleContacts.php
+++ b/system/classes/ModuleContacts.php
@@ -13,7 +13,7 @@ use Admidio\Users\Entity\User;
  * **Code example**
  * ```
  * // generate html output with available registrations
- * $page = new ModuleContacts('admidio-contacts', $headline);
+ * $page = new ModuleContacts('adm_contacts', $headline);
  * $page->createContentAssignUser();
  * $page->show();
  * ```

--- a/system/classes/ModuleLogin.php
+++ b/system/classes/ModuleLogin.php
@@ -1,4 +1,5 @@
 <?php
+use Admidio\Hooks\Hooks;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Preferences\ValueObject\SettingsManager;
@@ -128,13 +129,33 @@ class ModuleLogin
     /**
      * Check if a user with that username exists and the password is set correct. If the user choose a different
      * organization than the session data will be updated.
+     *
+     * This is the boundary of one login attempt and therefore where the login hooks live. It is
+     * deliberately not User::checkLogin(): a user name that belongs to nobody is refused here, before
+     * a User object exists, and an attempt with an unknown name is exactly what a consumer of
+     * **login_failed** wants to hear about.
+     *
+     * Three actions are dispatched, none of which is ever given the password:
+     *
+     * - **login_attempt** before anything is looked up, with the login name and the organization that
+     *   was chosen. It is dispatched with doAction(), so a callback that throws refuses the attempt -
+     *   which is how a rate limit or a block list is applied;
+     * - **login_succeeded** with the user, once the login is established;
+     * - **login_failed** with the login name and the reason, for every attempt that does not succeed.
+     *   It is a diagnostic and is dispatched with doActionCatchErrors(), so that a failing listener
+     *   cannot replace the reason the login was refused. It has two dispatch sites: every check of
+     *   User::checkLogin() signals a failure by throwing, so the one for a **false** return is the
+     *   defensive half of that method's bool contract and does not fire today.
+     *
+     * The hooks describe the interactive login form. A login through SSO or through the updater does
+     * not pass here.
+     *
      * @return bool Returns **true** if the login data are valid
      * @throws Exception
      */
     public function checkLogin(): bool
     {
-        global $gDb, $gCurrentOrganization, $gCurrentOrgId, $gProfileFields, $gCurrentSession, $gSettingsManager;
-        global $gMenu, $gCurrentUser, $gCurrentUserId, $gCurrentUserUUID, $gLogger;
+        global $gCurrentOrganization, $gCurrentSession;
 
         // check form field input and sanitized it from malicious content
         $loginForm = $gCurrentSession->getFormObject($_POST['adm_csrf_token']);
@@ -145,6 +166,33 @@ class ModuleLogin
         $postTotpCode = ($formValues['usr_totp_code'] ?? $formValues['plg_usr_totp_code'] ?? null);
         $postOrgShortName = ($formValues['org_shortname'] ?? ($formValues['plg_org_shortname'] ?? $gCurrentOrganization->getValue('org_shortname')));
         $postAutoLogin = ($formValues['auto_login'] ?? $formValues['plg_auto_login'] ?? false);
+
+        Hooks::doAction('login_attempt', (string)$postLoginName, (string)$postOrgShortName);
+
+        try {
+            return $this->authenticate((string)$postLoginName, (string)$postPassword, $postTotpCode, (string)$postOrgShortName, (bool)$postAutoLogin);
+        } catch (\Throwable $exception) {
+            Hooks::doActionCatchErrors('login_failed', (string)$postLoginName, $exception->getMessage(), (string)$postOrgShortName);
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * Look the user up, switch the organization if another one was chosen, and let the user object
+     * check the password and everything that goes with it.
+     * @param string $postLoginName The login name or, if that is enabled, the email address.
+     * @param string $postPassword The password of the login form.
+     * @param string|null $postTotpCode The second factor, if one was asked for.
+     * @param string $postOrgShortName The organization that was chosen.
+     * @param bool $postAutoLogin Whether the login should be remembered.
+     * @return bool Returns **true** if the login data are valid
+     * @throws Exception
+     */
+    private function authenticate(string $postLoginName, string $postPassword, ?string $postTotpCode, string $postOrgShortName, bool $postAutoLogin): bool
+    {
+        global $gDb, $gCurrentOrganization, $gCurrentOrgId, $gProfileFields, $gCurrentSession, $gSettingsManager;
+        global $gMenu, $gCurrentUser, $gCurrentUserId, $gCurrentUserUUID, $gLogger;
 
         // Search for username
         $sql = 'SELECT usr_id
@@ -200,6 +248,14 @@ class ModuleLogin
         $gCurrentUserId = $gCurrentUser->getValue('usr_id');
         $gCurrentUserUUID = $gCurrentUser->getValue('usr_uuid');
 
-        return $gCurrentUser->checkLogin(password: $postPassword, totpCode: $postTotpCode, setAutoLogin: $postAutoLogin);
+        $loggedIn = $gCurrentUser->checkLogin(password: $postPassword, totpCode: $postTotpCode, setAutoLogin: $postAutoLogin);
+
+        if ($loggedIn) {
+            Hooks::doAction('login_succeeded', $gCurrentUser, $postOrgShortName);
+        } else {
+            Hooks::doActionCatchErrors('login_failed', $postLoginName, 'SYS_LOGIN_USERNAME_PASSWORD_INCORRECT', $postOrgShortName);
+        }
+
+        return $loggedIn;
     }
 }

--- a/system/classes/ModuleLogin.php
+++ b/system/classes/ModuleLogin.php
@@ -16,7 +16,7 @@ use Admidio\Users\Entity\User;
  * **Code example**
  * ```
  * // generate html output with available registrations
- * $page = new ModuleContacts('admidio-contacts', $headline);
+ * $page = new ModuleContacts('adm_contacts', $headline);
  * $page->createContentAssignUser();
  * $page->show();
  * ```

--- a/system/common.php
+++ b/system/common.php
@@ -303,3 +303,24 @@ if ($gValidLogin) {
 } else {
     $gHomepage = ADMIDIO_URL . '/' . $gSettingsManager->getString('homepage_logout');
 }
+
+use Admidio\Hooks\Hooks;
+// Register in your plugin bootstrap
+Hooks::add_action('user_created', function ($user, $actorId) {
+    global $gLogger;
+    $gLogger->warning('User Created: ', array('user' => $user, 'actorID' => $actorId));
+    // log, sync, enqueue job, etc.
+}, priority: 20, accepted_args: 2);
+
+Hooks::add_filter('changelog_headline', function ($value) {
+    return "HOOKED: {" . $value . "}";
+}, priority: 5, accepted_args: 2);
+Hooks::add_filter('user_readable_name', function ($value, $user) {
+    return "HOOKED: {" . $value . "}";
+}, priority: 5, accepted_args: 2);
+
+
+// Later in core:
+// Hooks::do_action('user_created', $user, $actorId);
+
+/// $name = Hooks::apply_filters('display_name', $user->fullname, $user);

--- a/system/common.php
+++ b/system/common.php
@@ -303,24 +303,3 @@ if ($gValidLogin) {
 } else {
     $gHomepage = ADMIDIO_URL . '/' . $gSettingsManager->getString('homepage_logout');
 }
-
-use Admidio\Hooks\Hooks;
-// Register in your plugin bootstrap
-Hooks::add_action('user_created', function ($user, $actorId) {
-    global $gLogger;
-    $gLogger->warning('User Created: ', array('user' => $user, 'actorID' => $actorId));
-    // log, sync, enqueue job, etc.
-}, priority: 20, accepted_args: 2);
-
-Hooks::add_filter('changelog_headline', function ($value) {
-    return "HOOKED: {" . $value . "}";
-}, priority: 5, accepted_args: 2);
-Hooks::add_filter('user_readable_name', function ($value, $user) {
-    return "HOOKED: {" . $value . "}";
-}, priority: 5, accepted_args: 2);
-
-
-// Later in core:
-// Hooks::do_action('user_created', $user, $actorId);
-
-/// $name = Hooks::apply_filters('display_name', $user->fullname, $user);

--- a/system/file_upload.php
+++ b/system/file_upload.php
@@ -120,7 +120,7 @@ try {
         $gNavigation->addUrl(CURRENT_URL, $headline);
 
         // create an HTML page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-file-upload', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_file_upload', $headline);
 
         $fileUpload = new FileUpload($page, $getModule, $getUuid);
         $fileUpload->setHeaderData();

--- a/system/login.php
+++ b/system/login.php
@@ -31,7 +31,7 @@ try {
         $gNavigation->addUrl(CURRENT_URL, $headline);
 
         // create an HTML page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-login', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_login', $headline);
         $loginModule = new ModuleLogin();
         $loginModule->addHtmlLogin($page, $getOrganizationShortName);
         $page->show();

--- a/system/logout.php
+++ b/system/logout.php
@@ -9,12 +9,16 @@
  ***********************************************************************************************
  */
 
+use Admidio\Hooks\Hooks;
 use Admidio\Preferences\ValueObject\SettingsManager;
 
 try {
     require_once(__DIR__ . '/common.php');
 
     $gValidLogin = false;
+
+    // the user is still known here, which is what a listener needs; afterwards the object is cleared
+    Hooks::doAction('logout', $gCurrentUser);
 
     // remove user from session
     $gCurrentSession->logout();

--- a/system/password_reset.php
+++ b/system/password_reset.php
@@ -116,7 +116,7 @@ try {
         } else {
             // show dialog to change password
 
-            $page = PagePresenter::withHtmlIDAndHeadline('admidio-profile-photo-edit', $gL10n->get('SYS_CHANGE_PASSWORD'));
+            $page = PagePresenter::withHtmlIDAndHeadline('adm_password_reset_set_password', $gL10n->get('SYS_CHANGE_PASSWORD'));
 
             // show form
             $form = new FormPresenter(
@@ -268,7 +268,7 @@ try {
         $gNavigation->addUrl(CURRENT_URL, $headline);
 
         // create an HTML page object
-        $page = PagePresenter::withHtmlIDAndHeadline('admidio-password-reset', $headline);
+        $page = PagePresenter::withHtmlIDAndHeadline('adm_password_reset', $headline);
 
         // show form
         $form = new FormPresenter(

--- a/system/redirect.php
+++ b/system/redirect.php
@@ -29,7 +29,7 @@ try {
     }
 
     // create an HTML page object
-    $page = PagePresenter::withHtmlIDAndHeadline('admidio-redirect', $gL10n->get('SYS_REDIRECT'));
+    $page = PagePresenter::withHtmlIDAndHeadline('adm_redirect', $gL10n->get('SYS_REDIRECT'));
 
     // add special header for automatic redirection after x seconds
     $page->addHeader('<meta http-equiv="refresh" content="' . $gSettingsManager->getInt('weblinks_redirect_seconds') . '; url=' . $getUrl . '">');

--- a/tests/hooks/BufferedStatement.php
+++ b/tests/hooks/BufferedStatement.php
@@ -1,0 +1,69 @@
+<?php
+namespace Admidio\Tests\Hooks;
+
+use PDO;
+use PDOStatement;
+
+/**
+ * A PDOStatement that answers rowCount() for a SELECT.
+ *
+ * The SQLite driver of PDO returns 0 there, it only counts the rows an INSERT, UPDATE or DELETE
+ * touched. Entity::readData() decides whether it found its record by exactly that number, so
+ * without this the real code would take the not-found branch for every record that is read back.
+ * The rows of a SELECT are therefore buffered on execute() and served from that buffer.
+ */
+class BufferedStatement extends PDOStatement
+{
+    /** @var array<int,array>|null The buffered rows of a SELECT, null for any other statement. */
+    private ?array $rows = null;
+
+    protected function __construct()
+    {
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        $result = parent::execute($params);
+
+        if (stripos(ltrim($this->queryString), 'SELECT') === 0) {
+            $this->rows = parent::fetchAll(PDO::FETCH_ASSOC);
+        }
+
+        return $result;
+    }
+
+    public function rowCount(): int
+    {
+        return ($this->rows === null) ? parent::rowCount() : count($this->rows);
+    }
+
+    public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0): mixed
+    {
+        if ($this->rows === null) {
+            return parent::fetch($mode, $cursorOrientation, $cursorOffset);
+        }
+
+        return (count($this->rows) > 0) ? array_shift($this->rows) : false;
+    }
+
+    public function fetchAll(int $mode = PDO::FETCH_DEFAULT, mixed ...$args): array
+    {
+        if ($this->rows === null) {
+            return parent::fetchAll($mode, ...$args);
+        }
+
+        $rows = $this->rows;
+        $this->rows = array();
+        return $rows;
+    }
+
+    public function fetchColumn(int $column = 0): mixed
+    {
+        if ($this->rows === null) {
+            return parent::fetchColumn($column);
+        }
+
+        $row = $this->fetch();
+        return ($row === false) ? false : array_values($row)[$column];
+    }
+}

--- a/tests/hooks/EntityChangeTrackingFixed.php
+++ b/tests/hooks/EntityChangeTrackingFixed.php
@@ -1,0 +1,100 @@
+<?php
+// Harness around the change-tracking part of Entity::setValue() as it now stands in the working tree,
+// extracted verbatim so the test cannot drift from the code.
+class EntityChangeTrackingFixed
+{
+    public array $dbColumns = [];
+    public array $columnsInfos = [];
+    public bool $columnsValueChanged = false;
+    public bool $insertRecord = false;
+
+    public function __construct(array $persisted, array $types)
+    {
+        foreach ($persisted as $col => $val) {
+            $this->dbColumns[$col] = $val;
+            $this->columnsInfos[$col] = ['type' => $types[$col], 'changed' => false, 'previousValue' => null];
+        }
+    }
+
+    public function setValue(string $columnName, mixed $newValue): void
+    {
+        if ($this->valueChanged($columnName, $newValue)) {
+            if ($this->columnsInfos[$columnName]['changed'] && !$this->insertRecord
+                && !$this->valuesDiffer($columnName, $this->columnsInfos[$columnName]['previousValue'], $newValue)) {
+                // The field is back at the value that the database holds. It is not a change any
+                // more, so it must neither be written nor appear in the change history.
+                $this->dbColumns[$columnName] = $newValue;
+                $this->columnsInfos[$columnName]['changed'] = false;
+                $this->columnsInfos[$columnName]['previousValue'] = null;
+                $this->columnsValueChanged = $this->hasChangedColumns();
+            } else {
+                if (!$this->columnsInfos[$columnName]['changed']) {
+                    // Remember the value that the database holds. A field that is set more than once
+                    // before the save must still report the change from its persisted value and not
+                    // from the intermediate one.
+                    $this->columnsInfos[$columnName]['previousValue'] = $this->dbColumns[$columnName];
+                }
+                $this->dbColumns[$columnName] = $newValue;
+                $this->columnsValueChanged = true;
+                $this->columnsInfos[$columnName]['changed'] = true;
+            }
+        }
+    }
+
+    protected function hasChangedColumns(): bool
+    {
+        foreach ($this->columnsInfos as $columnInfo) {
+            if (!empty($columnInfo['changed'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    protected function valueChanged(string $columnName, ?string $newValue): bool
+    {
+        return $this->valuesDiffer($columnName, $this->dbColumns[$columnName] ?? null, $newValue);
+    }
+    protected function valuesDiffer(string $columnName, mixed $oldValue, ?string $newValue): bool
+    {
+        $oldValue = !empty($oldValue) ? $oldValue : null;
+
+        // certain data types need special handling to detect changes
+        //   * bool: unset/null and 0 mean false
+        //   * date/time: Make sure seconds are handled consistently, no need to convert to string
+        //   * all other types can be compared by converting to string and comparing strings
+        switch ($this->columnsInfos[$columnName]['type']) {
+            case 'boolean': // fallthrough
+            case 'tinyint':
+                if (empty($newValue)) $newValue = 0;
+                return $oldValue != $newValue;
+            case 'timestamp': // fallthrough
+            case 'date': // fallthrough
+            case 'time':
+                // if both are empty, no need to go through DateTime
+                if (empty($oldValue) && empty($newValue)) {
+                    return false;
+                } elseif (empty($oldValue) || empty($newValue)) {
+                    return true;
+                }
+                try {
+                    // Convert old and new to a DateTime and compare that directly
+                    $oldDate = new DateTime($oldValue);
+                    $newDate = new DateTime($newValue);
+                    return $oldDate != $newDate;
+                } catch (\Exception) {
+                    // if DateTime-conversion did not work, compare the strings
+                    return $oldValue != $newValue;
+                }
+            default:
+                // only mark as "changed" if the value is different (DON'T use binary safe function!)
+                if (!isset($oldValue) && !isset($newValue)) {
+                    return false;
+                } elseif (!isset($oldValue) && isset($newValue)) {
+                    return true;
+                } else {
+                    return strcmp((string)$oldValue, (string)$newValue) !== 0;
+                }
+        }
+    }
+}

--- a/tests/hooks/FakeDatabase.php
+++ b/tests/hooks/FakeDatabase.php
@@ -1,0 +1,79 @@
+<?php
+namespace Admidio\Tests\Hooks;
+
+use Admidio\Infrastructure\Database;
+use PDO;
+use PDOStatement;
+
+/**
+ * A Database that runs against an in-memory SQLite connection, so that the real Entity lifecycle
+ * can be executed in a test without a server. Only the three methods that Entity uses are
+ * overridden; the parent constructor is deliberately not called, because it would connect.
+ */
+class FakeDatabase extends Database
+{
+    private PDO $sqlite;
+    /** @var array<string,array> */
+    private array $columns = array();
+    /** @var array<int,string> */
+    public array $statements = array();
+    /** Make the next statement fail, to reach the failure path of the lifecycle. */
+    public bool $breakNextStatement = false;
+
+    public function __construct()
+    {
+        $this->sqlite = new PDO('sqlite::memory:', null, null, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION));
+    }
+
+    /**
+     * Create a table and remember the column properties in the shape Entity expects.
+     * @param string $table Name of the table.
+     * @param array $columns Column name to array(type, null, key, serial).
+     * @return void
+     */
+    public function createTable(string $table, array $columns): void
+    {
+        $definitions = array();
+        foreach ($columns as $name => $property) {
+            $definitions[] = $property['serial']
+                ? $name . ' INTEGER PRIMARY KEY AUTOINCREMENT'
+                : $name . ' TEXT';
+        }
+        $this->sqlite->exec('CREATE TABLE ' . $table . ' (' . implode(', ', $definitions) . ')');
+        $this->columns[$table] = $columns;
+    }
+
+    public function getTableColumnsProperties(string $table): array
+    {
+        return $this->columns[$table] ?? array();
+    }
+
+    public function queryPrepared(string $sql, array $params = array(), bool $showError = true): false|PDOStatement
+    {
+        $this->statements[] = $sql;
+
+        if ($this->breakNextStatement) {
+            $this->breakNextStatement = false;
+            $sql = str_replace('INTO ' . TABLE_PREFIX, 'INTO missing_' . TABLE_PREFIX, $sql);
+        }
+
+        $statement = $this->sqlite->prepare($sql);
+        $statement->execute(array_values($params));
+        return $statement;
+    }
+
+    public function lastInsertId(): int
+    {
+        return (int)$this->sqlite->lastInsertId();
+    }
+
+    /**
+     * Read a whole table back, to check what the lifecycle actually wrote.
+     * @param string $table Name of the table.
+     * @return array Returns all rows.
+     */
+    public function fetchAll(string $table): array
+    {
+        return $this->sqlite->query('SELECT * FROM ' . $table)->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/tests/hooks/FakeDatabase.php
+++ b/tests/hooks/FakeDatabase.php
@@ -22,7 +22,10 @@ class FakeDatabase extends Database
 
     public function __construct()
     {
-        $this->sqlite = new PDO('sqlite::memory:', null, null, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION));
+        $this->sqlite = new PDO('sqlite::memory:', null, null, array(
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_STATEMENT_CLASS => array(BufferedStatement::class, array())
+        ));
     }
 
     /**
@@ -65,6 +68,46 @@ class FakeDatabase extends Database
     public function lastInsertId(): int
     {
         return (int)$this->sqlite->lastInsertId();
+    }
+
+    public function startTransaction(): bool
+    {
+        if ($this->transactions > 0) {
+            ++$this->transactions;
+            return true;
+        }
+
+        $this->sqlite->beginTransaction();
+        $this->transactions = 1;
+        return true;
+    }
+
+    public function endTransaction(): bool
+    {
+        if ($this->transactions === 0) {
+            return true;
+        }
+        if ($this->transactions > 1) {
+            --$this->transactions;
+            return true;
+        }
+
+        $this->sqlite->commit();
+        $this->transactions = 0;
+        $this->runAfterCommitCallbacks();
+        return true;
+    }
+
+    public function rollback(): bool
+    {
+        if ($this->transactions === 0) {
+            return false;
+        }
+
+        $this->sqlite->rollBack();
+        $this->transactions = 0;
+        $this->runAfterRollbackCallbacks();
+        return true;
     }
 
     /**

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -15,6 +15,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/page-hooks.php
     php tests/hooks/component-hooks.php
     php tests/hooks/translation-hooks.php
+    php tests/hooks/login-hooks.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -43,6 +44,12 @@ checkout, so the cache, the fallback to the reference language and the placehold
 only the four path constants of the Admidio bootstrap are defined in the test. The text it uses to
 exercise the fallback is looked up rather than named, so the check keeps working when the translation
 catches up.
+
+`login-hooks.php` is two things at once. The control flow around the hooks is checked through a
+stand-in, because `ModuleLogin::checkLogin()` needs a session, a form, a database and a user; and the
+property that actually matters - that no login hook is ever handed the password - is checked against
+the real source file, which a stand-in could not prove. The one-line dispatch sites in `logout.php` and
+`system/bootstrap/function.php` are not driven by any test.
 
 `component-hooks.php` works the same way as `page-hooks.php`: `Component` reads the settings, the
 current user and the database, so the stand-in carries the two wrappers verbatim. The wrappers are the

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -6,13 +6,18 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-lifecycle.php
     php tests/hooks/entity-lifecycle-2.php
     php tests/hooks/entity-value-filter.php
+    php tests/hooks/entity-transactions.php
     php tests/hooks/entity-change-tracking-after.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
-`entity-lifecycle*.php` and `entity-value-filter.php` execute the real `Entity::save()` and
-`Entity::delete()`. `FakeDatabase` is a `Database` subclass over an in-memory SQLite connection that
-overrides the three methods `Entity` uses, so the rows are really written, read back and deleted.
+`entity-lifecycle*.php`, `entity-value-filter.php` and `entity-transactions.php` execute the real
+`Entity::save()` and `Entity::delete()`. `FakeDatabase` is a `Database` subclass over an in-memory
+SQLite connection that
+overrides the four methods `Entity` uses plus the transaction handling, so the rows are really
+written, read back, committed, rolled back and deleted. `BufferedStatement` exists because the SQLite
+driver of PDO answers `rowCount()` with 0 for a SELECT, which is the number `Entity::readData()`
+decides on.
 The changelog is switched off in `bootstrap.php`, it needs settings and tables of its own and is not
 what these tests are about.
 

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -9,6 +9,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-transactions.php
     php tests/hooks/entity-cascade-delete.php
     php tests/hooks/entity-change-tracking-after.php
+    php tests/hooks/change-notification.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -21,6 +22,13 @@ driver of PDO answers `rowCount()` with 0 for a SELECT, which is the number `Ent
 decides on.
 The changelog is switched off in `bootstrap.php`, it needs settings and tables of its own and is not
 what these tests are about.
+
+`change-notification.php` runs the real `ChangeNotification` listener against the real `Entity`
+lifecycle. The three tables of a person are created with the columns of `install/db_scripts/db.sql` and
+the entity subclasses carry the hook ID, the sensitive columns and the ignored columns of the real
+`User`, `UserData` and `Membership`; `$gProfileFields`, `$gSettingsManager` and `$gL10n` are stubs at the
+top of the file, because the mail is not what is being tested - what the listener hears and what it makes
+of it is.
 
 `entity-change-tracking-after.php` is different: it extracts the change-tracking block of
 `Entity::setValue()` and its comparison methods verbatim from the source and runs them against a

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -1,0 +1,25 @@
+# Hook tests
+
+Run them with the PHP CLI, they need nothing but `vendor/`:
+
+    php tests/hooks/hooks-behaviour.php
+    php tests/hooks/entity-lifecycle.php
+    php tests/hooks/entity-lifecycle-2.php
+    php tests/hooks/entity-value-filter.php
+    php tests/hooks/entity-change-tracking-after.php
+
+Each script prints one line per check and exits non-zero when a check fails.
+
+`entity-lifecycle*.php` and `entity-value-filter.php` execute the real `Entity::save()` and
+`Entity::delete()`. `FakeDatabase` is a `Database` subclass over an in-memory SQLite connection that
+overrides the three methods `Entity` uses, so the rows are really written, read back and deleted.
+The changelog is switched off in `bootstrap.php`, it needs settings and tables of its own and is not
+what these tests are about.
+
+`entity-change-tracking-after.php` is different: it extracts the change-tracking block of
+`Entity::setValue()` and its comparison methods verbatim from the source and runs them against a
+fixture, so that the test cannot drift from the code it describes.
+
+These are plain scripts and not PHPUnit cases on purpose - the branch has no test bootstrap yet.
+They are written so that moving them into one is a matter of turning each `check()` into an
+assertion.

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -10,6 +10,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-cascade-delete.php
     php tests/hooks/entity-change-tracking-after.php
     php tests/hooks/change-notification.php
+    php tests/hooks/user-valid-default.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -29,6 +30,12 @@ the entity subclasses carry the hook ID, the sensitive columns and the ignored c
 `User`, `UserData` and `Membership`; `$gProfileFields`, `$gSettingsManager` and `$gL10n` are stubs at the
 top of the file, because the mail is not what is being tested - what the listener hears and what it makes
 of it is.
+
+`user-valid-default.php` is a mixture of the two. The real `User` cannot be instantiated without a
+`ProfileFields` object and a database, so its constructor and its `clear()` are carried in the test
+reduced to the two lines that touch `usr_valid`; everything below them is the real `Entity`, and the
+checks are about which columns end up marked as changed, which `Entity` alone decides. The last check
+pins the defect of finding 86 by keeping the previous `clear()` next to the current one.
 
 `entity-change-tracking-after.php` is different: it extracts the change-tracking block of
 `Entity::setValue()` and its comparison methods verbatim from the source and runs them against a

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -14,6 +14,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/form-built.php
     php tests/hooks/page-hooks.php
     php tests/hooks/component-hooks.php
+    php tests/hooks/translation-hooks.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -36,6 +37,12 @@ of it is.
 
 `form-built.php` executes the real `FormPresenter`, which needs nothing but the autoloader, so the
 form, the dispatch and `validate()` are all the real ones.
+
+`translation-hooks.php` executes the real `Language` against the real `languages/*.xml` of this
+checkout, so the cache, the fallback to the reference language and the placeholders are the real ones;
+only the four path constants of the Admidio bootstrap are defined in the test. The text it uses to
+exercise the fallback is looked up rather than named, so the check keeps working when the translation
+catches up.
 
 `component-hooks.php` works the same way as `page-hooks.php`: `Component` reads the settings, the
 current user and the database, so the stand-in carries the two wrappers verbatim. The wrappers are the

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -10,6 +10,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-cascade-delete.php
     php tests/hooks/entity-change-tracking-after.php
     php tests/hooks/readable-name.php
+    php tests/hooks/roles-dependencies-delete.php
     php tests/hooks/change-notification.php
     php tests/hooks/user-valid-default.php
     php tests/hooks/form-built.php
@@ -81,6 +82,11 @@ fixture, so that the test cannot drift from the code it describes.
 `readable-name.php` executes the real `Entity::readableName()` and `Entity::filterReadableName()`
 against `TestRoom` (named) and `TestSession` (unnamed): the generic `entity_readable_name` filter
 always runs, the specific `<hookId>_readable_name` one only for an entity that names itself.
+
+`roles-dependencies-delete.php` executes the real `RolesDependencies`, not a stand-in - its
+constructor takes nothing but a `Database`, so there was no reason to copy it. It overrides
+`delete()` because `adm_role_dependencies` has a composite key, and until finding 96 that override
+never dispatched a hook at all.
 
 These are plain scripts and not PHPUnit cases on purpose - the branch has no test bootstrap yet.
 They are written so that moving them into one is a matter of turning each `check()` into an

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -11,6 +11,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-change-tracking-after.php
     php tests/hooks/readable-name.php
     php tests/hooks/roles-dependencies-delete.php
+    php tests/hooks/registration-accepted.php
     php tests/hooks/change-notification.php
     php tests/hooks/user-valid-default.php
     php tests/hooks/form-built.php
@@ -87,6 +88,14 @@ always runs, the specific `<hookId>_readable_name` one only for an entity that n
 constructor takes nothing but a `Database`, so there was no reason to copy it. It overrides
 `delete()` because `adm_role_dependencies` has a composite key, and until finding 96 that override
 never dispatched a hook at all.
+
+`registration-accepted.php` is different again: `UserRegistration` and `RegistrationService` both
+need a full `ProfileFields`/`User`/settings stack to construct, so this executes the mechanism they
+are built on instead of the methods themselves - `Database::registerAfterCommit()`, inherited by
+`FakeDatabase` unchanged, and the real `UserRegistration::ACCEPTED_BY_APPROVAL` /
+`ACCEPTED_BY_ASSIGNMENT` constants - reproducing the exact transaction nesting of
+`CoreTasks::registrationApprove()`, the one caller that wraps `acceptRegistration()` in a transaction
+of its own.
 
 These are plain scripts and not PHPUnit cases on purpose - the branch has no test bootstrap yet.
 They are written so that moving them into one is a matter of turning each `check()` into an

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -12,6 +12,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/change-notification.php
     php tests/hooks/user-valid-default.php
     php tests/hooks/form-built.php
+    php tests/hooks/page-hooks.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -34,6 +35,11 @@ of it is.
 
 `form-built.php` executes the real `FormPresenter`, which needs nothing but the autoloader, so the
 form, the dispatch and `validate()` are all the real ones.
+
+`page-hooks.php` is like `user-valid-default.php`: `PagePresenter` reads the settings, the
+organization, the language and the session out of the database and cannot be constructed here, so the
+stand-in carries `setHtmlID()` and the head of `show()` verbatim over the real `Hooks` engine. The
+constructor-then-setter order it reproduces is the whole point - it is what finding 91 was.
 
 `user-valid-default.php` is a mixture of the two. The real `User` cannot be instantiated without a
 `ProfileFields` object and a database, so its constructor and its `clear()` are carried in the test

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -11,6 +11,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-change-tracking-after.php
     php tests/hooks/change-notification.php
     php tests/hooks/user-valid-default.php
+    php tests/hooks/form-built.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -30,6 +31,9 @@ the entity subclasses carry the hook ID, the sensitive columns and the ignored c
 `User`, `UserData` and `Membership`; `$gProfileFields`, `$gSettingsManager` and `$gL10n` are stubs at the
 top of the file, because the mail is not what is being tested - what the listener hears and what it makes
 of it is.
+
+`form-built.php` executes the real `FormPresenter`, which needs nothing but the autoloader, so the
+form, the dispatch and `validate()` are all the real ones.
 
 `user-valid-default.php` is a mixture of the two. The real `User` cannot be instantiated without a
 `ProfileFields` object and a database, so its constructor and its `clear()` are carried in the test

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -16,6 +16,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/component-hooks.php
     php tests/hooks/translation-hooks.php
     php tests/hooks/login-hooks.php
+    php tests/hooks/email-hooks.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -44,6 +45,12 @@ checkout, so the cache, the fallback to the reference language and the placehold
 only the four path constants of the Admidio bootstrap are defined in the test. The text it uses to
 exercise the fallback is looked up rather than named, so the check keeps working when the translation
 catches up.
+
+`email-hooks.php` is built like `login-hooks.php`. The real `Email` is constructed, but nothing is
+ever handed to PHPMailer - a test that tried to deliver would need a mail server or would really send
+something - so the wrapper of `sendEmail()` is checked through a stand-in, the short circuit for a demo
+installation is checked on the real object, and the credentials property is checked against the real
+source file. That last check tests itself first, on a fabricated line that does leak.
 
 `login-hooks.php` is two things at once. The control flow around the hooks is checked through a
 stand-in, because `ModuleLogin::checkLogin()` needs a session, a form, a database and a user; and the

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -9,6 +9,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-transactions.php
     php tests/hooks/entity-cascade-delete.php
     php tests/hooks/entity-change-tracking-after.php
+    php tests/hooks/readable-name.php
     php tests/hooks/change-notification.php
     php tests/hooks/user-valid-default.php
     php tests/hooks/form-built.php
@@ -76,6 +77,10 @@ pins the defect of finding 86 by keeping the previous `clear()` next to the curr
 `entity-change-tracking-after.php` is different: it extracts the change-tracking block of
 `Entity::setValue()` and its comparison methods verbatim from the source and runs them against a
 fixture, so that the test cannot drift from the code it describes.
+
+`readable-name.php` executes the real `Entity::readableName()` and `Entity::filterReadableName()`
+against `TestRoom` (named) and `TestSession` (unnamed): the generic `entity_readable_name` filter
+always runs, the specific `<hookId>_readable_name` one only for an entity that names itself.
 
 These are plain scripts and not PHPUnit cases on purpose - the branch has no test bootstrap yet.
 They are written so that moving them into one is a matter of turning each `check()` into an

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -12,6 +12,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/readable-name.php
     php tests/hooks/roles-dependencies-delete.php
     php tests/hooks/registration-accepted.php
+    php tests/hooks/list-hooks.php
     php tests/hooks/change-notification.php
     php tests/hooks/user-valid-default.php
     php tests/hooks/form-built.php
@@ -96,6 +97,13 @@ are built on instead of the methods themselves - `Database::registerAfterCommit(
 `ACCEPTED_BY_ASSIGNMENT` constants - reproducing the exact transaction nesting of
 `CoreTasks::registrationApprove()`, the one caller that wraps `acceptRegistration()` in a transaction
 of its own.
+
+`list-hooks.php` proves the generic list hooks (`list_columns`, `list_data`, `list_rendered_data`,
+`list_row_actions`, §2.7) on `modules/contacts/contacts.php` and `contacts_data.php`, the first module
+to carry them. Neither file can run here - both need a full database, session and settings stack - so
+the dispatch lines are reproduced verbatim, including the count guard in `contacts.php` that refuses a
+`list_columns` filter which adds or removes a column, since `contacts_data.php` still builds every row
+by position and there is no shared list pipeline yet to keep the two in step.
 
 These are plain scripts and not PHPUnit cases on purpose - the branch has no test bootstrap yet.
 They are written so that moving them into one is a matter of turning each `check()` into an

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -13,6 +13,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/user-valid-default.php
     php tests/hooks/form-built.php
     php tests/hooks/page-hooks.php
+    php tests/hooks/component-hooks.php
 
 Each script prints one line per check and exits non-zero when a check fails.
 
@@ -35,6 +36,10 @@ of it is.
 
 `form-built.php` executes the real `FormPresenter`, which needs nothing but the autoloader, so the
 form, the dispatch and `validate()` are all the real ones.
+
+`component-hooks.php` works the same way as `page-hooks.php`: `Component` reads the settings, the
+current user and the database, so the stand-in carries the two wrappers verbatim. The wrappers are the
+whole change - the switch statements below them are untouched.
 
 `page-hooks.php` is like `user-valid-default.php`: `PagePresenter` reads the settings, the
 organization, the language and the session out of the database and cannot be constructed here, so the

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -7,6 +7,7 @@ Run them with the PHP CLI, they need nothing but `vendor/`:
     php tests/hooks/entity-lifecycle-2.php
     php tests/hooks/entity-value-filter.php
     php tests/hooks/entity-transactions.php
+    php tests/hooks/entity-cascade-delete.php
     php tests/hooks/entity-change-tracking-after.php
 
 Each script prints one line per check and exits non-zero when a check fails.

--- a/tests/hooks/bootstrap.php
+++ b/tests/hooks/bootstrap.php
@@ -17,6 +17,17 @@ use Admidio\Infrastructure\Entity\Entity;
 // the changelog needs settings and tables of its own and is not what these tests are about
 Entity::setLoggingEnabled(false);
 
+// Language::get() logs its lookup time; the helper lives in the Admidio bootstrap, which needs a
+// configuration and a database. This is the whole of it, copied from system/bootstrap/function.php.
+if (!function_exists('getExecutionTime')) {
+    function getExecutionTime(float $startTime): string
+    {
+        $stopTime = microtime(true);
+
+        return number_format(($stopTime - $startTime) * 1000, 6, '.', '') . ' ms';
+    }
+}
+
 $GLOBALS['adm_test_failures'] = 0;
 
 function check(string $name, bool $ok, string $detail = ''): void

--- a/tests/hooks/bootstrap.php
+++ b/tests/hooks/bootstrap.php
@@ -10,7 +10,7 @@ define('DB_TYPE', 'mysql');            // the PostgreSQL boolean conversion must
 define('TABLE_PREFIX', 'adm');
 define('DATETIME_NOW', date('Y-m-d H:i:s'));
 $GLOBALS['gCurrentUserId'] = 0;        // no creator/editor columns are stamped
-$GLOBALS['gLogger'] = null;
+$GLOBALS['gLogger'] = new \Psr\Log\NullLogger();   // Admidio logs unguarded in a few places
 
 use Admidio\Infrastructure\Entity\Entity;
 

--- a/tests/hooks/bootstrap.php
+++ b/tests/hooks/bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Enough of the Admidio runtime to execute the real Entity lifecycle against SQLite.
+ */
+require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/FakeDatabase.php';
+
+define('DB_TYPE', 'mysql');            // the PostgreSQL boolean conversion must stay out of the way
+define('TABLE_PREFIX', 'adm');
+define('DATETIME_NOW', date('Y-m-d H:i:s'));
+$GLOBALS['gCurrentUserId'] = 0;        // no creator/editor columns are stamped
+$GLOBALS['gLogger'] = null;
+
+use Admidio\Infrastructure\Entity\Entity;
+
+// the changelog needs settings and tables of its own and is not what these tests are about
+Entity::setLoggingEnabled(false);
+
+$GLOBALS['adm_test_failures'] = 0;
+
+function check(string $name, bool $ok, string $detail = ''): void
+{
+    if (!$ok) {
+        $GLOBALS['adm_test_failures']++;
+    }
+    printf("%-6s %s%s\n", $ok ? '  ok' : 'FAIL', $name, $detail !== '' ? '  -> ' . $detail : '');
+}
+
+function testSummary(): int
+{
+    $failures = $GLOBALS['adm_test_failures'];
+    echo $failures === 0 ? "\nall checks passed\n" : "\n$failures checks failed\n";
+    return $failures === 0 ? 0 : 1;
+}
+
+/**
+ * A table with the columns that Admidio entities normally have.
+ */
+function columnDefinition(string $prefix): array
+{
+    return array(
+        $prefix . '_id' => array('type' => 'integer', 'null' => false, 'key' => true, 'serial' => true, 'default' => null),
+        $prefix . '_uuid' => array('type' => 'varchar(36)', 'null' => false, 'key' => false, 'serial' => false, 'default' => null),
+        $prefix . '_name' => array('type' => 'varchar(255)', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        $prefix . '_secret' => array('type' => 'varchar(255)', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        $prefix . '_usr_id_create' => array('type' => 'integer', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        $prefix . '_timestamp_create' => array('type' => 'timestamp', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        $prefix . '_usr_id_change' => array('type' => 'integer', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        $prefix . '_timestamp_change' => array('type' => 'timestamp', 'null' => true, 'key' => false, 'serial' => false, 'default' => null)
+    );
+}

--- a/tests/hooks/bootstrap.php
+++ b/tests/hooks/bootstrap.php
@@ -3,6 +3,7 @@
  * Enough of the Admidio runtime to execute the real Entity lifecycle against SQLite.
  */
 require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/BufferedStatement.php';
 require __DIR__ . '/FakeDatabase.php';
 
 define('DB_TYPE', 'mysql');            // the PostgreSQL boolean conversion must stay out of the way

--- a/tests/hooks/change-notification.php
+++ b/tests/hooks/change-notification.php
@@ -571,14 +571,14 @@ $notification->suppressUser(1);
 
 check('a suppressed user gets no notification', !$notification->reportable(1));
 
-// ------------------------------------------------------------------------------ user_state_changed
+// ------------------------------------------------------------------------------ user_changes_cumulated
 
 $db = newDatabase();
 $user = aUser($db);
 $notification = newNotification();
 
 $states = array();
-Hooks::addAction('user_state_changed', function (?string $uuid, array $reasons) use (&$states) {
+Hooks::addAction('user_changes_cumulated', function (?string $uuid, array $reasons) use (&$states) {
     $states[] = ($uuid ?? '') . ':' . implode(',', $reasons);
 });
 
@@ -603,7 +603,7 @@ $db = newDatabase();
 $user = aUser($db);
 $notification = newNotification();
 $states = array();
-Hooks::addAction('user_state_changed', function (?string $uuid, array $reasons) use (&$states) {
+Hooks::addAction('user_changes_cumulated', function (?string $uuid, array $reasons) use (&$states) {
     $states[] = ($uuid ?? '') . ':' . implode(',', $reasons);
 });
 $user->setValue('usr_number_login', 7);
@@ -611,6 +611,6 @@ $user->setValue('usr_actual_login', '2026-08-26 10:00:00');
 $user->save();
 $notification->shutdown();
 
-check('a login is not a state change', $states === array(), implode(' ', $states));
+check('a login is not a change of the user', $states === array(), implode(' ', $states));
 
 exit(testSummary());

--- a/tests/hooks/change-notification.php
+++ b/tests/hooks/change-notification.php
@@ -1,0 +1,616 @@
+<?php
+/**
+ * ChangeNotification as a listener on the committed change sets. The listener under test is the real
+ * one and so are Entity, EntityHookQueue and the SQLite transactions underneath; the three tables of
+ * a person are created with the columns of install/db_scripts/db.sql, and $gProfileFields,
+ * $gSettingsManager and $gL10n are the stubs at the bottom of this file, because the mail is not what
+ * is being tested here - what the listener hears and what it makes of it is.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\Service\EntityHookQueue;
+use Admidio\Infrastructure\ChangeNotification;
+use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Tests\Hooks\FakeDatabase;
+
+define('TBL_USERS', TABLE_PREFIX . '_users');
+define('TBL_USER_DATA', TABLE_PREFIX . '_user_data');
+define('TBL_MEMBERS', TABLE_PREFIX . '_members');
+define('TBL_ROLES', TABLE_PREFIX . '_roles');
+define('TBL_CATEGORIES', TABLE_PREFIX . '_categories');
+
+// --------------------------------------------------------------------------------------- entities
+
+function column(string $type, bool $key = false, bool $serial = false): array
+{
+    return array('type' => $type, 'null' => true, 'key' => $key, 'serial' => $serial, 'default' => null);
+}
+
+/** adm_users, with the hook ID, the sensitive columns and the ignored columns of the real User. */
+class TestUser extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TBL_USERS, 'usr', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'user';
+    }
+
+    public function getSensitiveHookColumns(): array
+    {
+        return array('usr_password', 'usr_tfa_secret', 'usr_photo');
+    }
+
+    public function getIgnoredLogColumns(): array
+    {
+        return array_merge(parent::getIgnoredLogColumns(), array(
+            'usr_uuid', 'usr_pw_reset_id', 'usr_pw_reset_timestamp', 'usr_last_login',
+            'usr_actual_login', 'usr_number_login', 'usr_date_invalid', 'usr_number_invalid',
+            'usr_valid'
+        ));
+    }
+
+    /** The dependent records the real User::delete() removes, in the same way. */
+    public function delete(): bool
+    {
+        $usrId = $this->getValue('usr_id');
+        $this->db->startTransaction();
+        $this->deleteDependentRecords(new TestMembership($this->db), array('mem_id'), 'mem_usr_id = ?', array($usrId));
+        $this->deleteDependentRecords(new TestUserData($this->db), array('usd_id'), 'usd_usr_id = ?', array($usrId));
+        $returnValue = parent::delete();
+        $this->db->endTransaction();
+
+        return $returnValue;
+    }
+}
+
+/** adm_user_data, one profile field value of one user. */
+class TestUserData extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TBL_USER_DATA, 'usd', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'user_data';
+    }
+}
+
+/** adm_members, one membership of one user in one role. */
+class TestMembership extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TBL_MEMBERS, 'mem', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'membership';
+    }
+}
+
+/** adm_user_fields, which takes the values of everybody with it when it is deleted. */
+class TestProfileField extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TABLE_PREFIX . '_user_fields', 'usf', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'profile_field';
+    }
+
+    public function delete(): bool
+    {
+        $usfId = $this->getValue('usf_id');
+        $this->db->startTransaction();
+        $this->deleteDependentRecords(new TestUserData($this->db), array('usd_id'), 'usd_usf_id = ?', array($usfId));
+        $returnValue = parent::delete();
+        $this->db->endTransaction();
+
+        return $returnValue;
+    }
+}
+
+/** adm_roles, which takes the memberships of everybody with it when it is deleted. */
+class TestRole extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TBL_ROLES, 'rol', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'role';
+    }
+
+    public function delete(): bool
+    {
+        $rolId = $this->getValue('rol_id');
+        $this->db->startTransaction();
+        $this->deleteDependentRecords(new TestMembership($this->db), array('mem_id'), 'mem_rol_id = ?', array($rolId));
+        $returnValue = parent::delete();
+        $this->db->endTransaction();
+
+        return $returnValue;
+    }
+}
+
+/** Reads what the listener collected, which is what this test is about. */
+class ProbeNotification extends ChangeNotification
+{
+    public function collected(): array
+    {
+        return $this->changes;
+    }
+
+    public function reportable(int $userID): bool
+    {
+        return array_key_exists($userID, $this->changes) && $this->isReportable($this->changes[$userID]);
+    }
+}
+
+// ------------------------------------------------------------------------------------------ stubs
+
+/** The profile fields of the fixture, as much of ProfileFields as the listener asks for. */
+class StubProfileFields
+{
+    private array $fields = array(
+        1 => array('intern' => 'LAST_NAME', 'name' => 'Last name', 'type' => 'TEXT'),
+        2 => array('intern' => 'FIRST_NAME', 'name' => 'First name', 'type' => 'TEXT'),
+        3 => array('intern' => 'BIRTHDAY', 'name' => 'Birthday', 'type' => 'DATE')
+    );
+
+    public function getPropertyById(int $fieldId, string $column, string $format = ''): array|string
+    {
+        if (!array_key_exists($fieldId, $this->fields)) {
+            return '';
+        }
+
+        return ($column === 'usf_name_intern') ? $this->fields[$fieldId]['intern'] : $this->fields[$fieldId]['name'];
+    }
+
+    public function getProperty(string $fieldNameIntern, string $column, string $format = ''): mixed
+    {
+        foreach ($this->fields as $fieldId => $field) {
+            if ($field['intern'] === $fieldNameIntern) {
+                return $fieldId;
+            }
+        }
+
+        return 0;
+    }
+
+    public function formatValue(string $fieldNameIntern, mixed $value, string $format = ''): mixed
+    {
+        foreach ($this->fields as $field) {
+            if ($field['intern'] === $fieldNameIntern && $field['type'] === 'DATE' && $value !== '') {
+                $date = DateTime::createFromFormat('Y-m-d', (string)$value);
+                if ($date !== false) {
+                    return $date->format('d.m.Y');
+                }
+            }
+        }
+
+        return $value;
+    }
+}
+
+class StubSettingsManager
+{
+    public function has(string $name): bool
+    {
+        return true;
+    }
+
+    public function getBool(string $name): bool
+    {
+        // no mail is sent in this test, the collected changes are what is checked
+        return false;
+    }
+
+    public function getString(string $name): string
+    {
+        return 'd.m.Y';
+    }
+}
+
+class StubLanguage
+{
+    public function get(string $textId, array $params = array()): string
+    {
+        return $textId;
+    }
+}
+
+$GLOBALS['gProfileFields'] = new StubProfileFields();
+$GLOBALS['gSettingsManager'] = new StubSettingsManager();
+$GLOBALS['gL10n'] = new StubLanguage();
+$GLOBALS['gCurrentUser'] = null;
+
+// ---------------------------------------------------------------------------------------- fixture
+
+function newDatabase(): FakeDatabase
+{
+    Hooks::reset();
+    EntityHookQueue::reset();
+
+    $db = new FakeDatabase();
+    $db->createTable(TBL_USERS, array(
+        'usr_id' => column('integer', true, true),
+        'usr_uuid' => column('varchar(36)'),
+        'usr_login_name' => column('varchar(254)'),
+        'usr_password' => column('varchar(255)'),
+        'usr_tfa_secret' => column('varchar(255)'),
+        'usr_photo' => column('bytea'),
+        'usr_text' => column('text'),
+        'usr_last_login' => column('timestamp'),
+        'usr_actual_login' => column('timestamp'),
+        'usr_number_login' => column('integer'),
+        'usr_usr_id_create' => column('integer'),
+        'usr_timestamp_create' => column('timestamp'),
+        'usr_usr_id_change' => column('integer'),
+        'usr_timestamp_change' => column('timestamp'),
+        'usr_valid' => column('boolean')
+    ));
+    $db->createTable(TBL_USER_DATA, array(
+        'usd_id' => column('integer', true, true),
+        'usd_usr_id' => column('integer'),
+        'usd_usf_id' => column('integer'),
+        'usd_value' => column('varchar(4000)')
+    ));
+    $db->createTable(TBL_MEMBERS, array(
+        'mem_id' => column('integer', true, true),
+        'mem_rol_id' => column('integer'),
+        'mem_usr_id' => column('integer'),
+        'mem_uuid' => column('varchar(36)'),
+        'mem_begin' => column('date'),
+        'mem_end' => column('date'),
+        'mem_leader' => column('boolean'),
+        'mem_usr_id_create' => column('integer'),
+        'mem_timestamp_create' => column('timestamp'),
+        'mem_usr_id_change' => column('integer'),
+        'mem_timestamp_change' => column('timestamp')
+    ));
+    $db->createTable(TABLE_PREFIX . '_user_fields', array(
+        'usf_id' => column('integer', true, true),
+        'usf_name' => column('varchar(100)')
+    ));
+    $db->createTable(TBL_ROLES, array(
+        'rol_id' => column('integer', true, true),
+        'rol_cat_id' => column('integer'),
+        'rol_name' => column('varchar(100)')
+    ));
+    $db->createTable(TBL_CATEGORIES, array(
+        'cat_id' => column('integer', true, true),
+        'cat_name_intern' => column('varchar(110)')
+    ));
+
+    // one ordinary role and one that belongs to an event
+    $db->queryPrepared('INSERT INTO ' . TBL_CATEGORIES . ' (cat_id, cat_name_intern) VALUES (1, ?)', array('COMMON'));
+    $db->queryPrepared('INSERT INTO ' . TBL_CATEGORIES . ' (cat_id, cat_name_intern) VALUES (2, ?)', array('EVENTS'));
+    $db->queryPrepared('INSERT INTO ' . TBL_ROLES . ' (rol_id, rol_cat_id, rol_name) VALUES (1, 1, ?)', array('Choir'));
+    $db->queryPrepared('INSERT INTO ' . TBL_ROLES . ' (rol_id, rol_cat_id, rol_name) VALUES (2, 2, ?)', array('Summer camp'));
+    $db->queryPrepared('INSERT INTO ' . TABLE_PREFIX . '_user_fields (usf_id, usf_name) VALUES (1, ?)', array('Last name'));
+    $db->queryPrepared('INSERT INTO ' . TABLE_PREFIX . '_user_fields (usf_id, usf_name) VALUES (2, ?)', array('First name'));
+    $db->queryPrepared('INSERT INTO ' . TABLE_PREFIX . '_user_fields (usf_id, usf_name) VALUES (3, ?)', array('Birthday'));
+
+    $GLOBALS['gDb'] = $db;
+
+    return $db;
+}
+
+function newNotification(): ProbeNotification
+{
+    return new ProbeNotification();
+}
+
+/** A saved user with a last name, a first name and a membership. */
+function aUser(FakeDatabase $db, string $loginName = 'jdoe'): TestUser
+{
+    $user = new TestUser($db);
+    $user->setValue('usr_login_name', $loginName);
+    $user->setValue('usr_valid', true);
+    $user->save();
+
+    foreach (array(1 => 'Doe', 2 => 'John') as $fieldId => $value) {
+        $value_ = new TestUserData($db);
+        $value_->setValue('usd_usr_id', $user->getValue('usr_id'));
+        $value_->setValue('usd_usf_id', $fieldId);
+        $value_->setValue('usd_value', $value);
+        $value_->save();
+    }
+
+    return $user;
+}
+
+function aMembership(FakeDatabase $db, TestUser $user, int $roleId = 1): TestMembership
+{
+    $membership = new TestMembership($db);
+    $membership->setValue('mem_rol_id', $roleId);
+    $membership->setValue('mem_usr_id', $user->getValue('usr_id'));
+    $membership->setValue('mem_begin', '2026-01-01');
+    $membership->setValue('mem_end', '9999-12-31');
+    $membership->save();
+
+    return $membership;
+}
+
+/** The profile changes of one user as "label: old -> new", so a check can name what it expects. */
+function profileChanges(array $collected, int $userID): string
+{
+    $lines = array();
+    foreach ($collected[$userID]['profile_changes'] ?? array() as $change) {
+        $lines[] = $change[0] . ': ' . $change[1] . ' -> ' . $change[2];
+    }
+    return implode(' | ', $lines);
+}
+
+function roleChanges(array $collected, int $userID): string
+{
+    $lines = array();
+    foreach ($collected[$userID]['role_changes'] ?? array() as $change) {
+        $lines[] = $change[0] . '/' . $change[1] . ': ' . $change[2] . ' -> ' . $change[3];
+    }
+    return implode(' | ', $lines);
+}
+
+// ------------------------------------------------------------------------ a profile value changes
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$value = new TestUserData($db);
+$value->readDataByColumns(array('usd_usr_id' => $user->getValue('usr_id'), 'usd_usf_id' => 3));
+$value->setValue('usd_usf_id', 3);
+$value->setValue('usd_usr_id', $user->getValue('usr_id'));
+$value->setValue('usd_value', '1980-07-04');
+$value->save();
+
+check(
+    'a profile value that is written is reported with the format of the field',
+    profileChanges($notification->collected(), 1) === 'Birthday:  -> 04.07.1980',
+    profileChanges($notification->collected(), 1)
+);
+check('and it is a reason for the state of the user', array_keys($notification->collected()[1]['reasons']) === array('profile'));
+
+// ---------------------------------------------------------------- a value that was never persisted
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$unsaved = new TestUserData($db);
+$unsaved->setValue('usd_usr_id', $user->getValue('usr_id'));
+$unsaved->setValue('usd_usf_id', 3);
+$unsaved->setValue('usd_value', '1980-07-04');
+
+check('a value that was never saved is not reported', $notification->collected() === array());
+
+// ---------------------------------------------------------------------- a change that is rolled back
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$db->startTransaction();
+$user->setValue('usr_login_name', 'rolled-back');
+$user->save();
+$db->rollback();
+
+check('a change whose transaction is lost is not reported', $notification->collected() === array());
+
+// --------------------------------------------------------------------------- a value that comes back
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$user->setValue('usr_login_name', 'intermediate');
+$user->save();
+$user->setValue('usr_login_name', 'jdoe');
+$user->save();
+
+check(
+    'a value that ends where it started is no change',
+    profileChanges($notification->collected(), 1) === '',
+    profileChanges($notification->collected(), 1)
+);
+
+// ------------------------------------------------------------------------------- a login is no change
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$user->setValue('usr_last_login', '2026-08-01 10:00:00');
+$user->setValue('usr_number_login', 5);
+$user->setValue('usr_actual_login', '2026-08-26 10:00:00');
+$user->save();
+
+check('a login writes counters and is not a change of the user', $notification->collected() === array());
+
+// ---------------------------------------------------------------------------------- a user is created
+
+$db = newDatabase();
+$notification = newNotification();
+$user = aUser($db, 'newbie');
+
+$collected = $notification->collected();
+check('a new user is reported as a creation', ($collected[1]['created'] ?? false) === true);
+check(
+    'with the columns of the record and the profile fields that have a value',
+    profileChanges($collected, 1) === 'SYS_USERNAME:  -> newbie | Last name:  -> Doe | First name:  -> John',
+    profileChanges($collected, 1)
+);
+check(
+    'and both the record and the profile values are reasons',
+    array_keys($collected[1]['reasons']) === array('user', 'profile'),
+    implode(',', array_keys($collected[1]['reasons']))
+);
+
+// ---------------------------------------------------------------------------- a password is withheld
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$user->setValue('usr_password', 'a-real-secret');
+$user->save();
+
+check(
+    'a password change is reported without the password',
+    profileChanges($notification->collected(), 1) === 'SYS_PASSWORD:  -> ********',
+    profileChanges($notification->collected(), 1)
+);
+
+// -------------------------------------------------------------------------------- memberships
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+$membership = aMembership($db, $user);
+
+check(
+    'a new membership reports its start and its end',
+    roleChanges($notification->collected(), 1) === 'Choir/SYS_MEMBERSHIP_START:  -> 01.01.2026 | Choir/SYS_MEMBERSHIP_END:  -> 31.12.9999',
+    roleChanges($notification->collected(), 1)
+);
+
+$membership->setValue('mem_end', '2026-12-31');
+$membership->save();
+check(
+    'ending it reports the end against the value it had',
+    roleChanges($notification->collected(), 1) === 'Choir/SYS_MEMBERSHIP_START:  -> 01.01.2026 | Choir/SYS_MEMBERSHIP_END:  -> 31.12.2026',
+    roleChanges($notification->collected(), 1)
+);
+
+$db = newDatabase();
+$user = aUser($db);
+$membership = aMembership($db, $user, 2);
+$notification = newNotification();
+$membership->setValue('mem_end', '2026-12-31');
+$membership->save();
+check('taking part in an event is not a role of the person', $notification->collected() === array());
+
+// ------------------------------------------------------------------------------- a user is deleted
+
+$db = newDatabase();
+$user = aUser($db);
+aMembership($db, $user);
+$notification = newNotification();
+$user->delete();
+
+$collected = $notification->collected();
+check('a deleted user is reported as a deletion', ($collected[1]['deleted'] ?? false) === true);
+check(
+    'the record and the profile values it had are reported as emptied',
+    profileChanges($collected, 1) === 'Last name: Doe ->  | First name: John ->  | SYS_USERNAME: jdoe -> ',
+    profileChanges($collected, 1)
+);
+check(
+    'and so are the memberships it had',
+    roleChanges($collected, 1) === 'Choir/SYS_MEMBERSHIP_START: 01.01.2026 ->  | Choir/SYS_MEMBERSHIP_END: 31.12.9999 -> ',
+    roleChanges($collected, 1)
+);
+check('the login name survives the deletion', ($collected[1]['usr_login_name'] ?? '') === 'jdoe');
+check('and so does the name', ($collected[1]['last_name'] ?? '') === 'Doe' && ($collected[1]['first_name'] ?? '') === 'John');
+check('a deleted user with a valid account is reported', $notification->reportable(1));
+
+// ------------------------------------------------------ a user that was never activated is not news
+
+$db = newDatabase();
+$user = new TestUser($db);
+$user->setValue('usr_login_name', 'never-approved');
+$user->setValue('usr_valid', false);
+$user->save();
+$notification = newNotification();
+$user->delete();
+
+check('deleting an account that was never activated is not reported', !$notification->reportable(1));
+
+// -------------------------------------------------------------------- a cascade of something else
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$field = new TestProfileField($db, 3);
+$field->delete();
+
+check('deleting a profile field is not a change of the people who had a value in it', $notification->collected() === array());
+
+$db = newDatabase();
+$user = aUser($db);
+aMembership($db, $user);
+$notification = newNotification();
+
+$role = new TestRole($db, 1);
+$role->delete();
+
+check('deleting a role is not a change of its members', $notification->collected() === array());
+
+// ------------------------------------------------------------------------------------ suppression
+
+$db = newDatabase();
+$notification = newNotification();
+$user = aUser($db, 'registration');
+$notification->suppressUser(1);
+
+check('a suppressed user gets no notification', !$notification->reportable(1));
+
+// ------------------------------------------------------------------------------ user_state_changed
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+
+$states = array();
+Hooks::addAction('user_state_changed', function (?string $uuid, array $reasons) use (&$states) {
+    $states[] = ($uuid ?? '') . ':' . implode(',', $reasons);
+});
+
+$user->setValue('usr_login_name', 'renamed');
+$user->save();
+$value = new TestUserData($db);
+$value->setValue('usd_usr_id', 1);
+$value->setValue('usd_usf_id', 3);
+$value->setValue('usd_value', '1980-07-04');
+$value->save();
+aMembership($db, $user);
+$notification->shutdown();
+
+check('one action per affected user and request', count($states) === 1, (string)count($states));
+check(
+    'naming every part of the person that changed',
+    ($states[0] ?? '') === $user->getValue('usr_uuid') . ':user,profile,membership',
+    $states[0] ?? ''
+);
+
+$db = newDatabase();
+$user = aUser($db);
+$notification = newNotification();
+$states = array();
+Hooks::addAction('user_state_changed', function (?string $uuid, array $reasons) use (&$states) {
+    $states[] = ($uuid ?? '') . ':' . implode(',', $reasons);
+});
+$user->setValue('usr_number_login', 7);
+$user->setValue('usr_actual_login', '2026-08-26 10:00:00');
+$user->save();
+$notification->shutdown();
+
+check('a login is not a state change', $states === array(), implode(' ', $states));
+
+exit(testSummary());

--- a/tests/hooks/change-notification.php
+++ b/tests/hooks/change-notification.php
@@ -10,6 +10,7 @@ require __DIR__ . '/bootstrap.php';
 
 use Admidio\Hooks\Hooks;
 use Admidio\Hooks\Service\EntityHookQueue;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
 use Admidio\Infrastructure\ChangeNotification;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Entity\Entity;
@@ -551,6 +552,39 @@ $field = new TestProfileField($db, 3);
 $field->delete();
 
 check('deleting a profile field is not a change of the people who had a value in it', $notification->collected() === array());
+
+// Three users, of whom only two ever filled the field in. Deleting it must describe two rows, not
+// three: hookBulkDeletion() reads the rows that exist, and a profile field that was never filled in
+// has no row at all.
+$db = newDatabase();
+$withValue = array();
+foreach (array('a', 'b', 'c') as $index => $loginName) {
+    $person = aUser($db, $loginName);
+    if ($index < 2) {
+        $value = new TestUserData($db);
+        $value->setValue('usd_usr_id', $person->getValue('usr_id'));
+        $value->setValue('usd_usf_id', 3);
+        $value->setValue('usd_value', '1980-07-0' . ($index + 1));
+        $value->save();
+        $withValue[] = (int)$person->getValue('usr_id');
+    }
+}
+
+$notification = newNotification();
+$deletions = array();
+Hooks::addAction('user_data_deleted', function (EntityChangeSet $cs) use (&$deletions) {
+    $deletions[] = (int)$cs->getOldValue('usd_usr_id');
+});
+
+$field = new TestProfileField($db, 3);
+$field->delete();
+
+check(
+    'only the users who had a value in the field are described at all',
+    $deletions === $withValue,
+    implode(',', $deletions) . ' of 3 users'
+);
+check('and none of them gets a notification', $notification->collected() === array());
 
 $db = newDatabase();
 $user = aUser($db);

--- a/tests/hooks/component-hooks.php
+++ b/tests/hooks/component-hooks.php
@@ -132,4 +132,68 @@ Hooks::addFilter('component_visible', function (bool $visible) use (&$seen) {
 }, 10);
 check('every callback sees the answer of the one before it', ProbeComponent::isVisible('PHOTOS') === false && $seen === array(true, false), json_encode($seen));
 
+// ------------------------------------------------------- the real Component, for one component
+
+/**
+ * isVisible() is static and the CATEGORY-REPORT branch of its switch asks nothing but the settings
+ * and the current user, so the real method can be executed here with those two stubbed. Nothing is
+ * constructed and no other branch is reached.
+ */
+class StubSettings
+{
+    public array $values = array();
+
+    public function getBool(string $name): bool
+    {
+        return (bool)($this->values[$name] ?? false);
+    }
+
+    public function getInt(string $name): int
+    {
+        return (int)($this->values[$name] ?? 0);
+    }
+
+    public function getString(string $name): string
+    {
+        return (string)($this->values[$name] ?? '');
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->values);
+    }
+}
+
+class StubUser
+{
+    public array $rights = array();
+
+    public function checkRolesRight(string $right): bool
+    {
+        return (bool)($this->rights[$right] ?? false);
+    }
+}
+
+function categoryReport(bool $moduleEnabled, bool $hasRight): bool
+{
+    Hooks::reset();
+    $settings = new StubSettings();
+    $settings->values['category_report_module_enabled'] = $moduleEnabled;
+    $user = new StubUser();
+    $user->rights['rol_all_lists_view'] = $hasRight;
+
+    $GLOBALS['gSettingsManager'] = $settings;
+    $GLOBALS['gCurrentUser'] = $user;
+    $GLOBALS['gValidLogin'] = true;
+
+    return \Admidio\Components\Entity\Component::isVisible('CATEGORY-REPORT');
+}
+
+check('the category report is visible when it is switched on and the right is there', categoryReport(true, true));
+check('it is not visible without the right', !categoryReport(true, false));
+check(
+    'and it is not visible when the module is switched off, which is what finding 92 was',
+    !categoryReport(false, true)
+);
+
 exit(testSummary());

--- a/tests/hooks/component-hooks.php
+++ b/tests/hooks/component-hooks.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * component_visible and component_administrable: the two filters that decide, in one place, which
+ * modules the menu shows and which of them a user may administrate.
+ *
+ * `Component` reads the settings, the current user and the database, so it cannot be constructed here.
+ * What this file executes is the real `Hooks` engine and a stand-in that has the wrapper of both
+ * methods verbatim - the wrapper is the whole change, the switch statements below it are untouched.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+
+/** The two public methods of Component as they are after the patch. */
+class ProbeComponent
+{
+    /** @var array<string,bool> what Admidio itself answers, standing in for the two switch statements */
+    public static array $rights = array();
+
+    public static function isVisible(string $componentName): bool
+    {
+        return Hooks::applyTypedFilters('component_visible', self::checkVisible($componentName), $componentName);
+    }
+
+    public static function isAdministrable(string $componentName): bool
+    {
+        return Hooks::applyTypedFilters('component_administrable', self::checkAdministrable($componentName), $componentName);
+    }
+
+    private static function checkVisible(string $componentName): bool
+    {
+        return self::$rights['visible:' . $componentName] ?? false;
+    }
+
+    private static function checkAdministrable(string $componentName): bool
+    {
+        // the real one does the same: an administrator has to be able to see the module first
+        if (self::isVisible($componentName)) {
+            return self::$rights['admin:' . $componentName] ?? false;
+        }
+
+        return false;
+    }
+}
+
+function fixture(array $rights): void
+{
+    Hooks::reset();
+    ProbeComponent::$rights = $rights;
+}
+
+// -------------------------------------------------------------------- without a filter nothing moves
+
+fixture(array('visible:PHOTOS' => true, 'admin:PHOTOS' => false));
+check('the rights of Admidio are the answer', ProbeComponent::isVisible('PHOTOS') && !ProbeComponent::isAdministrable('PHOTOS'));
+
+// ------------------------------------------------------------------------------- a filter can revoke
+
+fixture(array('visible:PHOTOS' => true, 'admin:PHOTOS' => true));
+Hooks::addFilter('component_visible', function (bool $visible, string $component) {
+    return ($component === 'PHOTOS') ? false : $visible;
+});
+check('a filter can hide a module', !ProbeComponent::isVisible('PHOTOS'));
+check(
+    'and hiding it also takes the administration with it',
+    !ProbeComponent::isAdministrable('PHOTOS'),
+    'checkAdministrable() asks isVisible(), so it sees the filtered answer'
+);
+
+// -------------------------------------------------------------------------------- and it can grant
+
+fixture(array('visible:FORUM' => false));
+Hooks::addFilter('component_visible', function (bool $visible, string $component) {
+    return ($component === 'FORUM') ? true : $visible;
+});
+check('a filter can also show a module that Admidio would hide', ProbeComponent::isVisible('FORUM'));
+
+// -------------------------------------------------------------- the two filters are separate answers
+
+fixture(array('visible:EVENTS' => true, 'admin:EVENTS' => false));
+Hooks::addFilter('component_administrable', function (bool $administrable, string $component) {
+    return ($component === 'EVENTS') ? true : $administrable;
+});
+check('component_administrable grants administration on its own', ProbeComponent::isAdministrable('EVENTS'));
+check('and does not change what is visible', ProbeComponent::isVisible('EVENTS'));
+
+// -------------------------------------------------------------- one component does not affect another
+
+fixture(array('visible:PHOTOS' => true, 'visible:LINKS' => true));
+Hooks::addFilter('component_visible', function (bool $visible, string $component) {
+    return ($component === 'PHOTOS') ? false : $visible;
+});
+check('a filter that names one component leaves the others alone', ProbeComponent::isVisible('LINKS'));
+
+// ------------------------------------------------------------------- a permission is never coerced
+
+fixture(array('visible:PHOTOS' => true));
+Hooks::addFilter('component_visible', function () {
+    return 1;                       // truthy, but not an answer
+});
+$refused = false;
+try {
+    ProbeComponent::isVisible('PHOTOS');
+} catch (\Throwable $exception) {
+    $refused = str_contains($exception->getMessage(), 'returned int instead of bool');
+}
+check('a filter that does not answer with a bool is refused, not coerced', $refused);
+
+fixture(array('visible:PHOTOS' => true));
+Hooks::addFilter('component_visible', function () {
+    return 'yes';
+});
+$refused = false;
+try {
+    ProbeComponent::isVisible('PHOTOS');
+} catch (\Throwable $exception) {
+    $refused = str_contains($exception->getMessage(), 'returned string instead of bool');
+}
+check('and neither is a string that looks like one', $refused);
+
+// -------------------------------------------------------------------------- the chain is a chain
+
+fixture(array('visible:PHOTOS' => true));
+$seen = array();
+Hooks::addFilter('component_visible', function (bool $visible) use (&$seen) {
+    $seen[] = $visible;
+    return false;
+}, 5);
+Hooks::addFilter('component_visible', function (bool $visible) use (&$seen) {
+    $seen[] = $visible;
+    return $visible;
+}, 10);
+check('every callback sees the answer of the one before it', ProbeComponent::isVisible('PHOTOS') === false && $seen === array(true, false), json_encode($seen));
+
+exit(testSummary());

--- a/tests/hooks/email-hooks.php
+++ b/tests/hooks/email-hooks.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * The email hooks.
+ *
+ * The real `Email` is constructed here, but no mail is ever handed to PHPMailer: a test that tries to
+ * deliver would either need a mail server or would actually send something. So the wrapper of
+ * `sendEmail()` is checked through a stand-in that carries it verbatim, the short circuit for a demo
+ * installation is checked on the real object, and the property that matters - that no email hook is
+ * ever handed the message, because PHPMailer keeps the SMTP credentials in public properties - is
+ * checked against the real source file.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+
+class StubSettings
+{
+    public array $values = array(
+        'mail_sending_mode' => 0,
+        'mail_sender_mode' => 2,
+        'mail_sender_name' => 'Example Club',
+        'mail_sender_email' => 'noreply@example.org',
+        'mail_number_recipients' => 50
+    );
+
+    public function getBool(string $name): bool
+    {
+        return (bool)($this->values[$name] ?? false);
+    }
+
+    public function getInt(string $name): int
+    {
+        return (int)($this->values[$name] ?? 0);
+    }
+
+    public function getString(string $name): string
+    {
+        return (string)($this->values[$name] ?? '');
+    }
+
+    public function get(string $name)
+    {
+        return $this->values[$name] ?? null;
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->values);
+    }
+}
+
+class StubLanguage
+{
+    public function getLanguageIsoCode(): string
+    {
+        return 'en';
+    }
+
+    public function get(string $textId, array $params = array()): string
+    {
+        return $textId;
+    }
+}
+
+$GLOBALS['gSettingsManager'] = new StubSettings();
+$GLOBALS['gL10n'] = new StubLanguage();
+$GLOBALS['gDebug'] = false;
+$GLOBALS['gValidLogin'] = false;
+
+/** The wrapper of Email::sendEmail(), with the delivery replaced by something the test controls. */
+class ProbeEmail
+{
+    public array $recipients = array();
+    public string $subject = '';
+    /** @var callable what deliver() does */
+    public $deliver;
+
+    public function sendEmail(): bool
+    {
+        $this->recipients = Hooks::applyTypedFilters('email_recipients', $this->recipients, $this->subject);
+        $recipientCount = count($this->recipients);
+
+        try {
+            ($this->deliver)($this->recipients);
+        } catch (\Throwable $exception) {
+            Hooks::doActionCatchErrors('email_failed', $this->subject, $recipientCount, $exception->getMessage());
+
+            throw $exception;
+        }
+
+        Hooks::doActionCatchErrors('email_sent', $this->subject, $recipientCount);
+
+        return true;
+    }
+}
+
+function anEmail(callable $deliver): ProbeEmail
+{
+    Hooks::reset();
+    $mail = new ProbeEmail();
+    $mail->subject = 'The summer camp';
+    $mail->recipients = array(
+        array('email' => 'a@example.org', 'name' => 'Ann', 'firstname' => 'Ann', 'surname' => 'A'),
+        array('email' => 'b@example.org', 'name' => 'Bob', 'firstname' => 'Bob', 'surname' => 'B'),
+        array('email' => 'c@example.org', 'name' => 'Cid', 'firstname' => 'Cid', 'surname' => 'C')
+    );
+    $mail->deliver = $deliver;
+
+    return $mail;
+}
+
+// ------------------------------------------------------------------ a recipient can be taken away
+
+$delivered = array();
+$mail = anEmail(function (array $recipients) use (&$delivered) {
+    $delivered = array_column($recipients, 'email');
+});
+Hooks::addFilter('email_recipients', function (array $recipients) {
+    return array_values(array_filter($recipients, function (array $recipient) {
+        return $recipient['email'] !== 'b@example.org';
+    }));
+});
+$mail->sendEmail();
+
+check('a filter can remove a recipient', $delivered === array('a@example.org', 'c@example.org'), implode(',', $delivered));
+
+// removing every recipient means nothing is sent, and that is not an error
+$delivered = array();
+$mail = anEmail(function (array $recipients) use (&$delivered) {
+    $delivered = array_column($recipients, 'email');
+});
+Hooks::addFilter('email_recipients', function () {
+    return array();
+});
+check('a filter can suppress the mail altogether', $mail->sendEmail() === true && $delivered === array(), implode(',', $delivered));
+
+// ------------------------------------------------------------- the diagnostics say what happened
+
+$sent = array();
+$mail = anEmail(function () {
+});
+Hooks::addAction('email_sent', function (string $subject, int $count) use (&$sent) {
+    $sent[] = $subject . '/' . $count;
+});
+$mail->sendEmail();
+check('email_sent reports the subject and how many were addressed', $sent === array('The summer camp/3'), implode(',', $sent));
+
+// the count is the one after the filter, not the one the module handed in
+$sent = array();
+$mail = anEmail(function () {
+});
+Hooks::addFilter('email_recipients', function (array $recipients) {
+    return array(reset($recipients));
+});
+Hooks::addAction('email_sent', function (string $subject, int $count) use (&$sent) {
+    $sent[] = $subject . '/' . $count;
+});
+$mail->sendEmail();
+check('and it counts what was really addressed, after the filter', $sent === array('The summer camp/1'), implode(',', $sent));
+
+// ------------------------------------------------------------------------------ a failed delivery
+
+$failures = array();
+$mail = anEmail(function () {
+    throw new \RuntimeException('SMTP connect failed');
+});
+Hooks::addAction('email_failed', function (string $subject, int $count, string $error) use (&$failures) {
+    $failures[] = $subject . '/' . $count . '/' . $error;
+});
+Hooks::addAction('email_sent', function () use (&$failures) {
+    $failures[] = 'sent';
+});
+
+$reported = '';
+try {
+    $mail->sendEmail();
+} catch (\Throwable $exception) {
+    $reported = $exception->getMessage();
+}
+check('email_failed reports the failure', $failures === array('The summer camp/3/SMTP connect failed'), implode(',', $failures));
+check('email_sent does not fire for a mail that was not sent', !in_array('sent', $failures, true));
+check('and the failure still reaches the caller', $reported === 'SMTP connect failed', $reported);
+
+// a broken diagnostic must not swallow the delivery error
+$mail = anEmail(function () {
+    throw new \RuntimeException('SMTP connect failed');
+});
+Hooks::addAction('email_failed', function () {
+    throw new \LogicException('the outbox plugin is broken');
+});
+$reported = '';
+try {
+    $mail->sendEmail();
+} catch (\Throwable $exception) {
+    $reported = $exception->getMessage();
+}
+check('a listener that throws cannot replace the delivery error', $reported === 'SMTP connect failed', $reported);
+
+// --------------------------------------------- a demo installation dispatches nothing at all
+
+Hooks::reset();
+$GLOBALS['gDisableEmailSending'] = true;
+$dispatched = 0;
+foreach (array('email_sent', 'email_failed') as $stage) {
+    Hooks::addAction($stage, function () use (&$dispatched) {
+        $dispatched++;
+    });
+}
+Hooks::addFilter('email_recipients', function (array $recipients) use (&$dispatched) {
+    $dispatched++;
+    return $recipients;
+});
+
+$real = new \Admidio\Infrastructure\Email();
+$real->addRecipient('a@example.org', 'Ann', 'A');
+$result = $real->sendEmail();
+unset($GLOBALS['gDisableEmailSending']);
+
+check('a mail that is not sent because sending is switched off reports nothing', $result === true && $dispatched === 0, (string)$dispatched);
+
+// ----------------------------------------------- the message itself never reaches a callback
+
+$source = file_get_contents(__DIR__ . '/../../src/Infrastructure/Email.php');
+$dispatches = array();
+foreach (explode("\n", $source) as $line) {
+    if (str_contains($line, 'Hooks::')) {
+        $dispatches[] = trim($line);
+    }
+}
+
+check('the email class dispatches the three email hooks', count($dispatches) === 3, implode(' | ', $dispatches));
+
+// $this as an argument would carry PHPMailer::$Username and ::$Password with it. A property of it,
+// such as $this->Subject, is a value and is fine.
+$handsOverTheMessage = function (string $line): bool {
+    return preg_match('/,\\s*\\$this\\s*(?:,|\\))/', $line) === 1;
+};
+
+check(
+    'the check would notice a hook that was handed the message',
+    $handsOverTheMessage('Hooks::doAction(a, $this->Subject, $this);')
+    && !$handsOverTheMessage('Hooks::doAction(a, $this->Subject, $count);')
+);
+
+$leaks = array_values(array_filter($dispatches, $handsOverTheMessage));
+check('and none of them is handed the message, which holds the SMTP credentials', $leaks === array(), implode(' | ', $leaks));
+
+exit(testSummary());

--- a/tests/hooks/entities.php
+++ b/tests/hooks/entities.php
@@ -45,3 +45,36 @@ class TestSession extends Entity
         parent::__construct($database, TABLE_PREFIX . '_sessions', 'ses', $id);
     }
 }
+
+/** A dependent record, removed together with the record it belongs to. */
+class TestBooking extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TABLE_PREFIX . '_bookings', 'bok', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'booking';
+    }
+}
+
+/** A room that removes its bookings the way the Admidio entities remove their dependent records. */
+class TestRoomWithBookings extends TestRoom
+{
+    public function delete(): bool
+    {
+        $this->db->startTransaction();
+        $this->deleteDependentRecords(
+            new TestBooking($this->db),
+            array('bok_id'),
+            'bok_room_id = ?',
+            array($this->getValue('room_id'))
+        );
+        $returnValue = parent::delete();
+        $this->db->endTransaction();
+
+        return $returnValue;
+    }
+}

--- a/tests/hooks/entities.php
+++ b/tests/hooks/entities.php
@@ -1,0 +1,47 @@
+<?php
+namespace Admidio\Tests\Hooks;
+
+use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Entity\Entity;
+
+/** A hookable entity, standing in for Room, Event, Announcement and the rest. */
+class TestRoom extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TABLE_PREFIX . '_rooms', 'room', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'room';
+    }
+}
+
+/** A second hookable entity, to prove that a listener of one is not called for the other. */
+class TestClient extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TABLE_PREFIX . '_clients', 'ocl', $id);
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'oidc_client';
+    }
+
+    public function getSensitiveHookColumns(): array
+    {
+        return array('ocl_secret');
+    }
+}
+
+/** An entity that opts out, standing in for Session, AutoLogin, LogChanges and the tokens. */
+class TestSession extends Entity
+{
+    public function __construct(Database $database, int|string $id = '')
+    {
+        parent::__construct($database, TABLE_PREFIX . '_sessions', 'ses', $id);
+    }
+}

--- a/tests/hooks/entity-cascade-delete.php
+++ b/tests/hooks/entity-cascade-delete.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * The records that an entity removes together with itself. deleteDependentRecords() replaces them
+ * with one DELETE, so their delete hooks have to be queued before that statement runs - otherwise a
+ * listener never learns that they existed.
+ */
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/entities.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\Service\EntityHookQueue;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Tests\Hooks\TestBooking;
+use Admidio\Tests\Hooks\TestRoomWithBookings;
+
+function bookingColumns(): array
+{
+    $columns = columnDefinition('bok');
+    $columns['bok_room_id'] = array('type' => 'integer', 'null' => true, 'key' => false, 'serial' => false, 'default' => null);
+    return $columns;
+}
+
+function newDatabase(): FakeDatabase
+{
+    Hooks::reset();
+    EntityHookQueue::reset();
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_rooms', columnDefinition('room'));
+    $db->createTable(TABLE_PREFIX . '_bookings', bookingColumns());
+    return $db;
+}
+
+/** A room with two bookings, all committed. */
+function roomWithBookings(FakeDatabase $db): TestRoomWithBookings
+{
+    $room = new TestRoomWithBookings($db);
+    $room->setValue('room_name', 'Blue Room');
+    $room->save();
+
+    foreach (array('Choir', 'Board') as $name) {
+        $booking = new TestBooking($db);
+        $booking->setValue('bok_name', $name);
+        $booking->setValue('bok_room_id', $room->getValue('room_id'));
+        $booking->save();
+    }
+
+    return $room;
+}
+
+function watch(array &$events): void
+{
+    foreach (array('deleting', 'deleted', 'delete_failed') as $stage) {
+        Hooks::addAction('booking_' . $stage, function (EntityChangeSet $cs) use (&$events, $stage) {
+            $events[] = array('stage' => $stage, 'changeSet' => $cs);
+        });
+    }
+    Hooks::addAction('room_deleted', function (EntityChangeSet $cs) use (&$events) {
+        $events[] = array('stage' => 'room_deleted', 'changeSet' => $cs);
+    });
+}
+
+function stages(array $events): string
+{
+    return implode(' ', array_column($events, 'stage'));
+}
+
+// ------------------------------------------------ every dependent record reports its own deletion
+$db = newDatabase();
+$room = roomWithBookings($db);
+$events = array();
+watch($events);
+$room->delete();
+
+check(
+    'the dependent records are dispatched before the record they belong to',
+    stages($events) === 'deleting deleting deleted deleted room_deleted',
+    stages($events)
+);
+check('and the rows are really gone', $db->fetchAll(TABLE_PREFIX . '_bookings') === array());
+
+$deleted = array_values(array_filter($events, function (array $event) {
+    return $event['stage'] === 'deleted';
+}));
+$names = array_map(function (array $event) {
+    return $event['changeSet']->getOldValue('bok_name');
+}, $deleted);
+check('each of them names the record that was removed', $names === array('Choir', 'Board'), implode(',', $names));
+
+$first = $deleted[0]['changeSet'];
+check('the operation is a deletion', $first->isDelete() && $first->getHookId() === 'booking');
+check('the id of the removed record is known', $first->getId() === 1, var_export($first->getId(), true));
+check('the snapshot carries the record', ($first->getSnapshot()['bok_name'] ?? null) === 'Choir');
+check(
+    'and it says what removed it',
+    $first->isCascade() && $first->getCauseHookId() === 'room' && $first->getCauseId() === 1,
+    var_export(array($first->getCauseHookId(), $first->getCauseId()), true)
+);
+
+$roomEvent = array_values(array_filter($events, function (array $event) {
+    return $event['stage'] === 'room_deleted';
+}))[0]['changeSet'];
+check('the record that was asked for is no cascade', !$roomEvent->isCascade());
+check(
+    'the owner it belonged to is in the change set',
+    $first->getOldValue('bok_room_id') === 1,
+    var_export($first->getOldValue('bok_room_id'), true)
+);
+
+// ------------------------------------------------------------ nothing is dispatched before commit
+$db = newDatabase();
+$room = roomWithBookings($db);
+$events = array();
+watch($events);
+$db->startTransaction();
+$room->delete();
+check('the deletions wait for the outermost commit', stages($events) === 'deleting deleting', stages($events));
+$db->endTransaction();
+check('and are dispatched by it', stages($events) === 'deleting deleting deleted deleted room_deleted', stages($events));
+
+// ----------------------------------------------------------- a lost transaction reports a failure
+$db = newDatabase();
+$room = roomWithBookings($db);
+$events = array();
+watch($events);
+$db->startTransaction();
+$room->delete();
+$db->rollback();
+check(
+    'a rolled back cascade reports the failure instead',
+    stages($events) === 'deleting deleting delete_failed delete_failed',
+    stages($events)
+);
+check('and the rows are still there', count($db->fetchAll(TABLE_PREFIX . '_bookings')) === 2);
+
+// ---------------------------------------------------------- nothing is read while nobody listens
+$db = newDatabase();
+$room = roomWithBookings($db);
+Hooks::reset();
+$before = count($db->statements);
+$room->delete();
+$selects = 0;
+foreach (array_slice($db->statements, $before) as $statement) {
+    if (str_starts_with(ltrim($statement), 'SELECT * FROM ' . TABLE_PREFIX . '_bookings')) {
+        $selects++;
+    }
+}
+check('without a listener the dependent records are not read at all', $selects === 0, (string)$selects);
+
+exit(testSummary());

--- a/tests/hooks/entity-change-tracking-after.php
+++ b/tests/hooks/entity-change-tracking-after.php
@@ -1,0 +1,48 @@
+<?php
+require __DIR__ . '/EntityChangeTrackingFixed.php';
+
+function show(string $case, $e, string $col, $expectedOld, $expectedChanged): void
+{
+    $prev = $e->columnsInfos[$col]['previousValue'];
+    $changed = $e->columnsInfos[$col]['changed'];
+    $ok = ($prev === $expectedOld) && ($changed === $expectedChanged);
+    printf("%-6s %-56s previousValue=%-10s changed=%s\n",
+        $ok ? '  ok' : 'FAIL', $case, var_export($prev, true), var_export($changed, true));
+}
+function flag(string $case, bool $ok): void { printf("%-6s %s\n", $ok ? '  ok' : 'FAIL', $case); }
+
+$mk = fn() => new EntityChangeTrackingFixed(
+    ['ann_headline' => 'A', 'ann_cat_id' => 3, 'ann_date' => '2026-01-01', 'ann_flag' => 1],
+    ['ann_headline' => 'varchar', 'ann_cat_id' => 'integer', 'ann_date' => 'date', 'ann_flag' => 'boolean']);
+
+$e = $mk(); $e->setValue('ann_headline', 'B'); $e->setValue('ann_headline', 'C');
+show('A -> B -> C reports the persisted old value A', $e, 'ann_headline', 'A', true);
+flag('  ... and the object holds C', $e->dbColumns['ann_headline'] === 'C');
+
+$e = $mk(); $e->setValue('ann_headline', 'B'); $e->setValue('ann_headline', 'A');
+show('A -> B -> A is no effective change', $e, 'ann_headline', null, false);
+flag('  ... and columnsValueChanged is false again', $e->columnsValueChanged === false);
+flag('  ... and the object holds A', $e->dbColumns['ann_headline'] === 'A');
+
+$e = $mk(); $e->setValue('ann_headline', 'B');
+show('A -> B still reports A', $e, 'ann_headline', 'A', true);
+flag('  ... and columnsValueChanged is true', $e->columnsValueChanged === true);
+
+$e = $mk(); $e->setValue('ann_headline', 'B'); $e->setValue('ann_cat_id', 7); $e->setValue('ann_headline', 'A');
+flag('one field reverted, another still changed -> still dirty', $e->columnsValueChanged === true);
+show('  ... reverted field is clean', $e, 'ann_headline', null, false);
+show('  ... other field keeps its old value', $e, 'ann_cat_id', 3, true);
+
+// date type round trip
+$e = $mk(); $e->setValue('ann_date', '2026-02-02'); $e->setValue('ann_date', '2026-01-01');
+show('date A -> B -> A is no effective change', $e, 'ann_date', null, false);
+
+// boolean round trip
+$e = $mk(); $e->setValue('ann_flag', 0); $e->setValue('ann_flag', 1);
+show('boolean 1 -> 0 -> 1 is no effective change', $e, 'ann_flag', null, false);
+
+// new record: nothing may be un-marked
+$e = $mk(); $e->insertRecord = true;
+foreach ($e->columnsInfos as $c => $_) { $e->columnsInfos[$c]['changed'] = true; }
+$e->setValue('ann_headline', 'B'); $e->setValue('ann_headline', 'A');
+flag('a new record keeps every column marked for the INSERT', $e->columnsInfos['ann_headline']['changed'] === true);

--- a/tests/hooks/entity-lifecycle-2.php
+++ b/tests/hooks/entity-lifecycle-2.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Deletion, redaction, the opt-out, selective dispatch and the value filters.
+ */
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/entities.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Hooks\ValueObject\EntityFieldChange;
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Tests\Hooks\TestClient;
+use Admidio\Tests\Hooks\TestRoom;
+use Admidio\Tests\Hooks\TestSession;
+
+function newDatabase(): FakeDatabase
+{
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_rooms', columnDefinition('room'));
+    $db->createTable(TABLE_PREFIX . '_clients', columnDefinition('ocl'));
+    $db->createTable(TABLE_PREFIX . '_sessions', columnDefinition('ses'));
+    return $db;
+}
+
+// ---------------------------------------------------------------- delete
+Hooks::reset();
+$log = array();
+$captured = array();
+foreach (array('entity_deleting', 'room_deleting', 'room_deleted', 'entity_deleted') as $name) {
+    Hooks::addAction($name, function (EntityChangeSet $cs) use (&$log, &$captured, $name) {
+        $log[] = $name;
+        $captured[$name] = $cs;
+    });
+}
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+$uuid = $room->getValue('room_uuid');
+$room->delete();
+check('a deletion dispatches the delete stages in the nesting order',
+    $log === array('entity_deleting', 'room_deleting', 'room_deleted', 'entity_deleted'), implode(' ', $log));
+$cs = $captured['entity_deleted'];
+check('the post-delete change set survives clear()', $cs->isDelete() && $cs->getUuid() === $uuid);
+check('it carries the deleted record in its snapshot', ($cs->getSnapshot()['room_name'] ?? null) === 'Blue Room',
+    var_export($cs->getSnapshot()['room_name'] ?? null, true));
+check('and reports the columns as old value to null', $cs->getOldValue('room_name') === 'Blue Room' && $cs->getNewValue('room_name') === null);
+check('the object itself was cleared', $room->getValue('room_name') === '');
+check('the row is gone', count($db->fetchAll(TABLE_PREFIX . '_rooms')) === 0);
+
+// ---------------------------------------------------------------- redaction
+Hooks::reset();
+$captured = null;
+Hooks::addAction('oidc_client_created', function (EntityChangeSet $cs) use (&$captured) { $captured = $cs; });
+$db = newDatabase();
+$client = new TestClient($db);
+$client->setValue('ocl_name', 'My App');
+$client->setValue('ocl_secret', 'hunter2');
+$client->save();
+check('a redacted column is reported as changed', $captured->hasChanged('ocl_secret'));
+check('but its value is withheld', $captured->getNewValue('ocl_secret') === EntityChangeSet::REDACTED_VALUE,
+    var_export($captured->getNewValue('ocl_secret'), true));
+check('and it is marked redacted', $captured->getChange('ocl_secret')->isRedacted());
+check('an ordinary column is untouched', $captured->getNewValue('ocl_name') === 'My App');
+check('the secret was still written to the database', $db->fetchAll(TABLE_PREFIX . '_clients')[0]['ocl_secret'] === 'hunter2');
+
+$captured = null;
+Hooks::reset();
+Hooks::addAction('oidc_client_deleted', function (EntityChangeSet $cs) use (&$captured) { $captured = $cs; });
+$client->delete();
+check('a redacted column is left out of the snapshot', !array_key_exists('ocl_secret', $captured->getSnapshot()));
+
+// ---------------------------------------------------------------- the opt-out
+Hooks::reset();
+$called = 0;
+foreach (array('entity_created', 'entity_updated', 'entity_deleted', 'ses_created') as $name) {
+    Hooks::addAction($name, function () use (&$called) { $called++; });
+}
+$db = newDatabase();
+$session = new TestSession($db);
+$session->setValue('ses_name', 'a session');
+$session->save();
+$session->delete();
+check('an entity without a hook ID dispatches nothing, the generic hooks included', $called === 0, $called . ' calls');
+check('it is still written normally', count($db->statements) > 0);
+
+// ---------------------------------------------------------------- selectivity
+Hooks::reset();
+$roomEvents = 0;
+$clientEvents = 0;
+Hooks::addAction('room_updated', function () use (&$roomEvents) { $roomEvents++; });
+Hooks::addAction('oidc_client_updated', function () use (&$clientEvents) { $clientEvents++; });
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'One');
+$room->save();
+$room->setValue('room_name', 'Two');
+$room->save();
+check('a listener on oidc_client_updated is not called for a room update', $clientEvents === 0 && $roomEvents === 1,
+    "room=$roomEvents client=$clientEvents");
+
+// ---------------------------------------------------------------- global suppression
+Hooks::reset();
+$called = 0;
+Hooks::addAction('entity_created', function () use (&$called) { $called++; });
+Entity::setHooksEnabled(false);
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'During the update');
+$room->save();
+Entity::setHooksEnabled(true);
+check('setHooksEnabled(false) silences the lifecycle', $called === 0, $called . ' calls');
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/entity-lifecycle.php
+++ b/tests/hooks/entity-lifecycle.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * The persistence lifecycle of Entity, executed against SQLite.
+ */
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/entities.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Hooks\ValueObject\EntityFieldChange;
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Tests\Hooks\TestClient;
+use Admidio\Tests\Hooks\TestRoom;
+use Admidio\Tests\Hooks\TestSession;
+
+function newDatabase(): FakeDatabase
+{
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_rooms', columnDefinition('room'));
+    $db->createTable(TABLE_PREFIX . '_clients', columnDefinition('ocl'));
+    $db->createTable(TABLE_PREFIX . '_sessions', columnDefinition('ses'));
+    return $db;
+}
+
+/** Record every dispatch of the lifecycle, so the order can be asserted. */
+function recordAll(array &$log): void
+{
+    foreach (array('entity', 'room', 'oidc_client', 'ses') as $prefix) {
+        foreach (array('creating', 'created', 'updating', 'updated', 'deleting', 'deleted',
+                       'create_failed', 'update_failed', 'delete_failed') as $stage) {
+            $name = $prefix . '_' . $stage;
+            Hooks::addAction($name, function (EntityChangeSet $cs) use (&$log, $name) {
+                $log[] = $name;
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------- create
+Hooks::reset();
+$log = array();
+recordAll($log);
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+check('a creation dispatches generic-before then specific-before, specific-after then generic-after',
+    $log === array('entity_creating', 'room_creating', 'room_created', 'entity_created'),
+    implode(' ', $log));
+
+// ---------------------------------------------------------------- create change set
+Hooks::reset();
+$captured = array();
+Hooks::addAction('room_creating', function (EntityChangeSet $cs) use (&$captured) { $captured['pre'] = $cs; });
+Hooks::addAction('room_created', function (EntityChangeSet $cs) use (&$captured) { $captured['post'] = $cs; });
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+$pre = $captured['pre'];
+$post = $captured['post'];
+check('the create change set says create', $pre->isCreate() && $pre->getOperation() === EntityChangeSet::OPERATION_CREATE);
+check('it carries the hook ID and the table', $pre->getHookId() === 'room' && $pre->getTableName() === TABLE_PREFIX . '_rooms');
+check('the old value of a creation is null', $pre->getOldValue('room_name') === null);
+check('the new value is what was set', $pre->getNewValue('room_name') === 'Blue Room', var_export($pre->getNewValue('room_name'), true));
+check('the snapshot of a creation is empty', $pre->getSnapshot() === array());
+check('the pre-action does not know the ID yet', $pre->getId() === null, var_export($pre->getId(), true));
+check('the post-action knows the ID', (int)$post->getId() === 1, var_export($post->getId(), true));
+check('both stages share one operation ID', $pre->getOperationId() === $post->getOperationId());
+check('the UUID is reported', $post->getUuid() !== null && strlen($post->getUuid()) === 36);
+check('the record really was written', count($db->fetchAll(TABLE_PREFIX . '_rooms')) === 1);
+
+// ---------------------------------------------------------------- update
+Hooks::reset();
+$log = array();
+recordAll($log);
+$captured = array();
+Hooks::addAction('room_updated', function (EntityChangeSet $cs) use (&$captured) { $captured['cs'] = $cs; });
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+$log = array();
+$room->setValue('room_name', 'Green Room');
+$room->save();
+check('an update dispatches the update stages', $log === array('entity_updating', 'room_updating', 'room_updated', 'entity_updated'), implode(' ', $log));
+$cs = $captured['cs'];
+check('the update reports the persisted old value', $cs->getOldValue('room_name') === 'Blue Room', var_export($cs->getOldValue('room_name'), true));
+check('and the new one', $cs->getNewValue('room_name') === 'Green Room');
+check('the snapshot holds the record as the database had it', ($cs->getSnapshot()['room_name'] ?? null) === 'Blue Room', var_export($cs->getSnapshot()['room_name'] ?? null, true));
+
+// ---------------------------------------------------------------- A -> B -> C and A -> B -> A
+Hooks::reset();
+$captured = array();
+Hooks::addAction('room_updated', function (EntityChangeSet $cs) use (&$captured) { $captured[] = $cs; });
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'A');
+$room->save();
+$room->setValue('room_name', 'B');
+$room->setValue('room_name', 'C');
+$room->save();
+check('A -> B -> C reports A -> C', count($captured) === 1
+    && $captured[0]->getOldValue('room_name') === 'A' && $captured[0]->getNewValue('room_name') === 'C',
+    count($captured) . ' events');
+
+$captured = array();
+$room->setValue('room_name', 'D');
+$room->setValue('room_name', 'C');
+$saved = $room->save();
+check('A -> B -> A dispatches nothing and saves nothing', $captured === array() && $saved === false);
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/entity-transactions.php
+++ b/tests/hooks/entity-transactions.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * The committed hooks: they fire at the outermost commit, they describe what the transaction did as
+ * a whole, and they do not fire at all when the transaction is lost.
+ */
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/entities.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\Service\EntityHookQueue;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Tests\Hooks\TestRoom;
+
+function newDatabase(): FakeDatabase
+{
+    Hooks::reset();
+    EntityHookQueue::reset();
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_rooms', columnDefinition('room'));
+    $db->createTable(TABLE_PREFIX . '_clients', columnDefinition('ocl'));
+    $db->createTable(TABLE_PREFIX . '_sessions', columnDefinition('ses'));
+    return $db;
+}
+
+/** Collect every committed and failed event of a room. */
+function watch(array &$events): void
+{
+    foreach (array('created', 'updated', 'deleted', 'create_failed', 'update_failed', 'delete_failed') as $stage) {
+        Hooks::addAction('room_' . $stage, function (EntityChangeSet $cs) use (&$events, $stage) {
+            $events[] = array('stage' => $stage, 'changeSet' => $cs);
+        });
+    }
+}
+
+function stages(array $events): string
+{
+    return implode(' ', array_column($events, 'stage'));
+}
+
+// ---------------------------------------------------------------- nothing fires before the commit
+$db = newDatabase();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+check('nothing is dispatched while the transaction is open', $events === array(), stages($events));
+check('but the operation is waiting', EntityHookQueue::countPending() === 1);
+$db->endTransaction();
+check('the commit dispatches it', stages($events) === 'created', stages($events));
+
+// ---------------------------------------------------------------- nested transactions
+$db = newDatabase();
+$events = array();
+watch($events);
+$db->startTransaction();
+$db->startTransaction();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+$db->endTransaction();
+check('the inner end does not dispatch', $events === array(), stages($events));
+$db->endTransaction();
+check('the outermost end does', stages($events) === 'created', stages($events));
+
+// ---------------------------------------------------------------- two saves become one event
+$db = newDatabase();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+$room->setValue('room_name', 'Green Room');
+$room->save();
+$db->endTransaction();
+check('a create and an update in one transaction are one creation', stages($events) === 'created', stages($events));
+check('with the final values', $events[0]['changeSet']->getNewValue('room_name') === 'Green Room',
+    var_export($events[0]['changeSet']->getNewValue('room_name'), true));
+
+// ---------------------------------------------------------------- two updates become one
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'A');
+$room->save();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room->setValue('room_name', 'B');
+$room->save();
+$room->setValue('room_name', 'C');
+$room->save();
+$db->endTransaction();
+check('two updates in one transaction are one update', stages($events) === 'updated', stages($events));
+check('from the value before the transaction to the value after it',
+    $events[0]['changeSet']->getOldValue('room_name') === 'A'
+    && $events[0]['changeSet']->getNewValue('room_name') === 'C',
+    var_export($events[0]['changeSet']->getOldValue('room_name'), true) . ' -> '
+    . var_export($events[0]['changeSet']->getNewValue('room_name'), true));
+
+// ---------------------------------------------------------------- a round trip is no change
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'A');
+$room->save();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room->setValue('room_name', 'B');
+$room->save();
+$room->setValue('room_name', 'A');
+$room->save();
+$db->endTransaction();
+check('a value that ends where it started dispatches nothing', $events === array(), stages($events));
+
+// ---------------------------------------------------------------- update then delete
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'A');
+$room->save();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room->setValue('room_name', 'B');
+$room->save();
+$room->delete();
+$db->endTransaction();
+check('an update and a deletion are one deletion', stages($events) === 'deleted', stages($events));
+check('measured against the state at the start of the transaction',
+    $events[0]['changeSet']->getOldValue('room_name') === 'A',
+    var_export($events[0]['changeSet']->getOldValue('room_name'), true));
+
+// ---------------------------------------------------------------- create then delete
+$db = newDatabase();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Ephemeral');
+$room->save();
+$room->delete();
+$db->endTransaction();
+check('a record created and deleted in one transaction never happened', $events === array(), stages($events));
+
+// ---------------------------------------------------------------- two objects, one row
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'A');
+$room->save();
+$id = (int)$room->getValue('room_id');
+$events = array();
+watch($events);
+$db->startTransaction();
+$first = new TestRoom($db, $id);
+$first->setValue('room_name', 'B');
+$first->save();
+$second = new TestRoom($db, $id);
+$second->setValue('room_name', 'C');
+$second->save();
+$db->endTransaction();
+check('two objects of one row are one record', stages($events) === 'updated', stages($events));
+check('and the merge spans both of them', $events[0]['changeSet']->getOldValue('room_name') === 'A'
+    && $events[0]['changeSet']->getNewValue('room_name') === 'C');
+
+// ---------------------------------------------------------------- rollback
+$db = newDatabase();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Never committed');
+$room->save();
+$db->rollback();
+check('a rollback dispatches the failure and not the success', stages($events) === 'create_failed', stages($events));
+check('and nothing is left waiting', EntityHookQueue::countPending() === 0);
+check('and the row really is gone', count($db->fetchAll(TABLE_PREFIX . '_rooms')) === 0);
+
+// ---------------------------------------------------------------- a lost transaction
+$db = newDatabase();
+$events = array();
+watch($events);
+$db->startTransaction();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Abandoned');
+$room->save();
+$db->runAfterRollbackCallbacks();
+check('an abandoned transaction dispatches the failure', stages($events) === 'create_failed', stages($events));
+
+// ---------------------------------------------------------------- without a transaction
+$db = newDatabase();
+$events = array();
+watch($events);
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Immediate');
+$room->save();
+check('without a transaction the statement is the commit', stages($events) === 'created', stages($events));
+check('and nothing is left waiting', EntityHookQueue::countPending() === 0);
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/entity-value-filter.php
+++ b/tests/hooks/entity-value-filter.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * The entity_value and <entity>_value filters, and the pre-action veto.
+ */
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/entities.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Tests\Hooks\TestClient;
+use Admidio\Tests\Hooks\TestRoom;
+use Admidio\Tests\Hooks\TestSession;
+
+function newDatabase(): FakeDatabase
+{
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_rooms', columnDefinition('room'));
+    $db->createTable(TABLE_PREFIX . '_clients', columnDefinition('ocl'));
+    $db->createTable(TABLE_PREFIX . '_sessions', columnDefinition('ses'));
+    return $db;
+}
+
+// ---------------------------------------------------------------- transform
+Hooks::reset();
+Hooks::addFilter('entity_value', function ($value, $entity, $column) {
+    return ($column === 'room_name') ? strtoupper($value) : $value;
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'blue room');
+check('entity_value transforms the value', $room->getValue('room_name') === 'BLUE ROOM', $room->getValue('room_name'));
+$room->save();
+check('and the transformed value is what is stored', $db->fetchAll(TABLE_PREFIX . '_rooms')[0]['room_name'] === 'BLUE ROOM');
+
+// ---------------------------------------------------------------- order and arguments
+Hooks::reset();
+$seen = array();
+Hooks::addFilter('entity_value', function ($value, $entity, $column, $oldValue) use (&$seen) {
+    $seen[] = 'generic:' . $column . ':' . var_export($oldValue, true);
+    return $value . '|g';
+});
+Hooks::addFilter('room_value', function ($value, $entity, $column, $oldValue) use (&$seen) {
+    $seen[] = 'specific:' . $column;
+    return $value . '|s';
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'x');
+check('the generic filter runs before the entity-specific one', $room->getValue('room_name') === 'x|g|s', $room->getValue('room_name'));
+check('the filter receives the column and the old value', $seen[0] === "generic:room_name:NULL", $seen[0]);
+
+// ---------------------------------------------------------------- the bookkeeping is not filtered
+Hooks::reset();
+$columns = array();
+Hooks::addFilter('entity_value', function ($value, $entity, $column) use (&$columns) {
+    $columns[] = $column;
+    return $value;
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'a room');
+$room->save();
+$GLOBALS['gCurrentUserId'] = 42;
+$room->setValue('room_name', 'another room');
+$room->save();
+$GLOBALS['gCurrentUserId'] = 0;
+check('the key, the UUID and the creator and editor columns are not filtered',
+    $columns === array('room_name', 'room_name'), implode(',', $columns));
+
+// ---------------------------------------------------------------- the core checks still run
+Hooks::reset();
+Hooks::addFilter('entity_value', function ($value) {
+    return '<b>' . $value . '</b><script>alert(1)</script>';
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'plain');
+check('the sanitizing of setValue runs on the result of the filter',
+    $room->getValue('room_name') === 'plainalert(1)', var_export($room->getValue('room_name'), true));
+
+// ---------------------------------------------------------------- an entity without a hook ID
+Hooks::reset();
+$called = 0;
+Hooks::addFilter('entity_value', function ($value) use (&$called) { $called++; return $value; });
+$db = newDatabase();
+$session = new TestSession($db);
+$session->setValue('ses_name', 'a session');
+check('an entity without a hook ID is not filtered', $called === 0, $called . ' calls');
+
+// ---------------------------------------------------------------- rejecting a value
+Hooks::reset();
+Hooks::addFilter('room_value', function ($value, $entity, $column) {
+    if ($column === 'room_name' && !str_starts_with($value, 'Room ')) {
+        throw new RuntimeException('SYS_FIELD_INVALID_INPUT');
+    }
+    return $value;
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$thrown = false;
+try {
+    $room->setValue('room_name', 'Lounge');
+} catch (RuntimeException $e) {
+    $thrown = true;
+}
+check('a filter rejects a value by throwing', $thrown);
+
+// ---------------------------------------------------------------- vetoing an operation
+Hooks::reset();
+Hooks::addAction('room_creating', function (EntityChangeSet $cs) {
+    throw new RuntimeException('not allowed');
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Lounge');
+$thrown = false;
+try {
+    $room->save();
+} catch (RuntimeException $e) {
+    $thrown = true;
+}
+check('a pre-action vetoes the operation by throwing', $thrown);
+check('and nothing was written', count($db->fetchAll(TABLE_PREFIX . '_rooms')) === 0);
+
+// a rejected save must leave the object saveable, so the caller can react and save again
+Hooks::reset();
+check('a vetoed save leaves the object unchanged', $room->hasColumnsValueChanged());
+$saved = $room->save();
+check('so the very same object can be saved afterwards', $saved === true
+    && count($db->fetchAll(TABLE_PREFIX . '_rooms')) === 1);
+check('and it kept its value', $db->fetchAll(TABLE_PREFIX . '_rooms')[0]['room_name'] === 'Lounge',
+    var_export($db->fetchAll(TABLE_PREFIX . '_rooms')[0]['room_name'] ?? null, true));
+
+// ---------------------------------------------------------------- failure actions
+Hooks::reset();
+$log = array();
+foreach (array('room_create_failed', 'entity_create_failed') as $name) {
+    Hooks::addAction($name, function (EntityChangeSet $cs) use (&$log, $name) { $log[] = $name; });
+}
+Hooks::addAction('room_creating', function (EntityChangeSet $cs) { /* listener exists, so a change set is built */ });
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Lounge');
+$db->breakNextStatement = true;
+$thrown = null;
+try {
+    $room->save();
+} catch (Throwable $e) {
+    $thrown = $e;
+}
+check('a failing statement dispatches the failure stages, specific first',
+    $log === array('room_create_failed', 'entity_create_failed'), implode(' ', $log));
+check('and the original failure is what is reported', $thrown !== null && str_contains($thrown->getMessage(), 'no such table'),
+    $thrown === null ? 'nothing thrown' : $thrown->getMessage());
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/form-built.php
+++ b/tests/hooks/form-built.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * form_built: the point at which a form is finished, and the element API that makes the hook useful.
+ *
+ * The real `FormPresenter` is executed here - it needs nothing but the autoloader - so what is checked
+ * is the actual form, the actual dispatch and the actual validate().
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\UI\Presenter\FormPresenter;
+
+function aForm(string $id = 'adm_probe_form'): FormPresenter
+{
+    Hooks::reset();
+    $form = new FormPresenter($id, 'form.tpl', 'index.php');
+    $form->addInput('first_name', 'First name', '');
+    $form->addInput('last_name', 'Last name', '');
+
+    return $form;
+}
+
+function elementIds(FormPresenter $form): string
+{
+    return implode(',', array_keys($form->getElements()));
+}
+
+// ------------------------------------------------------------------------- the hook fires exactly once
+
+$form = aForm();
+$dispatched = array();
+Hooks::addAction('form_built', function (FormPresenter $built) use (&$dispatched) {
+    $dispatched[] = $built->getId();
+});
+
+check('nothing is dispatched while the form is being built', $dispatched === array());
+
+$form->finalize();
+check('finalize() dispatches form_built with the form', $dispatched === array('adm_probe_form'), implode(',', $dispatched));
+
+$form->finalize();
+$form->getElements();
+$form->getAttributes();
+check('and never again, however often the form is read', count($dispatched) === 1, (string)count($dispatched));
+
+// ------------------------------------------------------------- every way of reading a finished form
+
+foreach (array('getElements', 'getAttributes') as $reader) {
+    $form = aForm();
+    $dispatched = array();
+    Hooks::addAction('form_built', function (FormPresenter $built) use (&$dispatched) {
+        $dispatched[] = $built->getId();
+    });
+    $form->$reader();
+    check($reader . '() finalizes the form', count($dispatched) === 1, (string)count($dispatched));
+}
+
+// ---------------------------------------------------------- a callback can change what is rendered
+
+$form = aForm();
+Hooks::addAction('form_built', function (FormPresenter $built) {
+    $built->removeElement('last_name');
+    $built->insertElement('nickname', array('id' => 'nickname', 'type' => 'text', 'label' => 'Nickname'), 'first_name');
+    $built->replaceElement('first_name', array('id' => 'first_name', 'type' => 'text', 'label' => 'Given name'));
+});
+
+check(
+    'a callback can remove, insert and replace elements',
+    elementIds($form) === 'adm_csrf_token,nickname,first_name',
+    elementIds($form)
+);
+check(
+    'and the replacement is what the form holds',
+    $form->getElement('first_name')['label'] === 'Given name',
+    (string)$form->getElement('first_name')['label']
+);
+
+// ------------------------------------------------------------ and the change reaches the validation
+
+$form = aForm();
+Hooks::addAction('form_built', function (FormPresenter $built) {
+    $built->removeElement('last_name');
+});
+$form->finalize();
+
+$rejected = false;
+try {
+    $form->validate(array('adm_csrf_token' => $form->getCsrfToken(), 'first_name' => 'John', 'last_name' => 'Doe'));
+} catch (\Throwable $exception) {
+    $rejected = str_contains($exception->getMessage(), 'Invalid payload');
+}
+check('a removed element is not accepted by validate() any more', $rejected);
+
+$accepted = $form->validate(array('adm_csrf_token' => $form->getCsrfToken(), 'first_name' => 'John'));
+check('what is left still validates', array_key_exists('first_name', $accepted), implode(',', array_keys($accepted)));
+
+// ----------------------------------------------- reading one element does not finish the form early
+
+$form = aForm();
+$dispatched = 0;
+Hooks::addAction('form_built', function () use (&$dispatched) {
+    $dispatched++;
+});
+
+check('hasElement() does not finalize', $form->hasElement('first_name') && $dispatched === 0);
+check('getElement() does not finalize', $form->getElement('first_name') !== null && $dispatched === 0);
+
+// InventoryItemPresenter does exactly this: look at an element, then add more
+$form->addInput('city', 'City', '');
+check('so a presenter can keep building afterwards', $dispatched === 0);
+check('and the later element is part of the form', str_contains(elementIds($form), 'city'), elementIds($form));
+check('which is only now finished', $dispatched === 1, (string)$dispatched);
+
+// --------------------------------------------------- the flag survives the trip through the session
+
+$form = aForm();
+$form->finalize();
+$restored = unserialize(serialize($form));
+$dispatched = 0;
+Hooks::addAction('form_built', function () use (&$dispatched) {
+    $dispatched++;
+});
+$restored->getElements();
+check('a form that comes back from the session is not built a second time', $dispatched === 0, (string)$dispatched);
+
+$form = aForm();                       // aForm() resets the registry, so listen again afterwards
+$dispatched = 0;
+Hooks::addAction('form_built', function () use (&$dispatched) {
+    $dispatched++;
+});
+$restored = unserialize(serialize($form));
+$restored->getElements();
+check('but one that was stored unfinished still gets its chance', $dispatched === 1, (string)$dispatched);
+
+exit(testSummary());

--- a/tests/hooks/form-built.php
+++ b/tests/hooks/form-built.php
@@ -132,4 +132,134 @@ $restored = unserialize(serialize($form));
 $restored->getElements();
 check('but one that was stored unfinished still gets its chance', $dispatched === 1, (string)$dispatched);
 
+// ------------------------------------------------------------------ form_select_options
+
+/** A form with the three element types whose entries validate() enforces. */
+function aFormWithChoices(): FormPresenter
+{
+    Hooks::reset();
+    $form = new FormPresenter('adm_choices_form', 'form.tpl', 'index.php');
+    $form->addSelectBox('role', 'Role', array(1 => 'Choir', 2 => 'Board', 3 => 'Youth'));
+    $form->addRadioButton('gender', 'Gender', array('f' => 'female', 'm' => 'male'));
+    $form->addInput('note', 'Note', '');
+
+    return $form;
+}
+
+function offeredIds(FormPresenter $form, string $elementId): string
+{
+    // getElements() finishes the form, getElement() deliberately does not
+    $element = $form->getElements()[$elementId];
+    $values = $element['values'];
+    // a select carries a list of id/value pairs, a radio an array of value to label
+    $ids = ($element['type'] === 'select') ? array_column($values, 'id') : array_keys($values);
+
+    return implode(',', $ids);
+}
+
+$form = aFormWithChoices();
+check(
+    'without a filter the entries are the ones the form was given',
+    offeredIds($form, 'role') === ',1,2,3',
+    offeredIds($form, 'role')
+);
+
+// --------------------------------------------------------------------- a filter can take one away
+
+$form = aFormWithChoices();
+Hooks::addFilter('form_select_options', function (array $values, string $elementId, string $type) {
+    if ($elementId !== 'role') {
+        return $values;
+    }
+
+    return array_values(array_filter($values, function (array $entry) {
+        return (string)$entry['id'] !== '2';
+    }));
+});
+
+check('a filter can remove an entry of a select', offeredIds($form, 'role') === ',1,3', offeredIds($form, 'role'));
+check('and leaves the other elements alone', offeredIds($form, 'gender') === 'f,m', offeredIds($form, 'gender'));
+
+// ------------------------------------------------------------- and the removal is enforced on POST
+
+$accepted = $form->validate(array('adm_csrf_token' => $form->getCsrfToken(), 'role' => '1', 'gender' => 'f', 'note' => ''));
+check('an entry that is still offered is accepted', ($accepted['role'] ?? null) == 1, var_export($accepted['role'] ?? null, true));
+
+$rejected = false;
+try {
+    $form->validate(array('adm_csrf_token' => $form->getCsrfToken(), 'role' => '2', 'gender' => 'f', 'note' => ''));
+} catch (\Throwable $exception) {
+    $rejected = true;
+}
+check('the entry the filter removed is refused, not only hidden', $rejected);
+
+// --------------------------------------------------------------------------------- a radio group
+
+$form = aFormWithChoices();
+Hooks::addFilter('form_select_options', function (array $values, string $elementId) {
+    if ($elementId !== 'gender') {
+        return $values;
+    }
+    unset($values['m']);
+
+    return $values;
+});
+check('a radio group keeps its own shape', offeredIds($form, 'gender') === 'f', offeredIds($form, 'gender'));
+
+$rejected = false;
+try {
+    $form->validate(array('adm_csrf_token' => $form->getCsrfToken(), 'role' => '1', 'gender' => 'm', 'note' => ''));
+} catch (\Throwable $exception) {
+    $rejected = true;
+}
+check('and its removed entry is refused too', $rejected);
+
+// ----------------------------------------------------------------- only the enforced types are asked
+
+$form = aFormWithChoices();
+$asked = array();
+Hooks::addFilter('form_select_options', function (array $values, string $elementId, string $type) use (&$asked) {
+    $asked[] = $elementId . ':' . $type;
+    return $values;
+});
+$form->finalize();
+check(
+    'the filter is asked for the selects and radios only, never for a text field',
+    $asked === array('role:select', 'gender:radio'),
+    implode(' ', $asked)
+);
+
+// ------------------------------------------------------------------ it runs after form_built
+
+$form = aFormWithChoices();
+$order = array();
+Hooks::addAction('form_built', function (FormPresenter $built) use (&$order) {
+    $order[] = 'built';
+    $built->addSelectBox('room', 'Room', array(7 => 'Hall'));
+});
+Hooks::addFilter('form_select_options', function (array $values, string $elementId) use (&$order) {
+    $order[] = 'options:' . $elementId;
+    return $values;
+});
+$form->finalize();
+check(
+    'a select that form_built added is filtered as well',
+    $order === array('built', 'options:role', 'options:gender', 'options:room'),
+    implode(' ', $order)
+);
+
+// -------------------------------------------------------------------- the answer has to be an array
+
+$form = aFormWithChoices();
+Hooks::addFilter('form_select_options', function () {
+    return 'not an array';
+});
+$refused = false;
+try {
+    $form->finalize();
+} catch (\Throwable $exception) {
+    $refused = str_contains($exception->getMessage(), 'returned string instead of array');
+}
+check('a filter that does not answer with an array is refused', $refused);
+
 exit(testSummary());

--- a/tests/hooks/hooks-behaviour.php
+++ b/tests/hooks/hooks-behaviour.php
@@ -1,0 +1,118 @@
+<?php
+require __DIR__ . '/../../src/Hooks/Hooks.php';
+use Admidio\Hooks\Hooks;
+
+$fails = 0;
+function check(string $name, bool $ok, string $detail = ''): void {
+    global $fails; if (!$ok) { $fails++; }
+    printf("%-6s %s%s\n", $ok ? '  ok' : 'FAIL', $name, $detail !== '' ? '  -> ' . $detail : '');
+}
+function calls(): array { return $GLOBALS['c'] ?? []; }
+function reset_calls(): void { $GLOBALS['c'] = []; }
+
+function probeListener(...$a) { $GLOBALS['c'][] = 'probeListener'; }
+class ProbeC { public static function m(...$a) { $GLOBALS['c'][] = 'ProbeC::m'; } }
+
+// 1 removal by function name
+reset_calls();
+Hooks::addAction('t1', 'probeListener');
+$r = Hooks::removeAction('t1', 'probeListener');
+Hooks::doAction('t1');
+check('removeAction by function name', $r === true && calls() === []);
+
+// 1b removal by explicit id
+reset_calls();
+Hooks::addAction('t1b', 'probeListener', 10, null, 'probeListener');
+$r = Hooks::removeAction('t1b', 'probeListener');
+Hooks::doAction('t1b');
+check('removeAction by an explicit id equal to the function name', $r === true && calls() === []);
+
+// 2 removal by [Class,method] and by its string form
+reset_calls();
+Hooks::addAction('t2', ['ProbeC', 'm']);
+$r = Hooks::removeAction('t2', 'ProbeC::m');
+Hooks::doAction('t2');
+check('removeAction by the string form of a static method', $r === true && calls() === []);
+
+// 3 explicit id replaces across priorities
+reset_calls();
+Hooks::addAction('t3', function () { $GLOBALS['c'][] = 'A'; }, 10, null, 'myid');
+Hooks::addAction('t3', function () { $GLOBALS['c'][] = 'B'; }, 5, null, 'myid');
+Hooks::doAction('t3');
+check('re-registering an explicit id replaces it across priorities', calls() === ['B'], implode(',', calls()));
+
+// 4 filter veto
+Hooks::addFilter('t4', function ($v) { throw new RuntimeException('veto'); });
+$thrown = false; $out = null;
+try { $out = Hooks::applyFilters('t4', 'orig'); } catch (Throwable $e) { $thrown = true; }
+check('a filter can veto by throwing', $thrown, var_export($out, true));
+
+// 5 action veto
+Hooks::addAction('t5', function () { throw new RuntimeException('veto'); });
+$thrown = false;
+try { Hooks::doAction('t5'); } catch (Throwable $e) { $thrown = true; }
+check('an action can veto by throwing', $thrown);
+
+// 5b failure dispatch does not propagate and still runs the rest
+reset_calls();
+Hooks::addAction('t5b', function () { throw new RuntimeException('boom'); }, 5);
+Hooks::addAction('t5b', function () { $GLOBALS['c'][] = 'cleanup'; }, 10);
+$thrown = false;
+try { Hooks::doActionCatchErrors('t5b'); } catch (Throwable $e) { $thrown = true; }
+check('doActionCatchErrors swallows and continues', !$thrown && calls() === ['cleanup'], implode(',', calls()));
+
+// 6 order
+reset_calls();
+Hooks::addAction('t7', function () { $GLOBALS['c'][] = '1'; }, 10);
+Hooks::addAction('t7', function () { $GLOBALS['c'][] = '2'; }, 10);
+Hooks::addAction('t7', function () { $GLOBALS['c'][] = '0'; }, 1);
+Hooks::doAction('t7');
+check('priority order, stable within a priority', calls() === ['0', '1', '2'], implode(',', calls()));
+
+// 7 acceptedArgs
+Hooks::addFilter('t8', function ($v) { return $v . '!'; }, 10, 1);
+check('acceptedArgs=1 truncates the extra arguments', Hooks::applyFilters('t8', 'a', 'x', 'y') === 'a!');
+$thrown = false;
+try { Hooks::addFilter('t8z', fn($v) => $v, 10, 0); } catch (InvalidArgumentException $e) { $thrown = true; }
+check('acceptedArgs=0 on a filter is rejected', $thrown);
+
+// 8 snapshot
+reset_calls();
+Hooks::addAction('t9', function () {
+    $GLOBALS['c'][] = 'first';
+    Hooks::addAction('t9', function () { $GLOBALS['c'][] = 'late'; }, 20);
+}, 10);
+Hooks::doAction('t9');
+check('dispatch uses a snapshot', calls() === ['first'], implode(',', calls()));
+reset_calls();
+Hooks::doAction('t9');
+check('the added listener runs on the next dispatch', calls() === ['first', 'late'], implode(',', calls()));
+
+// 9 resolver
+Hooks::addResolver('r1', fn() => null, 5);
+Hooks::addResolver('r1', fn() => 'answer', 10);
+Hooks::addResolver('r1', fn() => 'never', 20);
+check('resolver returns the first non-null answer', Hooks::resolve('r1', 'default') === 'answer');
+check('resolver falls back to the default', Hooks::resolve('r2', 'default') === 'default');
+foreach ([false, 0, '', []] as $falsy) {
+    Hooks::reset('r3');
+    Hooks::addResolver('r3', fn() => $falsy, 5);
+    Hooks::addResolver('r3', fn() => 'later', 10);
+    check('resolver accepts ' . var_export($falsy, true) . ' as an answer', Hooks::resolve('r3', 'default') === $falsy);
+}
+Hooks::reset('r4');
+Hooks::addResolver('r4', fn($a, $b) => $a . $b, 10, 2);
+check('resolver receives the dispatch arguments', Hooks::resolve('r4', 'default', 'x', 'y', 'z') === 'xy');
+
+// 10 has*/reset
+check('hasAction is false for an unknown hook', Hooks::hasAction('nope') === false);
+Hooks::addAction('t10', 'probeListener');
+check('hasAction is true after a registration', Hooks::hasAction('t10') === true);
+Hooks::removeAction('t10', 'probeListener');
+check('hasAction is false after the last removal', Hooks::hasAction('t10') === false);
+Hooks::addFilter('t11', fn($v) => $v);
+Hooks::reset();
+check('reset clears the whole registry', Hooks::hasFilter('t11') === false && Hooks::hasAction('t3') === false);
+
+echo $fails === 0 ? "\nall checks passed\n" : "\n$fails checks failed\n";
+exit($fails === 0 ? 0 : 1);

--- a/tests/hooks/list-hooks.php
+++ b/tests/hooks/list-hooks.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * The generic list hooks - list_columns, list_data, list_rendered_data, list_row_actions - proven on
+ * contacts.php/contacts_data.php, the first module to carry them (§2.7 of HOOKS_PLAN.md).
+ *
+ * Neither file can run here - both need a full database, session and settings stack - so this
+ * reproduces the exact dispatch lines verbatim rather than executing the module: the guard in
+ * contacts.php that refuses a list_columns filter which changes the column count, and the three
+ * dispatch calls in contacts_data.php's row loop. What is not exercised is the surrounding SQL and
+ * permission logic, which this filter layer does not touch.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+
+/**
+ * contacts.php's own guard, copied verbatim: list_columns may relabel a column but not add or
+ * remove one, because contacts_data.php still builds every row by position.
+ */
+function filterContactsColumnHeading(array $columnHeading): array
+{
+    $filtered = Hooks::applyTypedFilters('list_columns', $columnHeading, 'contacts');
+    if (count($filtered) !== count($columnHeading)) {
+        throw new \UnexpectedValueException('A list_columns filter for "contacts" changed the number of columns.');
+    }
+    return $filtered;
+}
+
+// ------------------------------------------------------------------- list_columns may only relabel
+Hooks::reset();
+Hooks::addFilter('list_columns', function (array $columns) {
+    $columns[1] = 'Renamed';
+    return $columns;
+});
+$result = filterContactsColumnHeading(array('No', 'Name', 'Email'));
+check('list_columns can relabel a column', $result === array('No', 'Renamed', 'Email'), implode(',', $result));
+
+Hooks::reset();
+Hooks::addFilter('list_columns', function (array $columns) {
+    $columns[] = 'Extra';
+    return $columns;
+});
+$threw = false;
+try {
+    filterContactsColumnHeading(array('No', 'Name', 'Email'));
+} catch (\UnexpectedValueException $exception) {
+    $threw = true;
+}
+check('list_columns cannot add a column - contacts_data.php builds rows by position', $threw);
+
+// -------------------------------------------------------------------------------------- list_data
+Hooks::reset();
+Hooks::addFilter('list_data', function (array $row, string $listId) {
+    $row['login_name'] = strtoupper($row['login_name']);
+    return $row;
+});
+$row = Hooks::applyTypedFilters('list_data', array('usr_uuid' => 'u-1', 'login_name' => 'jdoe'), 'contacts');
+check('list_data filters the raw row before anything is formatted from it', $row['login_name'] === 'JDOE', $row['login_name']);
+
+// -------------------------------------------------------------------------------- list_row_actions
+Hooks::reset();
+Hooks::addFilter('list_row_actions', function (string $actions, string $listId, array $row) {
+    return $actions . '<a href="#extra">Extra for ' . $row['usr_uuid'] . '</a>';
+});
+$actions = Hooks::applyTypedFilters('list_row_actions', '<a href="#edit">Edit</a>', 'contacts', array('usr_uuid' => 'u-1'));
+check('list_row_actions can add an action icon to the row', str_contains($actions, 'Extra for u-1'), $actions);
+
+// ------------------------------------------------------------------------------ list_rendered_data
+Hooks::reset();
+Hooks::addFilter('list_rendered_data', function (array $columnValues, string $listId, array $row) {
+    $columnValues['0'] = '<b>' . $columnValues['0'] . '</b>';
+    return $columnValues;
+});
+$columnValues = array('DT_RowId' => 'row_members_u-1', '0' => '1', '1' => 'Doe, Jane');
+$columnValues = Hooks::applyTypedFilters('list_rendered_data', $columnValues, 'contacts', array('usr_uuid' => 'u-1'));
+check('list_rendered_data filters the fully rendered row before it is sent', $columnValues['0'] === '<b>1</b>', $columnValues['0']);
+
+// ------------------------------------------------------------------- without a listener, no-op
+Hooks::reset();
+$row = array('usr_uuid' => 'u-1', 'login_name' => 'jdoe');
+check('list_data with no listener leaves the row unchanged', Hooks::applyTypedFilters('list_data', $row, 'contacts') === $row);
+check(
+    'the count guard passes when nobody filters list_columns',
+    filterContactsColumnHeading(array('No', 'Name', 'Email')) === array('No', 'Name', 'Email')
+);
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/login-hooks.php
+++ b/tests/hooks/login-hooks.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * The login hooks. Two things are checked here:
+ *
+ * 1. the control flow around them, through a stand-in that carries the try/catch of
+ *    ModuleLogin::checkLogin() verbatim - the real one needs a session, a form, a database and a user;
+ * 2. that no login hook is ever handed the password. That one is checked against the real source file,
+ *    because it is the property that matters and a stand-in could not prove it.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+
+/** The head of ModuleLogin::checkLogin(), with the lookup replaced by something the test controls. */
+class ProbeLogin
+{
+    /** @var callable what authenticate() does */
+    public $authenticate;
+
+    public function checkLogin(string $loginName, string $organization): bool
+    {
+        Hooks::doAction('login_attempt', $loginName, $organization);
+
+        try {
+            return ($this->authenticate)($loginName, $organization);
+        } catch (\Throwable $exception) {
+            Hooks::doActionCatchErrors('login_failed', $loginName, $exception->getMessage(), $organization);
+
+            throw $exception;
+        }
+    }
+}
+
+function aLogin(callable $authenticate): ProbeLogin
+{
+    Hooks::reset();
+    $login = new ProbeLogin();
+    $login->authenticate = $authenticate;
+
+    return $login;
+}
+
+// ---------------------------------------------------------------- an attempt can be refused outright
+
+$reached = false;
+$login = aLogin(function () use (&$reached) {
+    $reached = true;
+    return true;
+});
+Hooks::addAction('login_attempt', function (string $loginName) {
+    if ($loginName === 'blocked') {
+        throw new \RuntimeException('too many attempts');
+    }
+});
+
+$refused = '';
+try {
+    $login->checkLogin('blocked', 'example');
+} catch (\Throwable $exception) {
+    $refused = $exception->getMessage();
+}
+check('a callback of login_attempt can refuse the attempt', $refused === 'too many attempts', $refused);
+check('and the password is then never checked at all', !$reached);
+
+check('an attempt that nobody objects to goes through', $login->checkLogin('jdoe', 'example') === true);
+check('and it did reach the authentication', $reached);
+
+// ----------------------------------------------------------------------- a failure keeps its reason
+
+$login = aLogin(function () {
+    throw new \RuntimeException('SYS_LOGIN_USERNAME_PASSWORD_INCORRECT');
+});
+$failures = array();
+Hooks::addAction('login_failed', function (string $loginName, string $reason) use (&$failures) {
+    $failures[] = $loginName . '/' . $reason;
+});
+
+$reported = '';
+try {
+    $login->checkLogin('ghost', 'example');
+} catch (\Throwable $exception) {
+    $reported = $exception->getMessage();
+}
+check('login_failed is told who failed and why', $failures === array('ghost/SYS_LOGIN_USERNAME_PASSWORD_INCORRECT'), implode(',', $failures));
+check('and the original reason is still what the user is told', $reported === 'SYS_LOGIN_USERNAME_PASSWORD_INCORRECT', $reported);
+
+// a name that belongs to nobody is refused before a User object exists, and is still an attempt
+$login = aLogin(function () {
+    throw new \RuntimeException('SYS_LOGIN_USERNAME_PASSWORD_INCORRECT');
+});
+$attempts = array();
+Hooks::addAction('login_attempt', function (string $loginName) use (&$attempts) {
+    $attempts[] = $loginName;
+});
+Hooks::addAction('login_failed', function (string $loginName) use (&$attempts) {
+    $attempts[] = 'failed:' . $loginName;
+});
+try {
+    $login->checkLogin('nobody-has-this-name', 'example');
+} catch (\Throwable) {
+    // expected
+}
+check(
+    'an unknown user name is reported as an attempt and as a failure',
+    $attempts === array('nobody-has-this-name', 'failed:nobody-has-this-name'),
+    implode(',', $attempts)
+);
+
+// -------------------------------------------------- a broken diagnostic must not change the outcome
+
+$login = aLogin(function () {
+    throw new \RuntimeException('SYS_LOGIN_MAX_INVALID_LOGIN');
+});
+Hooks::addAction('login_failed', function () {
+    throw new \LogicException('the audit plugin is broken');
+});
+
+$reported = '';
+try {
+    $login->checkLogin('jdoe', 'example');
+} catch (\Throwable $exception) {
+    $reported = $exception->getMessage();
+}
+check(
+    'a listener that throws cannot replace the reason the login was refused',
+    $reported === 'SYS_LOGIN_MAX_INVALID_LOGIN',
+    $reported
+);
+
+// ------------------------------------------------------- the password never leaves the login module
+
+$source = file_get_contents(__DIR__ . '/../../system/classes/ModuleLogin.php');
+$dispatches = array();
+foreach (explode("\n", $source) as $line) {
+    if (str_contains($line, 'Hooks::doAction')) {
+        $dispatches[] = trim($line);
+    }
+}
+
+// four sites for three hooks: login_failed is dispatched both when a check throws and, defensively,
+// when User::checkLogin() returns false - which it cannot do today, every check of it throws instead
+check('the login module dispatches the login hooks and nothing else', count($dispatches) === 4, implode(' | ', $dispatches));
+
+$leaks = array_values(array_filter($dispatches, function (string $line) {
+    return str_contains($line, 'Password') || str_contains($line, 'password');
+}));
+check('and none of them is handed the password', $leaks === array(), implode(' | ', $leaks));
+
+$names = array();
+foreach ($dispatches as $line) {
+    if (preg_match("/doAction(?:CatchErrors)?\('([a-z_]+)'/", $line, $matches) === 1) {
+        $names[] = $matches[1];
+    }
+}
+$names = array_values(array_unique($names));
+sort($names);
+check('and they are the ones this step promised', $names === array('login_attempt', 'login_failed', 'login_succeeded'), implode(',', $names));
+
+exit(testSummary());

--- a/tests/hooks/page-hooks.php
+++ b/tests/hooks/page-hooks.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * The page hooks, and the typed filter they are the first consumer of.
+ *
+ * `PagePresenter` cannot be constructed here - it reads the settings, the organization, the language
+ * and the session out of the database - so what this file executes is the real `Hooks` engine and a
+ * stand-in page that carries the three lines of `PagePresenter::show()` and `setHtmlID()` verbatim.
+ * The assertion about the order of the assignments is the point: it is what the defect of finding 91
+ * was, and the stand-in reproduces the constructor-then-setter sequence of the real class.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+
+/** The parts of PagePresenter that the page hooks touch, over a real Smarty-like variable bag. */
+class ProbePage
+{
+    protected string $id = '';
+    protected string $title = '';
+    protected string $headline = '';
+    public array $assigned = array();
+
+    public function __construct()
+    {
+        // assignBasicSmartyVariables(), from the constructor
+        $this->assigned['id'] = $this->id;
+        $this->assigned['title'] = $this->title;
+        $this->assigned['headline'] = $this->headline;
+    }
+
+    /** setHtmlID(), as it is after the patch */
+    public function setHtmlID(string $htmlID): void
+    {
+        $this->id = $htmlID;
+        $this->assigned['id'] = $this->id;
+    }
+
+    public function getHtmlID(): string
+    {
+        return $this->id;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function setHeadline(string $headline): void
+    {
+        $this->headline = $headline;
+    }
+
+    /** the head of show(), as it is after the patch */
+    public function show(): void
+    {
+        $this->title = Hooks::applyTypedFilters('page_title', $this->title, $this);
+        $this->headline = Hooks::applyTypedFilters('page_headline', $this->headline, $this);
+        Hooks::doAction('page_before_render', $this);
+
+        $this->assigned['id'] = $this->id;
+        $this->assigned['title'] = $this->title;
+        $this->assigned['headline'] = $this->headline;
+    }
+}
+
+/** setHtmlID() as it was: the member is set, the template never hears about it. */
+class LegacyPage extends ProbePage
+{
+    public function setHtmlID(string $htmlID): void
+    {
+        $this->id = $htmlID;
+    }
+
+    public function show(): void
+    {
+        // the old show() assigned neither the id nor the two texts
+    }
+}
+
+function aPage(): ProbePage
+{
+    Hooks::reset();
+    $page = new ProbePage();
+    $page->setHtmlID('adm_contacts');
+    $page->setTitle('Admidio - Contacts');
+    $page->setHeadline('Contacts');
+
+    return $page;
+}
+
+// ------------------------------------------------------------------ the ID reaches the page at all
+
+$legacy = new LegacyPage();
+$legacy->setHtmlID('adm_contacts');
+$legacy->show();
+check(
+    'the previous setHtmlID() left the body id empty, which is what this test pins',
+    $legacy->assigned['id'] === '',
+    var_export($legacy->assigned['id'], true)
+);
+
+$page = aPage();
+$page->show();
+check('now the id of the page is what was set', $page->assigned['id'] === 'adm_contacts', $page->assigned['id']);
+
+// ------------------------------------------------------------------------------ the two text filters
+
+$page = aPage();
+Hooks::addFilter('page_title', function (string $title) {
+    return $title . ' | Example Club';
+});
+Hooks::addFilter('page_headline', function (string $headline, ProbePage $subject) {
+    return ($subject->getHtmlID() === 'adm_contacts') ? 'Our contacts' : $headline;
+});
+$page->show();
+
+check('page_title filters the title', $page->assigned['title'] === 'Admidio - Contacts | Example Club', $page->assigned['title']);
+// the headline filter above only answers 'Our contacts' because it was handed the page and asked it
+check('page_headline filters the headline and is handed the page', $page->assigned['headline'] === 'Our contacts', $page->assigned['headline']);
+
+// ------------------------------------------------------------------ the filters run in priority order
+
+$page = aPage();
+Hooks::addFilter('page_title', function (string $title) { return $title . ' second'; }, 20);
+Hooks::addFilter('page_title', function (string $title) { return $title . ' first'; }, 5);
+$page->show();
+check(
+    'a lower priority runs earlier',
+    $page->assigned['title'] === 'Admidio - Contacts first second',
+    $page->assigned['title']
+);
+
+// --------------------------------------------------------------------------- page_before_render last
+
+$page = aPage();
+$order = array();
+Hooks::addFilter('page_title', function (string $title) use (&$order) {
+    $order[] = 'title';
+    return $title;
+});
+Hooks::addAction('page_before_render', function (ProbePage $subject) use (&$order) {
+    $order[] = 'render';
+    $subject->setHeadline('Changed at the last moment');
+});
+$page->show();
+check('page_before_render runs after the filters', $order === array('title', 'render'), implode(',', $order));
+check(
+    'and what it changes still reaches the page',
+    $page->assigned['headline'] === 'Changed at the last moment',
+    $page->assigned['headline']
+);
+
+// ------------------------------------------------------------------- a wrongly typed result throws
+
+$page = aPage();
+Hooks::addFilter('page_title', function () {
+    return array('not', 'a', 'string');
+});
+$message = '';
+try {
+    $page->show();
+} catch (\Throwable $exception) {
+    $message = $exception->getMessage();
+}
+check('a filter that answers with the wrong type is refused', str_contains($message, 'returned array instead of string'), $message);
+check('and it names the hook', str_contains($message, 'page_title'), $message);
+
+// the untyped applyFilters() still passes anything through, for the sites that want that
+Hooks::reset();
+Hooks::addFilter('anything', function () {
+    return array('still', 'fine');
+});
+check('applyFilters() is unchanged', Hooks::applyFilters('anything', '') === array('still', 'fine'));
+
+// a bool filter has to answer with a bool, which is what component_visible will need
+Hooks::reset();
+Hooks::addFilter('permitted', function () {
+    return 1;
+});
+$refused = false;
+try {
+    Hooks::applyTypedFilters('permitted', true);
+} catch (\Throwable $exception) {
+    $refused = str_contains($exception->getMessage(), 'returned int instead of bool');
+}
+check('an int is not a bool', $refused);
+
+Hooks::reset();
+Hooks::addFilter('permitted', function () {
+    return false;
+});
+check('and a bool is', Hooks::applyTypedFilters('permitted', true) === false);
+
+exit(testSummary());

--- a/tests/hooks/page-hooks.php
+++ b/tests/hooks/page-hooks.php
@@ -18,6 +18,7 @@ class ProbePage
     protected string $id = '';
     protected string $title = '';
     protected string $headline = '';
+    protected bool $textFiltered = false;
     public array $assigned = array();
 
     public function __construct()
@@ -50,11 +51,33 @@ class ProbePage
         $this->headline = $headline;
     }
 
+    /**
+     * filterText(), as it is after the patch: page_title and page_headline run exactly once,
+     * however many times this is called and whether it runs before or after show().
+     */
+    public function filterText(): void
+    {
+        if ($this->textFiltered) {
+            return;
+        }
+        $this->textFiltered = true;
+
+        $this->title = Hooks::applyTypedFilters('page_title', $this->title, $this);
+        $this->headline = Hooks::applyTypedFilters('page_headline', $this->headline, $this);
+    }
+
+    /** getFilteredHeadline(), as it is after the patch: for a caller that needs it before show(). */
+    public function getFilteredHeadline(): string
+    {
+        $this->filterText();
+
+        return $this->headline;
+    }
+
     /** the head of show(), as it is after the patch */
     public function show(): void
     {
-        $this->title = Hooks::applyTypedFilters('page_title', $this->title, $this);
-        $this->headline = Hooks::applyTypedFilters('page_headline', $this->headline, $this);
+        $this->filterText();
         Hooks::doAction('page_before_render', $this);
 
         $this->assigned['id'] = $this->id;
@@ -117,6 +140,22 @@ $page->show();
 check('page_title filters the title', $page->assigned['title'] === 'Admidio - Contacts | Example Club', $page->assigned['title']);
 // the headline filter above only answers 'Our contacts' because it was handed the page and asked it
 check('page_headline filters the headline and is handed the page', $page->assigned['headline'] === 'Our contacts', $page->assigned['headline']);
+
+// --------------------------------------- getFilteredHeadline() runs the filter exactly once, either side of show()
+
+$page = aPage();
+$calls = 0;
+Hooks::addFilter('page_headline', function (string $headline) use (&$calls) {
+    $calls++;
+    return $headline;
+});
+$first = $page->getFilteredHeadline();
+$second = $page->getFilteredHeadline();
+check('a caller can read the filtered headline before show()', $first === 'Contacts', $first);
+check('asking twice does not filter twice', $calls === 1, (string) $calls);
+$page->show();
+check('show() finds the work already done', $calls === 1, (string) $calls);
+check('and the page renders with the same value', $page->assigned['headline'] === $second, $page->assigned['headline']);
 
 // ------------------------------------------------------------------ the filters run in priority order
 

--- a/tests/hooks/readable-name.php
+++ b/tests/hooks/readable-name.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Entity::readableName() dispatches entity_readable_name and, for a named entity, the specific
+ * <hookId>_readable_name as well. Executed against the real Entity.
+ */
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/entities.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Tests\Hooks\TestRoom;
+use Admidio\Tests\Hooks\TestSession;
+
+function newDatabase(): FakeDatabase
+{
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_rooms', columnDefinition('room'));
+    $db->createTable(TABLE_PREFIX . '_sessions', columnDefinition('ses'));
+    return $db;
+}
+
+// ---------------------------------------------------------------- a named entity gets both filters
+Hooks::reset();
+$log = array();
+Hooks::addFilter('entity_readable_name', function (string $name) use (&$log) {
+    $log[] = 'entity:' . $name;
+    return $name;
+});
+Hooks::addFilter('room_readable_name', function (string $name) use (&$log) {
+    $log[] = 'room:' . $name;
+    return $name . ' (Room)';
+});
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Blue Room');
+$room->save();
+$name = $room->readableName();
+check('the generic filter runs before the specific one', $log === array('entity:Blue Room', 'room:Blue Room'), implode(',', $log));
+check('the specific filter\'s result is what readableName() returns', $name === 'Blue Room (Room)', $name);
+
+// ---------------------------------------------------------------- an unnamed entity gets only the generic filter
+Hooks::reset();
+$log = array();
+Hooks::addFilter('entity_readable_name', function (string $name) use (&$log) {
+    $log[] = 'entity:' . $name;
+    return $name;
+});
+Hooks::addFilter('ses_readable_name', function (string $name) use (&$log) {
+    $log[] = 'ses:' . $name;
+    return $name;
+});
+$db = newDatabase();
+$session = new TestSession($db);
+$session->setValue('ses_name', 'A Session');
+$session->save();
+$session->readableName();
+check('an entity with no hook ID never reaches a specific filter', $log === array('entity:A Session'), implode(',', $log));
+
+// ---------------------------------------------------------------- no listener costs nothing and changes nothing
+Hooks::reset();
+$db = newDatabase();
+$room = new TestRoom($db);
+$room->setValue('room_name', 'Green Room');
+$room->save();
+check('without a listener the name is unchanged', $room->readableName() === 'Green Room', $room->readableName());
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/registration-accepted.php
+++ b/tests/hooks/registration-accepted.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * user_registration_accepted, dispatched by UserRegistration::acceptRegistration() and
+ * RegistrationService::assignRegistration() through Database::registerAfterCommit() - the same
+ * primitive EntityHookQueue uses, called directly because this event does not belong to one entity's
+ * change set.
+ *
+ * UserRegistration and RegistrationService both need a full ProfileFields/User/settings stack to
+ * construct, more than this harness sets up elsewhere, so this executes the real mechanism they rely
+ * on - Database::registerAfterCommit(), inherited by FakeDatabase unchanged - and the real
+ * UserRegistration::ACCEPTED_BY_* constants, reproducing the exact call shape of both methods
+ * (including CoreTasks::registrationApprove(), the one caller that wraps acceptRegistration() in a
+ * transaction of its own) rather than the method bodies themselves.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Tests\Hooks\FakeDatabase;
+use Admidio\Users\Entity\UserRegistration;
+
+// ---------------------------------------------------- outside any transaction, it fires immediately
+Hooks::reset();
+$fired = array();
+Hooks::addAction('user_registration_accepted', function ($user, $method) use (&$fired) {
+    $fired[] = array($user, $method);
+});
+
+$db = new FakeDatabase();
+// acceptRegistration()'s own transaction, exactly as confirmRegistration() calls it: nothing wraps it
+$db->startTransaction();
+$db->endTransaction();
+$db->registerAfterCommit(function () use (&$dispatched) {
+    Hooks::doAction('user_registration_accepted', 'user-1', UserRegistration::ACCEPTED_BY_APPROVAL);
+});
+check(
+    'with no enclosing transaction the event fires as soon as acceptRegistration() commits',
+    $fired === array(array('user-1', UserRegistration::ACCEPTED_BY_APPROVAL)),
+    var_export($fired, true)
+);
+
+// -------------------------------------- CoreTasks::registrationApprove() wraps it in its own transaction
+Hooks::reset();
+$fired = array();
+Hooks::addAction('user_registration_accepted', function ($user, $method) use (&$fired) {
+    $fired[] = array($user, $method);
+});
+
+$db = new FakeDatabase();
+$db->startTransaction();               // the CLI command's own transaction
+    $db->startTransaction();           // acceptRegistration()'s transaction, now nested
+    $db->endTransaction();             // only decrements, nothing has really committed yet
+    $db->registerAfterCommit(function () {
+        Hooks::doAction('user_registration_accepted', 'user-2', UserRegistration::ACCEPTED_BY_APPROVAL);
+    });
+    check('the event has not fired while the CLI command is still assigning roles', $fired === array());
+    // ... the CLI command's own further work would run here, e.g. Role::startMembership() ...
+$db->endTransaction();                 // the CLI command's own commit, the real one
+check(
+    'and fires once the outermost transaction actually commits',
+    $fired === array(array('user-2', UserRegistration::ACCEPTED_BY_APPROVAL)),
+    var_export($fired, true)
+);
+
+// ------------------------------------------------------- a rollback of the outer transaction drops it
+Hooks::reset();
+$fired = array();
+Hooks::addAction('user_registration_accepted', function ($user, $method) use (&$fired) {
+    $fired[] = array($user, $method);
+});
+
+$db = new FakeDatabase();
+$db->startTransaction();
+    $db->startTransaction();
+    $db->endTransaction();
+    $db->registerAfterCommit(function () {
+        Hooks::doAction('user_registration_accepted', 'user-3', UserRegistration::ACCEPTED_BY_APPROVAL);
+    });
+$db->rollback();
+check('a rolled back outer transaction drops the event entirely, it is not deferred or retried', $fired === array());
+
+// --------------------------------------------------------------- assignRegistration()'s own method name
+Hooks::reset();
+$fired = array();
+Hooks::addAction('user_registration_accepted', function ($user, $method) use (&$fired) {
+    $fired[] = $method;
+});
+$db = new FakeDatabase();
+$db->startTransaction();
+$db->endTransaction();
+$db->registerAfterCommit(function () {
+    Hooks::doAction('user_registration_accepted', 'user-4', UserRegistration::ACCEPTED_BY_ASSIGNMENT);
+});
+check(
+    'assignRegistration() and acceptRegistration() are told apart by the method argument',
+    $fired === array(UserRegistration::ACCEPTED_BY_ASSIGNMENT)
+    && UserRegistration::ACCEPTED_BY_ASSIGNMENT !== UserRegistration::ACCEPTED_BY_APPROVAL,
+    implode(',', $fired)
+);
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/roles-dependencies-delete.php
+++ b/tests/hooks/roles-dependencies-delete.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * RolesDependencies::delete() overrides the base Entity::delete() because the table has a composite
+ * key instead of a single auto-increment column - and until finding 96 it never dispatched its own
+ * hooks at all. Executed against the real class over SQLite, not a stand-in: its constructor takes
+ * nothing but a Database.
+ */
+require __DIR__ . '/bootstrap.php';
+
+define('TBL_ROLE_DEPENDENCIES', TABLE_PREFIX . '_role_dependencies');
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Roles\Entity\RolesDependencies;
+use Admidio\Tests\Hooks\FakeDatabase;
+
+function roleDependencyColumns(): array
+{
+    $text = fn() => array('type' => 'text', 'null' => true, 'key' => false, 'serial' => false, 'default' => null);
+    return array(
+        'rld_rol_id_parent' => $text(),
+        'rld_rol_id_child' => $text(),
+        'rld_comment' => $text(),
+        'rld_usr_id' => $text(),
+        'rld_timestamp' => $text(),
+    );
+}
+
+function newDatabase(): FakeDatabase
+{
+    $db = new FakeDatabase();
+    $db->createTable(TBL_ROLE_DEPENDENCIES, roleDependencyColumns());
+    return $db;
+}
+
+// ------------------------------------------------------------------------ delete dispatches its hooks
+Hooks::reset();
+$db = newDatabase();
+$dependency = new RolesDependencies($db);
+$dependency->setValue('rld_rol_id_parent', 3);
+$dependency->setValue('rld_rol_id_child', 7);
+$dependency->save();
+
+$events = array();
+foreach (array('role_dependency_deleting', 'role_dependency_deleted', 'entity_deleting', 'entity_deleted') as $name) {
+    Hooks::addAction($name, function (EntityChangeSet $cs) use (&$events, $name) {
+        $events[] = $name;
+    });
+}
+$dependency->delete();
+
+check(
+    'both the specific and the generic hooks fire, generic-then-specific before and after the delete',
+    $events === array('entity_deleting', 'role_dependency_deleting', 'role_dependency_deleted', 'entity_deleted'),
+    implode(' ', $events)
+);
+check('the row is really gone', $db->fetchAll(TBL_ROLE_DEPENDENCIES) === array());
+
+// ---------------------------------------------------------------- the change set names the old record
+Hooks::reset();
+$db = newDatabase();
+$dependency = new RolesDependencies($db);
+$dependency->setValue('rld_rol_id_parent', 3);
+$dependency->setValue('rld_rol_id_child', 7);
+$dependency->save();
+
+$captured = null;
+Hooks::addAction('role_dependency_deleted', function (EntityChangeSet $cs) use (&$captured) {
+    $captured = $cs;
+});
+$dependency->delete();
+
+check('the operation is a deletion', $captured->isDelete() && $captured->getHookId() === 'role_dependency');
+check(
+    'the parent and child ids are in the snapshot',
+    ($captured->getSnapshot()['rld_rol_id_parent'] ?? null) === '3' && ($captured->getSnapshot()['rld_rol_id_child'] ?? null) === '7',
+    var_export($captured->getSnapshot(), true)
+);
+
+// ------------------------------------------------------- without a listener, nothing extra is read
+Hooks::reset();
+$db = newDatabase();
+$dependency = new RolesDependencies($db);
+$dependency->setValue('rld_rol_id_parent', 1);
+$dependency->setValue('rld_rol_id_child', 2);
+$dependency->save();
+
+$before = count($db->statements);
+$dependency->delete();
+$selects = 0;
+foreach (array_slice($db->statements, $before) as $statement) {
+    if (str_starts_with(ltrim($statement), 'SELECT * FROM ' . TBL_ROLE_DEPENDENCIES)) {
+        $selects++;
+    }
+}
+check('without a listener hookBulkDeletion() reads nothing', $selects === 0, (string) $selects);
+
+echo "\n";
+exit(testSummary());

--- a/tests/hooks/translation-hooks.php
+++ b/tests/hooks/translation-hooks.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * The translation hooks. The real `Language` is executed against the real `languages/*.xml` of this
+ * checkout, so the cache, the fallback to the reference language and the placeholders are the real
+ * ones. Only the four path constants of the Admidio bootstrap are defined here.
+ */
+require __DIR__ . '/bootstrap.php';
+
+define('ADMIDIO_PATH', realpath(__DIR__ . '/../..'));
+define('FOLDER_DATA', '/adm_my_files');
+define('FOLDER_LANGUAGES', '/languages');
+define('FOLDER_PLUGINS', '/plugins');
+
+use Admidio\Hooks\Hooks;
+use Admidio\Infrastructure\Language;
+
+function aLanguage(string $language = 'de'): Language
+{
+    Hooks::reset();
+
+    return new Language($language);
+}
+
+// ------------------------------------------------------------------------ nothing changes by itself
+
+$l10n = aLanguage();
+check('a text of the language file is returned as it is', $l10n->get('SYS_SAVE') === 'Speichern', $l10n->get('SYS_SAVE'));
+check('a text nobody has is marked as undefined', $l10n->get('ZZZ_NOT_THERE') === '#ZZZ_NOT_THERE#', $l10n->get('ZZZ_NOT_THERE'));
+
+// ---------------------------------------------------------------------------- the missing resolver
+
+$l10n = aLanguage();
+$asked = array();
+Hooks::addResolver('translation_missing', function (string $textId, string $language) use (&$asked) {
+    $asked[] = $textId . '/' . $language;
+    return ($textId === 'ZZZ_PLUGIN_TEXT') ? 'Von einem Plugin' : null;
+});
+
+check('a resolver can supply a text that no file has', $l10n->get('ZZZ_PLUGIN_TEXT') === 'Von einem Plugin', $l10n->get('ZZZ_PLUGIN_TEXT'));
+check('and it is told which text and which language', $asked === array('ZZZ_PLUGIN_TEXT/de'), implode(',', $asked));
+
+$l10n->get('ZZZ_PLUGIN_TEXT');
+$l10n->get('ZZZ_PLUGIN_TEXT');
+check('the answer is cached, so the resolver is asked once', count($asked) === 1, (string)count($asked));
+
+check('a resolver that has no answer changes nothing', $l10n->get('ZZZ_STILL_NOT_THERE') === '#ZZZ_STILL_NOT_THERE#');
+
+// the cache lives in the session, so a plugin whose texts changed clears it the way Admidio does
+$restored = unserialize(serialize($l10n));
+check('and it survives the session', $restored->get('ZZZ_PLUGIN_TEXT') === 'Von einem Plugin', $restored->get('ZZZ_PLUGIN_TEXT'));
+
+// ------------------------------------------------------------------- placeholders after the resolver
+
+$l10n = aLanguage();
+Hooks::addResolver('translation_missing', function () {
+    return 'Angelegt von #VAR1# am #VAR2#';
+});
+check(
+    'a resolved text still gets its placeholders',
+    $l10n->get('ZZZ_WITH_PARAMS', array('John Doe', '2026-08-26')) === 'Angelegt von John Doe am 2026-08-26',
+    $l10n->get('ZZZ_WITH_PARAMS', array('John Doe', '2026-08-26'))
+);
+
+// -------------------------------------------------------------------------------- the unresolved hook
+
+$l10n = aLanguage();
+$unresolved = array();
+Hooks::addAction('translation_unresolved', function (string $textId, string $language) use (&$unresolved) {
+    $unresolved[] = $textId . '/' . $language;
+});
+$l10n->get('ZZZ_NOBODY_HAS_THIS');
+check('translation_unresolved reports what nobody could answer', $unresolved === array('ZZZ_NOBODY_HAS_THIS/de'), implode(',', $unresolved));
+
+// a diagnostic must not be able to break the page
+$l10n = aLanguage();
+Hooks::addAction('translation_unresolved', function () {
+    throw new \RuntimeException('the devhelper is broken');
+});
+check('and a diagnostic that throws does not take the page with it', $l10n->get('ZZZ_NOBODY_HAS_THIS') === '#ZZZ_NOBODY_HAS_THIS#');
+
+// ------------------------------------------------------------------------------- the fallback hook
+
+$l10n = aLanguage('de');
+$fallbacks = array();
+Hooks::addAction('translation_fallback_used', function (string $textId, string $language, string $reference) use (&$fallbacks) {
+    $fallbacks[] = $textId . ' ' . $language . '->' . $reference;
+});
+check('a text that the language has does not report a fallback', $l10n->get('SYS_SAVE') === 'Speichern' && $fallbacks === array(), implode(',', $fallbacks));
+
+// a text that German does not have but English does. It is looked up rather than named, so that the
+// check keeps working when the translation catches up.
+$onlyInReference = null;
+$germanIds = array();
+foreach (simplexml_load_file(ADMIDIO_PATH . '/languages/de.xml')->string as $string) {
+    $germanIds[(string)$string['name']] = true;
+}
+foreach (simplexml_load_file(ADMIDIO_PATH . '/languages/en.xml')->string as $string) {
+    if (!array_key_exists((string)$string['name'], $germanIds)) {
+        $onlyInReference = (string)$string['name'];
+        break;
+    }
+}
+
+if ($onlyInReference === null) {
+    check('every text is translated into German, so the fallback cannot be exercised', true, 'nothing to check');
+} else {
+    $l10n = aLanguage('de');
+    $fallbacks = array();
+    Hooks::addAction('translation_fallback_used', function (string $textId, string $language, string $reference) use (&$fallbacks) {
+        $fallbacks[] = $textId . ' ' . $language . '->' . $reference;
+    });
+    $text = $l10n->get($onlyInReference);
+
+    check(
+        'a text that only the reference language has reports the fallback',
+        $fallbacks === array($onlyInReference . ' de->en'),
+        implode(',', $fallbacks) . ' for ' . $onlyInReference
+    );
+    check('and the English text is what is shown', $text !== '' && $text !== '#' . $onlyInReference . '#', $text);
+
+    $l10n->get($onlyInReference);
+    check('the cache answers the second time, so it is reported once per session', count($fallbacks) === 1, (string)count($fallbacks));
+}
+
+// an English installation must not report a fallback for every single text
+$l10n = aLanguage('en');
+$fallbacks = array();
+Hooks::addAction('translation_fallback_used', function () use (&$fallbacks) {
+    $fallbacks[] = 'reported';
+});
+$l10n->get('SYS_SAVE');
+check('and neither does the reference language itself', $fallbacks === array(), implode(',', $fallbacks));
+
+// ------------------------------------------------------------------------------------- the filter
+
+$l10n = aLanguage();
+Hooks::addFilter('translation_text', function (string $text, string $textId) {
+    return ($textId === 'SYS_SAVE') ? 'Sichern' : $text;
+});
+check('translation_text changes a text', $l10n->get('SYS_SAVE') === 'Sichern', $l10n->get('SYS_SAVE'));
+check('and leaves the others alone', $l10n->get('SYS_CANCEL') !== 'Sichern');
+
+// it runs after the cache, so a second call is filtered as well
+check('it runs on every call and not only on the first', $l10n->get('SYS_SAVE') === 'Sichern', $l10n->get('SYS_SAVE'));
+
+// and it runs before the placeholders, so a filter sees the template
+$l10n = aLanguage();
+Hooks::addFilter('translation_text', function (string $text) {
+    return str_replace('#VAR1#', '<b>#VAR1#</b>', $text);
+});
+$created = $l10n->get('SYS_CREATED_BY_AND_AT', array('John Doe', '2026-08-26'));
+check('a filter sees the placeholders, not the filled-in values', str_contains($created, '<b>John Doe</b>'), $created);
+
+// a text is a string
+$l10n = aLanguage();
+Hooks::addFilter('translation_text', function () {
+    return array('not a text');
+});
+$refused = false;
+try {
+    $l10n->get('SYS_SAVE');
+} catch (\Throwable $exception) {
+    $refused = str_contains($exception->getMessage(), 'returned array instead of string');
+}
+check('a filter that does not answer with a string is refused', $refused);
+
+// ------------------------------------------------------------- the cache is not filtered, the text is
+
+$l10n = aLanguage();
+$l10n->get('SYS_SAVE');                       // fills the cache with the unfiltered text
+Hooks::addFilter('translation_text', function (string $text) {
+    return strtoupper($text);
+});
+check('a filter registered after the cache was filled still applies', $l10n->get('SYS_SAVE') === 'SPEICHERN', $l10n->get('SYS_SAVE'));
+
+Hooks::reset();
+check('and removing it gives the text back', $l10n->get('SYS_SAVE') === 'Speichern', $l10n->get('SYS_SAVE'));
+
+exit(testSummary());

--- a/tests/hooks/user-valid-default.php
+++ b/tests/hooks/user-valid-default.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * usr_valid is a value of the record, not a side effect of clear().
+ *
+ * The real `User` cannot be instantiated here - it needs a `ProfileFields` object, which reads the
+ * database. `ProbeUser` therefore carries `User::__construct()` and `User::clear()` as they stand in
+ * the source, reduced to the two lines that touch the column, and everything below it is the real
+ * `Entity`. The checks are about which columns end up marked as changed, which is what `Entity` alone
+ * decides.
+ */
+require __DIR__ . '/bootstrap.php';
+
+use Admidio\Hooks\Hooks;
+use Admidio\Hooks\ValueObject\EntityChangeSet;
+use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Tests\Hooks\FakeDatabase;
+
+/** User as it is after the patch: the default belongs to the creation of the record. */
+class ProbeUser extends Entity
+{
+    public function __construct(Database $database, int $userId = 0)
+    {
+        parent::__construct($database, TABLE_PREFIX . '_users', 'usr', $userId);
+
+        if ($this->newRecord) {
+            $this->initializeNewRecord();
+        }
+    }
+
+    public function getHookId(): ?string
+    {
+        return 'user';
+    }
+
+    protected function initializeNewRecord(): void
+    {
+        $this->setValue('usr_valid', 1);
+    }
+
+    /** clear() no longer touches the column. */
+    public function clear(): void
+    {
+        parent::clear();
+    }
+
+    public function clearAsNewUser(): void
+    {
+        $this->clear();
+        $this->initializeNewRecord();
+    }
+
+    public function changedFlag(string $column): bool
+    {
+        return (bool)($this->columnsInfos[$column]['changed'] ?? false);
+    }
+}
+
+/** User as it is before the patch, to show that the check would have caught it. */
+class LegacyUser extends ProbeUser
+{
+    public function clear(): void
+    {
+        Entity::clear();
+        $this->setValue('usr_valid', 1);
+        $this->columnsValueChanged = false;
+    }
+}
+
+function newDatabase(): FakeDatabase
+{
+    Hooks::reset();
+    $db = new FakeDatabase();
+    $db->createTable(TABLE_PREFIX . '_users', array(
+        'usr_id' => array('type' => 'integer', 'null' => false, 'key' => true, 'serial' => true, 'default' => null),
+        'usr_uuid' => array('type' => 'varchar(36)', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        'usr_login_name' => array('type' => 'varchar(254)', 'null' => true, 'key' => false, 'serial' => false, 'default' => null),
+        'usr_valid' => array('type' => 'boolean', 'null' => true, 'key' => false, 'serial' => false, 'default' => null)
+    ));
+    return $db;
+}
+
+/** The UPDATE that the next save writes, and the columns the hook reports. */
+function saveAndInspect(FakeDatabase $db, ProbeUser $user, string $column, string $value): array
+{
+    $reported = array();
+    Hooks::reset();
+    Hooks::addAction('user_updated', function (EntityChangeSet $cs) use (&$reported) {
+        $reported = array_keys($cs->getChanges());
+    });
+
+    $before = count($db->statements);
+    $user->setValue($column, $value);
+    $user->save();
+
+    $update = '';
+    foreach (array_slice($db->statements, $before) as $statement) {
+        if (str_starts_with(ltrim($statement), 'UPDATE')) {
+            $update = preg_replace('/\s+/', ' ', trim(explode('WHERE', $statement)[0]));
+        }
+    }
+
+    return array('update' => $update, 'reported' => $reported);
+}
+
+// ------------------------------------------------------------------ a new record is created active
+
+$db = newDatabase();
+$user = new ProbeUser($db);
+check('a new user object is active', $user->getValue('usr_valid') == 1, var_export($user->getValue('usr_valid'), true));
+
+$user->setValue('usr_login_name', 'jdoe');
+$user->save();
+$row = $db->fetchAll(TABLE_PREFIX . '_users')[0];
+check('and the record is written as active', (int)$row['usr_valid'] === 1, var_export($row['usr_valid'], true));
+$id = (int)$user->getValue('usr_id');
+
+// --------------------------------------------------------- a record that was read has no change yet
+
+$again = new ProbeUser($db, $id);
+check('a user that was read carries no pending change of usr_valid', !$again->changedFlag('usr_valid'));
+
+$result = saveAndInspect($db, $again, 'usr_login_name', 'renamed');
+check(
+    'so an ordinary save does not write the column',
+    $result['update'] === 'UPDATE adm_users SET usr_login_name = ?',
+    $result['update']
+);
+check(
+    'and does not report it as a change',
+    $result['reported'] === array('usr_login_name'),
+    implode(',', $result['reported'])
+);
+
+// ------------------------------------------------------------ the same object, read into afterwards
+
+$reused = new ProbeUser($db);
+$reused->readDataById($id);
+check('reading into an existing object leaves no pending change either', !$reused->changedFlag('usr_valid'));
+
+// ------------------------------------------------------------------- activation is a change like any
+
+$db = newDatabase();
+$registration = new ProbeUser($db);
+$registration->setValue('usr_login_name', 'pending');
+$registration->setValue('usr_valid', 0);          // UserRegistration::save() does this
+$registration->save();
+$id = (int)$registration->getValue('usr_id');
+check('a registration is created inactive', (int)$db->fetchAll(TABLE_PREFIX . '_users')[0]['usr_valid'] === 0);
+
+$accepted = new ProbeUser($db, $id);
+$result = saveAndInspect($db, $accepted, 'usr_valid', '1');
+check(
+    'accepting it writes the column',
+    $result['update'] === 'UPDATE adm_users SET usr_valid = ?',
+    $result['update']
+);
+check('and reports it as a change', $result['reported'] === array('usr_valid'), implode(',', $result['reported']));
+
+// -------------------------------------------------- clear() as "become a new user", as UserImport does
+
+$db = newDatabase();
+$user = new ProbeUser($db);
+$user->setValue('usr_login_name', 'original');
+$user->save();
+$duplicate = new ProbeUser($db, (int)$user->getValue('usr_id'));
+$duplicate->clearAsNewUser();
+$duplicate->setValue('usr_login_name', 'duplicate');
+$duplicate->save();
+$rows = $db->fetchAll(TABLE_PREFIX . '_users');
+check('a duplicated import user is created active', count($rows) === 2 && (int)$rows[1]['usr_valid'] === 1);
+
+// --------------------------------------------------------------- the defect this check exists to stop
+
+$db = newDatabase();
+$legacy = new LegacyUser($db);
+$legacy->setValue('usr_login_name', 'jdoe');
+$legacy->save();
+$legacy = new LegacyUser($db, (int)$legacy->getValue('usr_id'));
+$result = saveAndInspect($db, $legacy, 'usr_login_name', 'renamed');
+check(
+    'the previous clear() did mark it changed on every read, which is what this test pins',
+    $result['reported'] === array('usr_login_name', 'usr_valid'),
+    implode(',', $result['reported'])
+);
+
+exit(testSummary());


### PR DESCRIPTION
This is a first proof-of-concept to add a proper messaging system with hooks, filters and actions to Admidio, similar to the actions/filters of Wordpress. This is not yet meant for immediate merge, but to get some feedback for the final, polished implementation.

The changes to User.php, common.php and changelog.php show how this can be used inside the existing Admidio code.

1) Add a filter in the core code to let other code modify the default behavior (e.g. modify a displayed text/block, change a display, or prevent certain parts from being displayed altogether, e.g. hiding certain menu items selectively):
```
    use Admidio\Hooks\Hooks;
    $headline =  Hooks::apply_filters('changelog_headline', $headline);
```

Filters can modify the objects passed to them, but are not expected to have many side-effects.

All filters registered for 'changelog_headline' will be given a chance to modify the passed object(s). E.g. anywhere in a PHP file that is loaded on startup (plugin, other module, ...), you can register a filter. This example simply wraps "HOOKED: {........}" around the original headline:
```
Hooks::add_filter('changelog_headline', function ($value) {
    return "HOOKED: {" . $value . "}";
}, priority: 5, accepted_args: 1);
```

2) Actions cannot modify the objects they are passed, but they are intended for their side-effects. E.g. when a user is created/modified/deleted, other parts of the code can react to it and e.g. sync the changes to a different server, send out notification emails or update newsletter subscriptions. Example in User.php:

```
    use Admidio\Hooks\Hooks;
        if ($newRecord) {
            Hooks::do_action('user_created', $this, $gCurrentUser);
        }
```

To add a listener to the action, simply register a function with add_action:
```
Hooks::add_action('user_created', function ($user, $actorId) {
    global $gLogger;
    $gLogger->warning('User Created: ', array('user' => $user, 'actorID' => $actorId));
    // log, sync, enqueue job, etc.
}, priority: 20, accepted_args: 2);
```


Of course, to be able to properly make use of this functionality, one needs to go through all the Admidio code and add lots of generic hooks and actions all over the place to make Admidio as flexible as possible. 

My first target is to hook into the User creation/modification/deletion to sync the user data to Nextcloud via SCIM (as basis for the SSO). But other uses I envision is to modify the sidebar menu depending on the user groups. 

This would also allow us to entangle some code in Admidio, e.g. by moving the user modification notification mails out from the User.php class into their own listeners in a separated file (in the future, even in a separate plugin, once a proper plugin system is implemented).
