### PR TITLE
Remove default user_uuid for not logged in users to fix ical export

### DIFF
--- a/modules/events/events_function.php
+++ b/modules/events/events_function.php
@@ -44,7 +44,7 @@ try {
     // Initialize and check the parameters
     $getEventUuid = admFuncVariableIsValid($_GET, 'dat_uuid', 'uuid');
     $getMode = admFuncVariableIsValid($_GET, 'mode', 'string', array('requireValue' => true, 'validValues' => array('edit', 'delete', 'participate', 'participate_cancel', 'participate_maybe', 'export')));
-    $getUserUuid = admFuncVariableIsValid($_GET, 'user_uuid', 'uuid', array('defaultValue' => $gCurrentUser->getValue('usr_uuid')));
+    $getUserUuid = admFuncVariableIsValid($_GET, 'user_uuid', 'uuid', $gValidLogin ? array('defaultValue' => $gCurrentUser->getValue('usr_uuid')): []);
     $getCopy = admFuncVariableIsValid($_GET, 'copy', 'bool');
     $getCatUuid = admFuncVariableIsValid($_GET, 'cat_uuid', 'uuid');
     $getDateFrom = admFuncVariableIsValid($_GET, 'date_from', 'date');


### PR DESCRIPTION
if a not logged in user clicks on 'Download iCal' on the /modules/events/events.php page, they get the error message 

The parameter "user_uuid" is not a valid UUID! in /system/bootstrap/function.php, in line 431

Stacktrace:
#0 /modules/events/events_function.php(47): admFuncVariableIsValid(Array, 'user_uuid', 'uuid', Array) #1 {main}

This happens because the function uses $gCurrentUser->getValue('usr_uuid') as the default value for  $getUserUuid. Since there is no current user in this case, the uuid validation fails. So for not logged in users, there should be not default value on this variable.