### PR TITLE
Show writable move targets below read-only folders

### DIFF
--- a/src/Documents/Service/DocumentsService.php
+++ b/src/Documents/Service/DocumentsService.php
@@ -230,9 +230,16 @@ class DocumentsService
         while ($row = $filesStatement->fetch()) {
             $folder = new Folder($this->db, $row['fol_id']);
 
-            if ($folder->hasUploadRight()) {
-                $arrAllUploadableFolders[$folder->getValue('fol_uuid')] = $indent . '- ' . $folder->getValue('fol_name');
+            $hasUploadRight = $folder->hasUploadRight();
 
+            if ($hasUploadRight) {
+                $arrAllUploadableFolders[$folder->getValue('fol_uuid')] = $indent . '- ' . $folder->getValue('fol_name');
+            }
+
+            $isVisible = $folder->hasViewRight()
+                || ($folder->getValue('fol_public') && !$folder->getValue('fol_locked'));
+
+            if ($hasUploadRight || $isVisible) {
                 $arrAllUploadableFolders = $this->findFoldersWithUploadRights($row['fol_id'], $arrAllUploadableFolders, $indent . '&nbsp;&nbsp;&nbsp;');
             }
         }
@@ -260,7 +267,12 @@ class DocumentsService
 
         $row = $filesStatement->fetch();
 
-        $arrAllUploadableFolders = array($row['fol_uuid'] => $gL10n->get('SYS_DOCUMENTS_FILES'));
+        $arrAllUploadableFolders = array();
+        $folder = new Folder($this->db, $row['fol_id']);
+
+        if ($folder->hasUploadRight()) {
+            $arrAllUploadableFolders[$row['fol_uuid']] = $gL10n->get('SYS_DOCUMENTS_FILES');
+        }
 
         return $this->findFoldersWithUploadRights($row['fol_id'], $arrAllUploadableFolders);
     }


### PR DESCRIPTION
## Summary

The move dialog stopped traversing a folder branch when the current user had no upload permission for an intermediate folder. Writable descendants were therefore missing from the destination list even when the intermediate folder was visible.

This change separates folder selection from folder traversal:

- only folders with upload permission are selectable,
- visible or writable intermediate folders are traversed,
- hidden branches are not traversed,
- the Documents & Files root is selectable only with upload permission.

The existing server-side upload-right check for the selected destination remains unchanged.

## Tests

- `php -l src/Documents/Service/DocumentsService.php`
- `git diff --check`
- Writable descendants below a visible, non-writable parent are listed.
- File moves to `U_2` and nested folder `U_1_1` succeed.
- A folder with view permission but without upload permission is not selectable.
- The root folder is not selectable without upload permission.
- A branch without effective view or upload permission is not displayed.

## Scope

The pre-existing destination-file collision when selecting the file's current folder is not changed by this pull request and may be handled separately.

Fixes #2095
