### PR TITLE
Add generic maintenance mode support

### DIFF
--- a/src/Infrastructure/Utils/MaintenanceMode.php
+++ b/src/Infrastructure/Utils/MaintenanceMode.php
@@ -1,0 +1,197 @@
+<?php
+namespace Admidio\Infrastructure\Utils;
+
+/**
+ * @brief Class to enable and disable a generic application-wide maintenance mode.
+ *
+ * The maintenance state is stored in adm_my_files/maintenance.json so that it can
+ * be evaluated by the early bootstrap before the Composer autoloader or any database
+ * connection is initialized.
+ * 
+ * NOTE: All methods in this class MUST WORK WITHOUT A DB CONNECTION OR OTHER ADMIDIO CLASSES LODADED!
+ *       Also, no SESSION might be available (when called through the CLI)
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+final class MaintenanceMode
+{
+    private const DEFAULT_TITLE = 'Maintenance';
+    private const DEFAULT_MESSAGE = 'This Admidio installation is currently in maintenance mode. Please try again later.';
+    private const STATE_FILE = 'maintenance.json';
+
+    /**
+     * Enables maintenance mode.
+     *
+     * @param string $title          Title that is shown while maintenance mode is active
+     * @param string $message        Message that is shown while maintenance mode is active
+     * @param array<int,string> $allowedScripts Relative script paths that may still be executed
+     * @param int $retryAfter        Number of seconds a client should wait before retrying
+     * @param string $owner          Optional identifier of the operation that owns maintenance mode
+     * @throws \JsonException
+     * @throws \RuntimeException
+     * @throws \UnexpectedValueException
+     */
+    public static function enable(string $title = self::DEFAULT_TITLE, string $message = self::DEFAULT_MESSAGE,
+            array $allowedScripts = array(), int $retryAfter = 120, string $owner = ''
+    ): void {
+        if ($title === '') {
+            $title = self::DEFAULT_TITLE;
+        }
+
+        if ($message === '') {
+            $message = self::DEFAULT_MESSAGE;
+        }
+
+        if ($retryAfter < 1) {
+            throw new \UnexpectedValueException('Maintenance mode retry interval must be greater than zero.');
+        }
+
+        $normalizedAllowedScripts = array();
+        foreach ($allowedScripts as $script) {
+            $normalizedAllowedScripts[] = self::normalizeScriptPath($script);
+        }
+        $normalizedAllowedScripts = array_values(array_unique($normalizedAllowedScripts));
+
+        $currentState = self::getState();
+        if ($currentState !== null) {
+            $currentOwner = (string) ($currentState['owner'] ?? '');
+
+            if ($currentOwner !== $owner) {
+                throw new \RuntimeException('Maintenance mode is already enabled by another operation.');
+            }
+
+            return;
+        }
+
+        $state = array(
+            'schema' => 1,
+            'owner' => $owner,
+            'startedAt' => time(),
+            'retryAfter' => $retryAfter,
+            'title' => $title,
+            'message' => $message,
+            'allowedScripts' => $normalizedAllowedScripts
+        );
+
+        $stateDirectory = ADMIDIO_PATH . FOLDER_DATA;
+        FileSystemUtils::createDirectoryIfNotExists($stateDirectory);
+
+        $json = json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $temporaryFile = tempnam($stateDirectory, '.maintenance-');
+
+        if ($temporaryFile === false) {
+            throw new \RuntimeException('Temporary maintenance mode state could not be created.');
+        }
+
+        try {
+            $bytes = file_put_contents($temporaryFile, $json . PHP_EOL, LOCK_EX);
+
+            if ($bytes === false || !rename($temporaryFile, self::getStateFilePath())) {
+                throw new \RuntimeException('Maintenance mode state could not be written.');
+            }
+        } finally {
+            if (is_file($temporaryFile)) {
+                unlink($temporaryFile);
+            }
+        }
+    }
+
+    /**
+     * Disables maintenance mode.
+     *
+     * If an owner is given, the state is only removed if the owner matches the operation that
+     * enabled maintenance mode.
+     *
+     * @param string $owner Optional identifier of the operation that owns maintenance mode
+     * @return bool Returns true if maintenance mode was disabled or false if it was not enabled
+     * @throws \JsonException
+     * @throws \RuntimeException
+     */
+    public static function disable(string $owner = ''): bool
+    {
+        if (!self::isEnabled()) {
+            return false;
+        }
+
+        if ($owner !== '') {
+            $state = self::getState();
+
+            if ($state === null || (string) ($state['owner'] ?? '') !== $owner) {
+                throw new \RuntimeException('Maintenance mode is owned by another operation.');
+            }
+        }
+
+        if (!unlink(self::getStateFilePath())) {
+            throw new \RuntimeException('Maintenance mode state could not be removed.');
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns whether maintenance mode is enabled.
+     */
+    public static function isEnabled(): bool
+    {
+        return is_file(self::getStateFilePath());
+    }
+
+    /**
+     * Returns the current maintenance state.
+     *
+     * @return array<string,mixed>|null
+     * @throws \JsonException
+     * @throws \RuntimeException
+     */
+    public static function getState(): ?array
+    {
+        $stateFile = self::getStateFilePath();
+
+        if (!is_file($stateFile)) {
+            return null;
+        }
+
+        $json = file_get_contents($stateFile);
+        if ($json === false) {
+            throw new \RuntimeException('Maintenance mode state could not be read.');
+        }
+
+        $state = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($state)) {
+            throw new \RuntimeException('Maintenance mode state is invalid.');
+        }
+
+        return $state;
+    }
+
+    /**
+     * Returns the absolute path of the maintenance state file.
+     */
+    private static function getStateFilePath(): string
+    {
+        return ADMIDIO_PATH . FOLDER_DATA . '/' . self::STATE_FILE;
+    }
+
+    /**
+     * Normalizes and validates a script path that may bypass maintenance mode.
+     *
+     * @throws \UnexpectedValueException
+     */
+    private static function normalizeScriptPath(string $script): string
+    {
+        $script = ltrim(str_replace('\\', '/', trim($script)), '/');
+
+        if (
+            $script === ''
+            || str_contains($script, "\0")
+            || preg_match('#(^|/)\.\.(/|$)#', $script) === 1
+        ) {
+            throw new \UnexpectedValueException('Invalid maintenance mode script path.');
+        }
+
+        return $script;
+    }
+}

