### PR TITLE
fix(captcha): resolve configured font path from ADMIDIO_PATH

### DIFF
--- a/libs/securimage/config.inc.php
+++ b/libs/securimage/config.inc.php
@@ -57,7 +57,7 @@ return array(
     // example UTF-8 charset (TTF file must support symbols being used
     // 'charset'          => "абвгдeжзийклмнопрстуфхцчшщъьюяАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЬЮЯ",
 
-    'ttf_file'         => '../../system/fonts/'.$gSettingsManager->getString('captcha_fonts'),
+    'ttf_file'         => ADMIDIO_PATH . '/system/fonts/' . $gSettingsManager->getString('captcha_fonts'),
 
     /**** Code Storage & Database Options ****/
 


### PR DESCRIPTION
## Summary
- fix issue #1957 by resolving the configured captcha `ttf_file` from `ADMIDIO_PATH` instead of a relative `../../...` path
- keeps behavior the same for selected font filename, but avoids failures when runtime working directory/path resolution changes (as reported on PHP 8.5)
- limits scope to a one-line config fix in Securimage integration

## Testing
- `git diff --check`
- Could not run PHP runtime checks (`php -l` / captcha render) in this environment because the `php` CLI is not installed

## Related
Fixes #1957
