### PR TITLE
Form, inventory and update script fixes, plus runtime preference defaults

### DIFF
--- a/install/db_scripts/update_5_1.xml
+++ b/install/db_scripts/update_5_1.xml
@@ -29,9 +29,9 @@
     <step id="260">UPDATE %PREFIX%_preferences SET prf_value = '#a7d9e0' WHERE prf_name = 'color_secondary' AND prf_value = '#263340'</step>
     <step id="270" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'color_primary' AND pr2.prf_org_id = pr1.prf_org_id SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'theme_color_primary'</step>
     <step id="280" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'color_primary' AND pr2.prf_org_id = pr1.prf_org_id AND pr1.prf_name = 'theme_color_primary'</step>
-    <step id="290">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'color_primary'</step>
-    <step id="280" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'color_secondary' AND pr2.prf_org_id = pr1.prf_org_id SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'theme_color_secondary'</step>
-    <step id="290" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'color_secondary' AND pr2.prf_org_id = pr1.prf_org_id AND pr1.prf_name = 'theme_color_secondary'</step>
+    <step id="281">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'color_primary'</step>
+    <step id="290" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'color_secondary' AND pr2.prf_org_id = pr1.prf_org_id SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'theme_color_secondary'</step>
+    <step id="291" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'color_secondary' AND pr2.prf_org_id = pr1.prf_org_id AND pr1.prf_name = 'theme_color_secondary'</step>
     <step id="300">DELETE FROM %PREFIX%_preferences WHERE prf_name = 'color_secondary'</step>
     <step id="310" database="mysql">UPDATE %PREFIX%_preferences pr1 INNER JOIN %PREFIX%_preferences pr2 ON pr2.prf_name = 'logo_file' AND pr2.prf_org_id = pr1.prf_org_id SET pr1.prf_value = pr2.prf_value WHERE pr1.prf_name = 'theme_logo_file'</step>
     <step id="320" database="pgsql">UPDATE %PREFIX%_preferences pr1 SET prf_value = pr2.prf_value FROM %PREFIX%_preferences pr2 WHERE pr2.prf_name = 'logo_file' AND pr2.prf_org_id = pr1.prf_org_id AND pr1.prf_name = 'theme_logo_file'</step>

--- a/src/Infrastructure/Plugins/PluginAbstract.php
+++ b/src/Infrastructure/Plugins/PluginAbstract.php
@@ -3,6 +3,7 @@
 namespace Admidio\Infrastructure\Plugins;
 
 use Admidio\Preferences\Service\PreferencesService;
+use Admidio\Preferences\ValueObject\SettingsManager;
 use Admidio\Components\Entity\Component;
 use Admidio\Components\Entity\ComponentUpdate;
 use Admidio\Menu\Entity\MenuEntry;
@@ -216,7 +217,39 @@ abstract class PluginAbstract implements PluginInterface
             self::$dependencies = $configData['dependencies'] ?? array();
             self::$defaultConfig = $configData['defaultConfig'] ?? array();
             self::$metadata = $configData;
+
+            self::registerDefaultConfig();
         }
