### PR TITLE
Preserve PNG transparency during image output

### DIFF
--- a/src/Infrastructure/Image.php
+++ b/src/Infrastructure/Image.php
@@ -67,6 +67,7 @@ class Image
                 break;
 
             case IMAGETYPE_PNG:
+                imagesavealpha($imageResource, true);
                 echo imagepng($imageResource);
                 break;
 
@@ -99,6 +100,7 @@ class Image
                 return imagejpeg($imageResource, $pathAndFilename, $quality);
 
             case IMAGETYPE_PNG:
+                imagesavealpha($imageResource, true);
                 return imagepng($imageResource, $pathAndFilename);
 
             default:


### PR DESCRIPTION
## Summary

PNG alpha transparency was lost when images were re-encoded for browser or file output.

This change enables alpha-channel preservation before encoding PNG resources in `Image::copyToBrowser()` and `Image::copyToFile()`.

## Tests

- PHP syntax check
- `git diff --check`
- Browser and file output for fully transparent, partially transparent, and opaque PNG pixels
- JPEG browser and file output
- Scaled and rotated PNG resources
- Manual CKEditor upload and announcement display

Fixes #2084