### PR TITLE
Allow custom language translation overrides

### DIFF
--- a/src/Infrastructure/Language.php
+++ b/src/Infrastructure/Language.php
@@ -85,6 +85,12 @@ class Language
             $this->setLanguage($language);
         }
 
+        $customLanguageFolderPath = ADMIDIO_PATH . FOLDER_DATA . FOLDER_LANGUAGES;
+
+        if (is_dir($customLanguageFolderPath)) {
+            $this->addLanguageFolderPath($customLanguageFolderPath);
+        }
+
         $this->addLanguageFolderPath(ADMIDIO_PATH . FOLDER_LANGUAGES);
 
         $this->addPluginLanguageFolderPaths();


### PR DESCRIPTION
Load language files from adm_my_files/languages before the bundled and plugin language directories. This allows installations to override selected translations in a language-specific XML file without modifying Admidio core files.

Existing fallback behavior remains unchanged for translation IDs that are not defined in the custom language file.

Fixes #421