+    }
+
+    /**
+     * Make the default values of the plugin known to the settings manager. The preferences of a
+     * plugin have no row in adm_preferences until they are saved for the first time, so without
+     * this registration the rest of Admidio would not see them at all: a plugin cannot add its
+     * preferences to install/db_scripts/preferences.php.
+     *
+     * @return void
+     * @throws Exception
+     */
+    private static function registerDefaultConfig(): void
+    {
+        $defaults = array();
+
+        foreach (self::$defaultConfig as $key => $configuration) {
+            if (!array_key_exists('value', $configuration)) {
+                continue;
+            }
+
+            $value = $configuration['value'];
+            // Preferences are stored as strings, so a boolean default has to be converted the same
+            // way SettingsManager::set() would store it.
+            if (is_bool($value)) {
+                $value = $value ? '1' : '0';
+            }
+            $defaults[$key] = $value;
+        }
+
+        SettingsManager::registerDefaults($defaults);
     }
 
     /**

--- a/src/Inventory/Service/ItemService.php
+++ b/src/Inventory/Service/ItemService.php
@@ -197,10 +197,12 @@ class ItemService
                         // Write value from field to the item class object
                         $this->itemRessource->setValue($infNameIntern, $formValues[$postKey]);
                     }
-                } elseif ($itemField->getValue('inf_type') === 'CHECKBOX' && !$multiEdit) {
-                    // Set value to '0' for unchecked checkboxes
-                    $this->itemRessource->setValue($itemField->getValue('inf_name_intern'), '0');
                 }
+                // NOTE: Unchecked checkboxes must NOT be set to '0' here. A field that is missing
+                // in the form values was not part of the submitted form at all - the borrow form
+                // for example only contains the borrow fields - and its value must stay unchanged.
+                // FormPresenter::validate() already adds the value '0' for every checkbox that
+                // belongs to the submitted form and was not checked by the user.
             }
 
             // save item data

--- a/src/Inventory/ValueObjects/ItemsData.php
+++ b/src/Inventory/ValueObjects/ItemsData.php
@@ -223,7 +223,9 @@ class ItemsData
 
             while ($row = $itemDataStatement->fetch()) {
                 if (!array_key_exists($row['ind_inf_id'], $this->mItemData)) {
-                    $this->mItemData[$row['ind_inf_id']] = new ItemData($this->mDb, $this, $row['ind_inf_id']);
+                    // The entities are indexed by the item field, but they are loaded by their own
+                    // key column ind_id. Passing ind_inf_id here reads an unrelated data row.
+                    $this->mItemData[$row['ind_inf_id']] = new ItemData($this->mDb, $this, (int)$row['ind_id']);
                 }
                 $this->mItemData[$row['ind_inf_id']]->setArray($row);
             }
@@ -238,15 +240,20 @@ class ItemsData
 
             while ($row = $itemBorrowStatement->fetch()) {
                 foreach ($this->getItemFields() as $itemField) {
-                    $itemBorrowData = new ItemBorrowData($this->mDb, $this, $row['inb_ini_id']);
                     $fieldNameIntern = $itemField->getValue('inf_name_intern');
-                    $fieldId = $itemField->getValue('inf_id');
-                    if (in_array($fieldNameIntern, $this->borrowFieldNames)) {
-                        if (!array_key_exists($fieldId, $this->mItemData)) {
-                            $this->mItemData[$fieldId] = $itemBorrowData;
-                        }
-                        $this->mItemData[$fieldId]->setArray($row);
+                    if (!in_array($fieldNameIntern, $this->borrowFieldNames)) {
+                        continue;
                     }
+                    $fieldId = $itemField->getValue('inf_id');
+                    if (!array_key_exists($fieldId, $this->mItemData)) {
+                        // Same as above: the entity is loaded by its own key column inb_id.
+                        // inb_ini_id is the item the borrow data belongs to and would read an
+                        // unrelated row. The object is only built for the borrow fields and only
+                        // when it is really needed, because the constructor clones this object
+                        // and reads from the database.
+                        $this->mItemData[$fieldId] = new ItemBorrowData($this->mDb, $this, (int)$row['inb_id']);
+                    }
+                    $this->mItemData[$fieldId]->setArray($row);
                 }
             }
         } else {

--- a/src/Preferences/ValueObject/SettingsManager.php
+++ b/src/Preferences/ValueObject/SettingsManager.php
@@ -38,6 +38,53 @@ class SettingsManager
     private bool $throwExceptions = true;
 
     /**
+     * @var array<string,string> Default values of preferences that were registered at runtime by a
+     *      module or a plugin instead of being seeded from install/db_scripts/preferences.php.
+     *      The list is static and is therefore not part of the settings that are stored in the
+     *      session, so it has to be built again in every request. That is intentional: the defaults
+     *      of a plugin that is no longer active must not survive its deactivation.
+     */
+    private static array $registeredDefaults = array();
+
+    /**
+     * Register the default values of preferences that do not come from the preferences.php of the
+     * installation. A preference that is registered here behaves like any other preference, but it
+     * needs no row in adm_preferences and therefore no installation and no update step: as long as
+     * it was never saved, reading it returns the registered default. The row is written by the
+     * usual set() as soon as the value is really changed.
+     *
+     * This is what allows a module or a plugin to add a preference of its own. Register the
+     * defaults in every request, before the preference is read for the first time.
+     *
+     * @param array<string,mixed> $defaults Named array of preference name => default value
+     * @return void
+     * @throws Exception
+     */
+    public static function registerDefaults(array $defaults): void
+    {
+        foreach ($defaults as $name => $value) {
+            if (!self::isValidName($name)) {
+                throw new Exception('Settings name "' . $name . '" is an invalid string!');
+            }
+
+            // if an array is given as value, convert it to a string, just like set() does
+            if (is_array($value)) {
+                foreach ($value as $entry) {
+                    if (!self::isValidValue($entry)) {
+                        throw new Exception('Settings value of "' . $name . '" is an invalid value!');
+                    }
+                }
+                $value = implode(',', $value);
+            }
+            if (!self::isValidValue($value)) {
+                throw new Exception('Settings value "' . $value . '" is an invalid value!');
+            }
+
+            self::$registeredDefaults[$name] = (string)$value;
+        }
+    }
+
+    /**
      * SettingsManager constructor.
      * @param Database $database
      * @param int $orgId
@@ -129,7 +176,9 @@ class SettingsManager
             $this->resetAll();
         }
 
-        return $this->settings;
+        // The stored values win over the registered defaults of the modules and plugins, which are
+        // only used for the preferences that were never saved.
+        return array_merge(self::$registeredDefaults, $this->settings);
     }
 
     /**
@@ -146,6 +195,12 @@ class SettingsManager
         }
         if (!$this->has($name, $update) && $this->throwExceptions) {
             throw new Exception('Settings name "' . $name . '" does not exist!');
+        }
+
+        // A preference that was registered by a module or a plugin and was never saved has no row
+        // in the database and falls back to its registered default.
+        if (!array_key_exists($name, $this->settings)) {
+            return (string)(self::$registeredDefaults[$name] ?? '');
         }
 
         return (string)$this->settings[$name];
@@ -239,7 +294,9 @@ class SettingsManager
 
                 return true;
             } catch (\UnexpectedValueException $e) {
-                return false;
+                // The preference has no row in the database, but it exists if a module or a
+                // plugin has registered a default value for it.
+                return array_key_exists($name, self::$registeredDefaults);
             }
         }
 

--- a/src/UI/Presenter/FormPresenter.php
+++ b/src/UI/Presenter/FormPresenter.php
@@ -2177,10 +2177,13 @@ class FormPresenter
                     throw new Exception('SYS_FIELD_EMPTY', array($element['label']));
                 }
             } elseif (isset($element['property']) && $element['property'] === $this::FIELD_DISABLED) {
-                // no value should be set if a field is marked as disabled
-                if (isset($fieldValues[$element['id']])) {
-                    unset($fieldValues[$element['id']]);
-                }
+                // No value should be set if a field is marked as disabled. The browser does not
+                // submit a disabled control at all, so there is nothing the user could have
+                // entered. Continue with the next element instead of only dropping the value:
+                // the checkbox default below would otherwise store '0' for a disabled checkbox
+                // and thereby clear a value the user was never able to change.
+                unset($fieldValues[$element['id']]);
+                continue;
             }
 
             // if element is a checkbox than add entry to $fieldValues if checkbox is unchecked


### PR DESCRIPTION
## Summary

Four bug fixes and one small addition to the preferences, all found while working on a
larger change history branch. They are independent of that work and of each other, so
they are submitted separately to keep them reviewable.

## Fixes

### Forms: a disabled checkbox was always saved as unchecked

`FormPresenter::validate()` removed the submitted value of a field marked
`FIELD_DISABLED` and then fell through to the checkbox default, which stores `'0'` for
every checkbox that has no value. A checkbox rendered read-only was therefore cleared on
every save, even though the user was never able to change it. The disabled branch now
skips the element entirely.

### Inventory: borrowing an item cleared its other checkboxes

`ItemService::save()` set every `CHECKBOX` item field that was missing from the form
values to `'0'`, on the assumption that a missing value means the user unticked the box.
That only holds for fields the submitted form actually rendered. The borrow form contains
just the three borrow fields, so checking an item out or returning it cleared every other
checkbox of that item. `FormPresenter::validate()` already adds `'0'` for every unchecked
checkbox that really belongs to the submitted form, so the extra handling is removed.

### Inventory: item data entities were loaded from the wrong row

`ItemsData::readItemData()` constructed `ItemData` with `ind_inf_id` and `ItemBorrowData`
with `inb_ini_id`, but both entities load by their own key column (`ind_id` / `inb_id`).
Every entity was therefore first read from an unrelated row before being overwritten with
`setArray()`. The borrow data objects are now also built only for the borrow fields
instead of once per item field, which avoids constructing objects that are thrown away.

### Update: duplicate step IDs in update_5_1.xml

The theme colour migration uses the ids 280 and 290 twice each. Because the update runs
steps by id, the duplicates can be skipped. They are renumbered to 281 and 291, which
deliberately breaks the usual step size of 10 so that the surrounding ids stay untouched.

## Addition

### Preferences: modules and plugins can register their own defaults

`SettingsManager::registerDefaults()` lets code declare a preference together with its
default value at runtime. Such a preference behaves like any other, but it needs no entry
in `install/db_scripts/preferences.php`, no row in `adm_preferences` and no update step:
as long as it was never saved, reading it returns the registered default, and the row is
written by the usual `set()` when the value is actually changed.

This is what allows a plugin to have preferences of its own — it cannot add them to
`preferences.php`. `PluginAbstract` now registers the `defaultConfig` of every plugin,
converting boolean defaults the same way `set()` would store them.

The registered defaults are static and are rebuilt in every request rather than stored in
the session, so the defaults of a plugin that is no longer active do not survive its
deactivation.
