### PR TITLE
SSO OIDC: Fix default issuer and endpoint URLs

### DIFF
--- a/languages/de.xml
+++ b/languages/de.xml
@@ -1607,7 +1607,7 @@
   <string name="SYS_SSO_OIDC_ENABLED">Single-Sign-On über OpenId Connect (OIDC) aktivieren</string>
   <string name="SYS_SSO_OIDC_ENABLED_DESC">Diese Einstellung macht Admidio zu einem OIDC-Identitätsanbieter (idP) für Single-Sign-On, der es anderen Webanwendungen ermöglicht, Benutzer:innen gegenüber der Admidio-Benutzerliste zu authentifizieren.</string>
   <string name="SYS_SSO_OIDC_ISSUER_URL">Aussteller</string>
-  <string name="SYS_SSO_OIDC_ISSUER_URL_DESC">Der eindeutige Bezeichner für OIDC dieser Admidio-Instanz. Normalerweise ist dies die Basis-URL deiner Admidio-Installation. Der Client muss mit genau der gleichen Entity-ID eingerichtet werden, sonst funktioniert die Anmeldung nicht.</string>
+  <string name="SYS_SSO_OIDC_ISSUER_URL_DESC">Die Aussteller-URL des OpenID-Connect-Providers. Lassen Sie dieses Feld leer, damit die URL automatisch aus der aktuellen Admidio-URL abgeleitet wird. Geben Sie nur dann eine eigene URL an, wenn der Provider unter einer abweichenden externen Adresse veröffentlicht wird.</string>
   <string name="SYS_SSO_OIDC_JWKS_ENDPOINT">JWKS Endpunkt</string>
   <string name="SYS_SSO_OIDC_LOGOUT_ENDPOINT">Abmelde-Endpunkt</string>
   <string name="SYS_SSO_OIDC_ROLE">OIDC Rollenname</string>

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -1609,7 +1609,7 @@
   <string name="SYS_SSO_OIDC_ENABLED">Enable Single-Sign-On via OpenId Connect (OIDC)</string>
   <string name="SYS_SSO_OIDC_ENABLED_DESC">This setting turns Admidio into a OIDC identity provider (idP) for single-sign-on, which allows other web applications to authenticate users agains the Admidio user list.</string>
   <string name="SYS_SSO_OIDC_ISSUER_URL">Issuer</string>
-  <string name="SYS_SSO_OIDC_ISSUER_URL_DESC">The unique identifier for OIDC of this Admidio instance. Typically this is the base URL of your Admidio installation. The client needs to be set up with the exact same entity ID, otherwise login will not work.</string>
+  <string name="SYS_SSO_OIDC_ISSUER_URL_DESC">The issuer URL of the OpenID Connect provider. Leave this field empty to derive the URL automatically from the current Admidio URL. Enter a custom URL only if the provider is published under a different external address.</string>
   <string name="SYS_SSO_OIDC_JWKS_ENDPOINT">JWKS Endpoint</string>
   <string name="SYS_SSO_OIDC_LOGOUT_ENDPOINT">Logout Endpoint</string>
   <string name="SYS_SSO_OIDC_ROLE">OIDC role name</string>

--- a/src/Preferences/Service/PreferencesService.php
+++ b/src/Preferences/Service/PreferencesService.php
@@ -10,6 +10,7 @@ use Admidio\Infrastructure\Entity\Text;
 use Admidio\Infrastructure\Email;
 use Admidio\Infrastructure\Plugins\PluginManager;
 use Admidio\Infrastructure\Language;
