### PR TITLE
Several minor fixes

### DIFF
--- a/modules/events/events.php
+++ b/modules/events/events.php
@@ -296,26 +296,28 @@ try {
                     $columnAlign = array('center', 'left', 'left', 'left', 'left', 'left');
                     $compactTable->disableColumnsSort(array(6));
                     $compactTable->setColumnsNotHideResponsive(array(6));
+                    $data['column_width'] = array('', '', '', '', '', '');
                     break;
                 case 'room':
                     $columnHeading = array('&nbsp;', $gL10n->get('SYS_PERIOD'), $gL10n->get('SYS_EVENT'), $gL10n->get('SYS_ROOM'), $gL10n->get('SYS_LEADERS'), $gL10n->get('SYS_PARTICIPANTS'), $gL10n->get('SYS_CALENDAR'));
                     $columnAlign = array('center', 'left', 'left', 'left', 'left', 'left', 'left');
                     $compactTable->disableColumnsSort(array(7));
                     $compactTable->setColumnsNotHideResponsive(array(7));
+                    $data['column_width'] = array('', '', '', '', '', '', '');
                     break;
                 case 'participants':
                     $columnHeading = array('&nbsp;', $gL10n->get('SYS_PERIOD'), $gL10n->get('SYS_EVENT'), $gL10n->get('SYS_PARTICIPANTS'), $gL10n->get('SYS_CALENDAR'));
                     $columnAlign = array('center', 'left', 'left', 'left', 'left');
                     $compactTable->disableColumnsSort(array(5));
                     $compactTable->setColumnsNotHideResponsive(array(5));
-                    $data['column_width'] = array('', '', '', '35%');
+                    $data['column_width'] = array('', '', '', '35%', '');
                     break;
                 case 'description':
                     $columnHeading = array('&nbsp;', $gL10n->get('SYS_PERIOD'), $gL10n->get('SYS_EVENT'), $gL10n->get('SYS_DESCRIPTION'), $gL10n->get('SYS_CALENDAR'));
                     $columnAlign = array('center', 'left', 'left', 'left', 'left');
                     $compactTable->disableColumnsSort(array(5));
                     $compactTable->setColumnsNotHideResponsive(array(5));
-                    $data['column_width'] = array('', '', '', '35%');
+                    $data['column_width'] = array('', '', '', '35%', '');
                     break;
             }
 

--- a/src/Infrastructure/Language.php
+++ b/src/Infrastructure/Language.php
@@ -544,7 +544,7 @@ class Language
         $xmlNodes = $xmlLanguageObjects[$languageFilePath]->xpath('/resources/string[@name="'.$textId.'"]');
 
         if ($xmlNodes === false || count($xmlNodes) === 0) {
-            throw new \OutOfBoundsException('Could not found text-id!');
+            throw new \OutOfBoundsException('Could not find text-id!');
         }
 
         // replace square brackets with HTML tags
@@ -573,7 +573,7 @@ class Language
             }
         }
 
-        throw new \OutOfBoundsException('Could not found text-id!');
+        throw new \OutOfBoundsException('Could not find text-id!');
     }
 
     /**

--- a/src/SSO/Entity/UserEntity.php
+++ b/src/SSO/Entity/UserEntity.php
@@ -19,7 +19,7 @@ class UserEntity extends User implements UserEntityInterface, ClaimSetInterface
     /**
      * Create a UserEntity from an Admidio user ID.
      */
-    public function __construct(Database $database, ProfileFields $profileFields = null, ?OIDCClient $client = null, int $userId = 0)
+    public function __construct(Database $database, ?ProfileFields $profileFields = null, ?OIDCClient $client = null, int $userId = 0)
     {
         parent::__construct($database, $profileFields, $userId);
         $this->client = $client;

--- a/src/SSO/Repository/AccessTokenRepository.php
+++ b/src/SSO/Repository/AccessTokenRepository.php
@@ -63,7 +63,7 @@ use Admidio\Infrastructure\Database;
     }
 
     private function getUserClaims(?UserEntityInterface $user): array {
-        return $user instanceof UserEntity ? $user->getClaims() : [];
+        return ($user instanceof \Admidio\SSO\Entity\UserEntity ) ? $user->getClaims() : [];
     }
 
     public function getUserIdByAccessToken(string $accessToken): ?string {

--- a/src/UI/Presenter/PreferencesPresenter.php
+++ b/src/UI/Presenter/PreferencesPresenter.php
@@ -189,7 +189,7 @@ class PreferencesPresenter extends PagePresenter
                         'icon'     => $entry['icon']    ?? 'bi-puzzle',
                         'subcards' => $entry['subcards'] ?? false,
                     ],
-                    \Admidio\Preferences\Service\PreferencesService::getOverviewPluginPanels()
+                    PreferencesService::getOverviewPluginPanels()
                 )
             ),
 
@@ -205,7 +205,7 @@ class PreferencesPresenter extends PagePresenter
                         'icon'     => $entry['icon']    ?? 'bi-puzzle',
                         'subcards' => $entry['subcards'] ?? false,
                     ],
-                    \Admidio\Preferences\Service\PreferencesService::getPluginPanels()
+                    PreferencesService::getPluginPanels()
                 )
             )
         );
@@ -1091,7 +1091,7 @@ class PreferencesPresenter extends PagePresenter
         $formInventory->addCheckbox(
             'inventory_system_field_names_editable',
             $gL10n->get('SYS_INVENTORY_SYSTEM_FIELDNAME_EDIT'),
-            $formValues['inventory_system_field_names_editable'],
+            (bool) $formValues['inventory_system_field_names_editable'],
             array('helpTextId' => 'SYS_INVENTORY_SYSTEM_FIELDNAME_EDIT_DESC')
         );
 
@@ -1099,7 +1099,7 @@ class PreferencesPresenter extends PagePresenter
             $formInventory->addCheckbox(
                 'inventory_allow_keeper_edit',
                 $gL10n->get('SYS_INVENTORY_ACCESS_EDIT'),
-                $formValues['inventory_allow_keeper_edit'],
+                (bool) $formValues['inventory_allow_keeper_edit'],
                 array('helpTextId' => 'SYS_INVENTORY_ACCESS_EDIT_DESC')
             );
 


### PR DESCRIPTION
* events view had missing column widths, leading to broken display in non-complex view mode
* typo in exception message ("Could not found text-id" -> "Could not find text-id", or alternatively "Text-id could not be found")
* Use explicitly nullable types in constructor when null default is given
* UserEntity was accssed without using the namespace or given full namespace path
* removed unneeded namespace prefix in call
* Cast 3rd argument to addCheckbox to book