### PR TITLE
In install/update.php we also need the global $gHtmlPurifierFilter

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -77,6 +77,14 @@ try {
 
     require_once($rootPath . '/system/bootstrap/bootstrap.php');
 
+    // check HTML string for invalid tags and scripts
+    $gHtmlPurifierConfig = HTMLPurifier_Config::createDefault();
+    $gHtmlPurifierConfig->set('HTML.Doctype', 'HTML 4.01 Transitional');
+    $gHtmlPurifierConfig->set('Attr.AllowedFrameTargets', array('_blank', '_top', '_self', '_parent'));
+    $gHtmlPurifierConfig->set('Cache.SerializerPath', ADMIDIO_PATH . FOLDER_DATA . '/templates');
+    $gHtmlPurifierFilter = new HTMLPurifier($gHtmlPurifierConfig);
+
+
     // Initialize and check the parameters
 
     $getMode = admFuncVariableIsValid($_GET, 'mode', 'string', array('defaultValue' => 'dialog', 'validValues' => array('dialog', 'update', 'result')));

--- a/system/common.php
+++ b/system/common.php
@@ -63,7 +63,7 @@ try {
     exit();
 }
 
-// check HTML string vor invalid tags and scripts
+// check HTML string for invalid tags and scripts
 $gHtmlPurifierConfig = HTMLPurifier_Config::createDefault();
 $gHtmlPurifierConfig->set('HTML.Doctype', 'HTML 4.01 Transitional');
 $gHtmlPurifierConfig->set('Attr.AllowedFrameTargets', array('_blank', '_top', '_self', '_parent'));


### PR DESCRIPTION
Globals defined in common.php must also be copied to install/update.php if they are used there. The html purifier is used by the exception handler, so we need to add it!