--- a/system/bootstrap/bootstrap.php
+++ b/system/bootstrap/bootstrap.php
@@ -39,6 +39,70 @@ if (version_compare(PHP_VERSION, MIN_PHP_VERSION, '<')) {
         the minimum requirements for this Admidio version. You need at least PHP ' . MIN_PHP_VERSION . ' or higher.</div>');
 }
 
+// Check maintenance mode before loading the autoloader or other application files.
+// The maintenance.json file optionally contains a list of allowed script filenames that are still executed.
+// This keeps maintenance mode active even if core files are temporarily unavailable or inconsistent.
+$maintenanceFile = ADMIDIO_PATH . FOLDER_DATA . '/maintenance.json';
+
+if (is_file($maintenanceFile)) {
+    $maintenanceJson = file_get_contents($maintenanceFile);
+    $maintenanceState = is_string($maintenanceJson) ? json_decode($maintenanceJson, true) : null;
+
+    $currentScript = realpath($_SERVER['SCRIPT_FILENAME']);
+    if ($currentScript === false) {
+        $currentScript = $_SERVER['SCRIPT_FILENAME'];
+    }
+
+    $currentScript = str_replace('\\', '/', $currentScript);
+    $admidioPath = rtrim(str_replace('\\', '/', ADMIDIO_PATH), '/');
+    $relativeScript = '';
+
+    if (str_starts_with($currentScript, $admidioPath . '/')) {
+        $relativeScript = substr($currentScript, strlen($admidioPath) + 1);
+    }
+
+    $allowedScripts = is_array($maintenanceState)
+        && isset($maintenanceState['allowedScripts'])
+        && is_array($maintenanceState['allowedScripts'])
+        ? $maintenanceState['allowedScripts']
+        : array();
+
+    if (!in_array($relativeScript, $allowedScripts, true)) {
+        $retryAfter = is_array($maintenanceState) && isset($maintenanceState['retryAfter'])
+            ? max(1, (int) $maintenanceState['retryAfter'])
+            : 120;
+        $title = is_array($maintenanceState) && isset($maintenanceState['title']) && is_string($maintenanceState['title'])
+            ? $maintenanceState['title']
+            : 'Maintenance';
+        $message = is_array($maintenanceState) && isset($maintenanceState['message']) && is_string($maintenanceState['message'])
+            ? $maintenanceState['message']
+            : 'This Admidio installation is currently in maintenance mode. Please try again later.';
+
+        http_response_code(503);
+        header('Retry-After: ' . $retryAfter);
+        header('Cache-Control: no-store, no-cache, must-revalidate');
+
+        $title = htmlspecialchars($title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $message = htmlspecialchars($message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        exit('<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex,nofollow">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>' . $title . '</title>
+</head>
+<body>
+    <main style="max-width: 48rem; margin: 10vh auto; padding: 2rem; font-family: sans-serif;">
+        <h1>' . $title . '</h1>
+        <p style="white-space: pre-line;">' . $message . '</p>
+    </main>
+</body>
+</html>');
+    }
+}
+
 /**
  * includes WITHOUT database connections
  */


### PR DESCRIPTION
## Summary

Adds a generic maintenance mode for Admidio.

Maintenance mode is persisted in:

```text
adm_my_files/maintenance.json
```

Normal requests are blocked early in `system/bootstrap/bootstrap.php` with HTTP 503, while explicitly allowed scripts can continue to run.

## Usage

```php
MaintenanceMode::enable(
    'Admidio update',
    'A new Admidio version is currently being installed.',
    array(
        'install/core-update/index.php',
        'install/update.php'
    ),
    120,
    'core-update:7f3c8a9e4d1b'
);
```

Disable it with:

```php
MaintenanceMode::disable('core-update:7f3c8a9e4d1b');
```

`title` and `message` are optional and use default values if omitted.

## Example `maintenance.json`

```json
{
  "schema": 1,
  "owner": "core-update:7f3c8a9e4d1b",
  "startedAt": 1786392000,
  "retryAfter": 120,
  "title": "Admidio update",
  "message": "A new Admidio version is currently being installed.",
  "allowedScripts": [
    "install/core-update/index.php",
    "install/update.php"
  ]
}
```

## Notes

* Maintenance mode is checked before the normal Admidio runtime is loaded.
* State changes are written atomically.
* The optional `owner` prevents unrelated processes from disabling maintenance mode.
* The implementation is generic and can be reused by core updates, database maintenance, or other exclusive maintenance operations.
* 

Enabling/disabling maintenance mode is done by calling MaintenanceMode::enable(...) and MaintenanceMode::disable(). For now, the maintenance mode is not yet used, but will be used in an upcoming PR for the automatic core updater and it will be manually enabled/disabled using a CLI utility for admidio.

This implements part of #317. There is no scheduler in admidio, so in-advance warnings or even scheduling maintenance mode at some future time is not possible.

To test the patch, I'll attach a small helper script ./maintenance_test.php to be placed in the admidio directory. It will enable/disable maintenance mode for testing. It is also an example of a script that is allowed for execution despite maintenance mode being
[maintenance_test.php](https://github.com/user-attachments/files/30931537/maintenance_test.php)
 on.