### PR TITLE
Honor announcement_uuid in announcement card views

### DIFF
--- a/modules/announcements.php
+++ b/modules/announcements.php
@@ -52,7 +52,7 @@ try {
 
     switch ($getMode) {
         case 'cards':
-            $page = new AnnouncementsPresenter($getCategoryUUID);
+            $page = new AnnouncementsPresenter($getCategoryUUID, $getAnnouncementUUID);
             $page->createCards($getOffset);
             $gNavigation->addStartUrl(CURRENT_URL, $page->getHeadline(), 'bi-chat-dots-fill');
             $page->show();

--- a/src/Announcements/Service/AnnouncementsService.php
+++ b/src/Announcements/Service/AnnouncementsService.php
@@ -30,15 +30,21 @@ class AnnouncementsService
      * @var string UUID of the category for which the announcements should be filtered.
      */
     protected string $categoryUUID = '';
+    /**
+     * @var string UUID of the announcement that should be filtered.
+     */
+    protected string $announcementUUID = '';
 
     /**
      * @param Database $database Object of the class Database. This should be the default global object **$gDb**.
      * @param string $categoryUUID UUID of the category for which the announcements should be filtered.
+     * @param string $announcementUUID UUID of the announcement that should be filtered.
      */
-    public function __construct(Database $database, string $categoryUUID = '')
+    public function __construct(Database $database, string $categoryUUID = '', string $announcementUUID = '')
     {
         $this->db = $database;
         $this->categoryUUID = $categoryUUID;
+        $this->announcementUUID = $announcementUUID;
     }
 
     /**
@@ -52,13 +58,22 @@ class AnnouncementsService
 
         $visibleCategoryIDs = array_merge(array(0), $gCurrentUser->getAllVisibleCategories('ANN'));
 
+        $sqlConditions = '';
+        $queryParameters = $visibleCategoryIDs;
+
+        if ($this->announcementUUID !== '') {
+            $sqlConditions .= ' AND ann_uuid = ?';
+            $queryParameters[] = $this->announcementUUID;
+        }
+
         $sql = 'SELECT COUNT(*) AS count
                   FROM ' . TBL_ANNOUNCEMENTS . '
             INNER JOIN ' . TBL_CATEGORIES . '
                     ON cat_id = ann_cat_id
-                 WHERE cat_id IN (' . Database::getQmForValues($visibleCategoryIDs) . ') ';
+                 WHERE cat_id IN (' . Database::getQmForValues($visibleCategoryIDs) . ')
+                       ' . $sqlConditions;
 
-        $pdoStatement = $this->db->queryPrepared($sql, $visibleCategoryIDs);
+        $pdoStatement = $this->db->queryPrepared($sql, $queryParameters);
 
         return (int)$pdoStatement->fetchColumn();
     }
@@ -107,6 +122,11 @@ class AnnouncementsService
         if ($this->categoryUUID !== '') {
             $sqlConditions .= ' AND cat_uuid = ?';
             $sqlQueryParameters[] = $this->categoryUUID;
+        }
+
+        if ($this->announcementUUID !== '') {
+            $sqlConditions .= ' AND ann_uuid = ?';
+            $sqlQueryParameters[] = $this->announcementUUID;
         }
 
         // Check if limit was set

--- a/src/UI/Presenter/AnnouncementsPresenter.php
+++ b/src/UI/Presenter/AnnouncementsPresenter.php
@@ -35,6 +35,10 @@ class AnnouncementsPresenter extends PagePresenter
      */
     protected string $categoryUUID = '';
     /**
+     * @var string UUID of the announcement that should be displayed.
+     */
+    protected string $announcementUUID = '';
+    /**
      * @var CategoryService An object of the class CategoryService to get all categories.
      */
     protected CategoryService $categories;
@@ -50,13 +54,15 @@ class AnnouncementsPresenter extends PagePresenter
     /**
      * Constructor creates the page object and initialized all parameters.
      * @param string $categoryUUID UUID of the category for which the topics should be filtered.
+     * @param string $announcementUUID UUID of the announcement that should be displayed.
      * @throws Exception
      */
-    public function __construct(string $categoryUUID = '')
+    public function __construct(string $categoryUUID = '', string $announcementUUID = '')
     {
         global $gDb;
 
         $this->categoryUUID = $categoryUUID;
+        $this->announcementUUID = $announcementUUID;
         $this->categories = new CategoryService($gDb, 'FOT');
 
         parent::__construct($categoryUUID);
@@ -143,10 +149,17 @@ class AnnouncementsPresenter extends PagePresenter
     {
         global $gL10n, $gSettingsManager, $gDb;
 
-        $baseUrl = SecurityUtils::encodeUrl(ADMIDIO_URL . FOLDER_MODULES . '/announcements.php', array('mode' => 'cards', 'category_uuid' => $this->categoryUUID));
+        $baseUrl = SecurityUtils::encodeUrl(
+            ADMIDIO_URL . FOLDER_MODULES . '/announcements.php',
+            array(
+                'mode' => 'cards',
+                'category_uuid' => $this->categoryUUID,
+                'announcement_uuid' => $this->announcementUUID
+            )
+        );
 
         $this->prepareData($offset);
-        $announcementsService = new AnnouncementsService($gDb, $this->categoryUUID);
+        $announcementsService = new AnnouncementsService($gDb, $this->categoryUUID, $this->announcementUUID);
 
         $this->setHtmlID('adm_announcements_cards');
         $this->createSharedHeader('cards');
@@ -306,7 +319,7 @@ class AnnouncementsPresenter extends PagePresenter
     {
         global $gSettingsManager, $gDb, $gCurrentUser, $gL10n, $gCurrentSession;
 
-        $announcementsService = new AnnouncementsService($gDb, $this->categoryUUID);
+        $announcementsService = new AnnouncementsService($gDb, $this->categoryUUID, $this->announcementUUID);
         $data = $announcementsService->findAll($offset, $gSettingsManager->getInt('announcements_per_page'));
         $announcement = new Announcement($gDb);
 


### PR DESCRIPTION
## Summary

Direct announcement links validate `announcement_uuid`, but the value was not passed to the presenter or query service. As a result, the card view displayed all visible announcements.

This change passes the UUID through the presenter and service, applies it to the count and data queries while retaining the existing category visibility restrictions, and preserves it in pagination URLs.

Detailed technical and user documentation is provided in the `Documentation for review` comment on this pull request.

Fixes #2086