+use Admidio\SSO\Service\OIDCService;
 
 /**
  * @brief Class with methods to display the module pages.
@@ -374,13 +375,21 @@ class PreferencesService
                 }
                 break;
 
-            case 'sso':
-                if (empty($formData['sso_oidc_issuer_url'])) {
-                    $formValues['sso_oidc_issuer_url'] = ADMIDIO_URL . FOLDER_MODULES . '/sso/index.php/oidc';
+            case 'sso': 
+                // empty issuerURL means "Use the default URL from the admidio installation's URL"
+                $issuerURL = trim((string)($formValues['sso_oidc_issuer_url'] ?? ''));
+
+                if ($issuerURL !== '') {
+                    $issuerURL = rtrim($issuerURL, '/');
                 }
-                if (str_ends_with($formValues['sso_oidc_issuer_url'], '/')) {
-                    $formValues['sso_oidc_issuer_url'] = substr($formValues['sso_oidc_issuer_url'], 0, -1);
+
+                // Do not persist the installation-derived default. An empty setting
+                // allows the issuer URL to follow later changes to ADMIDIO_URL.
+                if ($issuerURL === OIDCService::getDefaultIssuerURL()) {
+                    $issuerURL = '';
                 }
+
+                $formValues['sso_oidc_issuer_url'] = $issuerURL;
                 break;
         }
 

--- a/src/SSO/Entity/IdTokenResponse.php
+++ b/src/SSO/Entity/IdTokenResponse.php
@@ -26,13 +26,16 @@ use OpenIDConnectServer\ClaimExtractor;
 class IdTokenResponse extends \OpenIDConnectServer\IdTokenResponse
 {
     protected ?string $nonce;
+    private string $issuerURL;
 
     public function __construct(
         IdentityProviderInterface $identityProvider,
         ClaimExtractor $claimExtractor,
+        string $issuerURL,
         ?string $keyIdentifier = null
     ) {
         parent::__construct($identityProvider, $claimExtractor, $keyIdentifier);
+        $this->issuerURL = $issuerURL;
     }
     /**
      * @param AccessTokenEntityInterface $accessToken
@@ -55,16 +58,15 @@ class IdTokenResponse extends \OpenIDConnectServer\IdTokenResponse
     // (https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery)
     // The issuer is the URL of the OpenID Provider (OP) that issued the ID token.
     // The OIDC library sets the issuer to the server name only ('https://' . $_SERVER['HTTP_HOST'),
-    // so we need to correct this here!
+    // so we need to override the correct issuerURL here!
 
     protected function getBuilder(AccessTokenEntityInterface $accessToken, UserEntityInterface $userEntity)
     {
-        global $gSettingsManager;
         $builder = parent::getBuilder($accessToken, $userEntity);
         if (!empty($this->nonce)) {
             $builder = $builder->withClaim('nonce', $this->nonce);
         }
-        return $builder->issuedBy( $gSettingsManager->get('sso_oidc_issuer_url'));
+        return $builder->issuedBy($this->issuerURL);
     }
 
     public function getNonce(): string|null {   

--- a/src/SSO/Service/OIDCService.php
+++ b/src/SSO/Service/OIDCService.php
@@ -86,6 +86,15 @@ class OIDCService extends SSOService {
 
     private bool $isServiceSetup = false;
 
+    /**
+     * Return the default issuer URL derived from the current Admidio URL.
+     * @return string
+     */
+    public static function getDefaultIssuerURL(): string
+    {
+        return ADMIDIO_URL . FOLDER_MODULES . '/sso/index.php/oidc';
+    }
+
     public function __construct($db, $currentUser) {//, ResourceServer $resourceServer) {
         global $gSettingsManager;
 
@@ -94,11 +103,15 @@ class OIDCService extends SSOService {
         $this->table = TBL_OIDC_CLIENTS;
 
         // Attention: IssuerURL must be the base URL, where ./well-known/openid-configuration is located!
-        $this->issuerURL = $gSettingsManager->get('sso_oidc_issuer_url') ?: ADMIDIO_URL;
-        if (empty($this->issuerURL)) {
-            $this->issuerURL = ADMIDIO_URL . FOLDER_MODULES . '/sso/index.php/oidc';
-            $gSettingsManager->set('sso_oidc_issuer_url', $this->issuerURL);
+        $configuredIssuerURL = trim((string)$gSettingsManager->get('sso_oidc_issuer_url'));
+
+        // empty stored issuer URL means "Use the default admidio URL", which will continue working when the installation is moved
+        if ($configuredIssuerURL === '') {
+            $this->issuerURL = self::getDefaultIssuerURL();
+        } else {
+            $this->issuerURL = rtrim($configuredIssuerURL, '/');
         }
+
         $this->authorizationEndpoint = $this->issuerURL  . "/authorize";
         $this->tokenEndpoint = $this->issuerURL . "/token";
         $this->userinfoEndpoint = $this->issuerURL . "/userinfo";
@@ -251,7 +264,12 @@ class OIDCService extends SSOService {
             // new ClaimSetEntity('openid', ['sub']),
             new ClaimSetEntity('groups', ['groups'])
         ]);
-        $responseType = new IdTokenResponse($userRepository, $claimsExtractor, $privateKeyObject->getValue('key_uuid'));
+        $responseType = new IdTokenResponse(
+            $userRepository,
+            $claimsExtractor,
+            $this->issuerURL,
+            $privateKeyObject->getValue('key_uuid')
+        );
 
         // Keep references to the relevant objects for later use
         $this->accessTokenRepository = $accessTokenRepository;

--- a/src/UI/Presenter/PreferencesPresenter.php
+++ b/src/UI/Presenter/PreferencesPresenter.php
@@ -13,6 +13,7 @@ use Admidio\Infrastructure\Utils\SystemInfoUtils;
 use Admidio\Inventory\ValueObjects\ItemsData;
 use Admidio\Preferences\Service\PreferencesService;
 use Admidio\SSO\Service\KeyService;
+use Admidio\SSO\Service\OIDCService;
 
 use Admidio\Infrastructure\Plugins\PluginManager;
 
@@ -2381,17 +2382,17 @@ class PreferencesPresenter extends PagePresenter
             array('helpTextId' => 'SYS_SSO_OIDC_ENABLED_DESC')
         );
 
-        if (empty($formValues['sso_oidc_issuer_url'])) {
-            $formValues['sso_oidc_issuer_url'] = ADMIDIO_URL . FOLDER_MODULES . '/sso/index.php/oidc';
-        }
-        if (str_ends_with($formValues['sso_oidc_issuer_url'], '/')) {
-            $formValues['sso_oidc_issuer_url'] = substr($formValues['sso_oidc_issuer_url'], 0, -1);
-        }
+        // An empty IssuerURL indicates the use of the default admidio base URL
+        // Leave the input box exmpty, but show the default value as 
+        // placeholder/hint and copy that value when the copy icon is clicked!
+        $defaultIssuerURL = OIDCService::getDefaultIssuerURL();
         $formSSO->addInput(
             'sso_oidc_issuer_url',
             $gL10n->get('SYS_SSO_OIDC_ISSUER_URL'),
             (string)$formValues['sso_oidc_issuer_url'],
-            array('class' => 'copy-container if-oidc-enabled', 'helpTextId' => 'SYS_SSO_OIDC_ISSUER_URL_DESC')
+            array('class' => 'copy-container if-oidc-enabled', 
+                  'placeholder' => $defaultIssuerURL,
+                  'helpTextId' => 'SYS_SSO_OIDC_ISSUER_URL_DESC')
         );
 
         $keyService = new KeyService($gDb);

--- a/themes/simple/templates/preferences/preferences.sso.tpl
+++ b/themes/simple/templates/preferences/preferences.sso.tpl
@@ -42,6 +42,10 @@
             // Determine how to get the value based on the element type
             if ($element.is("input, textarea, select")) {
                 textToCopy = $element.val(); // Get value for form elements
+                // Input fields with empty value, but a placeholder set, will copy the placeholder text rather than the empty string
+                if (textToCopy === "" && $element.is("input, textarea")) {
+                    textToCopy = $element.attr("placeholder") || "";
+                }
             } else {
                 textToCopy = $element.text().trim(); // Get text for divs or spans
             }


### PR DESCRIPTION
Derive the default OIDC issuer from the complete SSO route instead of falling back to the Admidio base URL. This restores the missing /oidc path in discovery, authorization, token, UserInfo and JWKS URLs.

When the default value is not changed, instead of storing the default value in the database, store an empty string and let the OIDCService class interpret empty issuer URLs as default value. When an installation is moved to a different (sub)domain, the admidio OIDC-part will adjust accordingly.

In the OIDC settings, display the resolved issuer in the SSO settings as a placeholder text if the input field is empty, but avoid persisting the default so that later changes to the Admidio base URL are reflected automatically.

Preserve explicitly configured issuer URLs and normalize trailing slashes. This is only an issue for OIDC (where actual URLs are configured), and must NOT be applied for SAML (where the entity ID is really a unique identifier and not a URL).

To show the placeholder text and also copy it with the copy icon next to the input field, the JS handler is extended accordingly. This functionality can be used in any input field by simply adding the 'placeholder' property when the 'copy-container' css class is assigned.

Fixes #2078 and #2079