### PR TITLE
Centralize date and datetime parsing in DateTimeUtils

### DIFF
--- a/modules/changelog/changelog.php
+++ b/modules/changelog/changelog.php
@@ -22,6 +22,7 @@
 
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\SecurityUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\Infrastructure\Language;
 use Admidio\UI\Component\DataTables;
 use Admidio\UI\Presenter\FormPresenter;
@@ -39,7 +40,7 @@ require(__DIR__ . '/../../system/login_valid.php');
 try {
 
     // calculate default date from which the profile fields history should be shown
-    $filterDateFrom = DateTime::createFromFormat('Y-m-d', DATE_NOW);
+    $filterDateFrom = new DateTime(DATE_NOW);
     $filterDateFrom->modify('-' . $gSettingsManager->getInt('contacts_field_history_days') . ' day');
 
 
@@ -151,25 +152,10 @@ try {
     // add page to navigation history
     $gNavigation->addUrl(CURRENT_URL, $headline);
 
-    // filter_date_from and filter_date_to can have different formats
-    // now we try to get a default format for intern use and html output
-    $objDateFrom = DateTime::createFromFormat('Y-m-d', $getDateFrom);
-    if ($objDateFrom === false) {
-        // check if date has system format
-        $objDateFrom = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $getDateFrom);
-        if ($objDateFrom === false) {
-            $objDateFrom = DateTime::createFromFormat($gSettingsManager->getString('system_date'), '1970-01-01');
-        }
-    }
-
-    $objDateTo = DateTime::createFromFormat('Y-m-d', $getDateTo);
-    if ($objDateTo === false) {
-        // check if date has system format
-        $objDateTo = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $getDateTo);
-        if ($objDateTo === false) {
-            $objDateTo = DateTime::createFromFormat($gSettingsManager->getString('system_date'), '1970-01-01');
-        }
-    }
+    // filter_date_from and filter_date_to can use the internal ISO format
+    // or the configured Admidio date format.
+    $objDateFrom = DateTimeUtils::parseDate($getDateFrom, '1970-01-01');
+    $objDateTo = DateTimeUtils::parseDate($getDateTo, DATE_NOW);
 
     // DateTo should be greater than DateFrom
     if ($objDateFrom > $objDateTo) {

--- a/modules/changelog/changelog_data.php
+++ b/modules/changelog/changelog_data.php
@@ -64,7 +64,7 @@ use Admidio\Infrastructure\Language;
 use Admidio\Infrastructure\Database;
 use Admidio\Users\Entity\User;
 use Admidio\Changelog\Service\ChangelogService;
-
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 
 
 
@@ -74,7 +74,7 @@ try {
     require(__DIR__ . '/../../system/login_valid.php');
 
     // calculate default date from which the profile fields history should be shown
-    $filterDateFrom = DateTime::createFromFormat('Y-m-d', DATE_NOW);
+    $filterDateFrom = new DateTime(DATE_NOW);
     $filterDateFrom->modify('-' . $gSettingsManager->getInt('contacts_field_history_days') . ' day');
 
 
@@ -145,26 +145,10 @@ try {
     }
 
 
-
-    // filter_date_from and filter_date_to can have different formats
-    // now we try to get a default format for intern use and html output
-    $objDateFrom = DateTime::createFromFormat('Y-m-d', $getDateFrom);
-    if ($objDateFrom === false) {
-        // check if date has system format
-        $objDateFrom = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $getDateFrom);
-        if ($objDateFrom === false) {
-            $objDateFrom = DateTime::createFromFormat($gSettingsManager->getString('system_date'), '1970-01-01');
-        }
-    }
-
-    $objDateTo = DateTime::createFromFormat('Y-m-d', $getDateTo);
-    if ($objDateTo === false) {
-        // check if date has system format
-        $objDateTo = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $getDateTo);
-        if ($objDateTo === false) {
-            $objDateTo = DateTime::createFromFormat($gSettingsManager->getString('system_date'), '1970-01-01');
-        }
-    }
+    // filter_date_from and filter_date_to can use the internal ISO format
+    // or the configured Admidio date format.
+    $objDateFrom = DateTimeUtils::parseDate($getDateFrom, '1970-01-01');
+    $objDateTo = DateTimeUtils::parseDate($getDateTo, DATE_NOW);
 
     // DateTo should be greater than DateFrom
     if ($objDateFrom > $objDateTo) {

--- a/modules/groups-roles/lists_show.php
+++ b/modules/groups-roles/lists_show.php
@@ -28,6 +28,8 @@ use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
+
 use Admidio\Roles\Entity\ListConfiguration;
 use Admidio\Roles\Entity\Role;
 use Admidio\Roles\Service\RolesService;
@@ -153,12 +155,7 @@ try {
         // if the event is in the past then show all members that were registered for this event
         $eventEnd = $event->getValue('dat_end', 'Y-m-d');
         $eventEnd = DateTime::createFromFormat('Y-m-d', $eventEnd);
-        $dateNow = DateTime::createFromFormat('Y-m-d',DATE_NOW);
-        if ($dateNow === false) {
-            // check if DATE_NOW has system format
-            $dateNow = DateTime::createFromFormat($gSettingsManager->getString('system_date'), DATE_NOW);
-            $dateNow->format('Y-m-d');
-        }
+        $dateNow = new DateTime(DATE_NOW);
 
         $getMembersShowFiler = ($eventEnd < $dateNow) ? 2 : 0;
         $getDateFrom = DATE_NOW;
@@ -166,19 +163,16 @@ try {
     }
 
     // Create date objects and format events in system format
-    $objDateFrom = DateTime::createFromFormat('Y-m-d', $getDateFrom);
-    if ($objDateFrom === false) {
-        // check if date_from  has system format
-        $objDateFrom = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $getDateFrom);
+    $objDateFrom = DateTimeUtils::parseDate($getDateFrom);
+    $objDateTo = DateTimeUtils::parseDate($getDateTo);
+
+    if ($objDateFrom === null || $objDateTo === null) {
+        throw new Exception('SYS_DATE_INVALID');
     }
+
     $dateFrom = $objDateFrom->format($gSettingsManager->getString('system_date'));
     $startDateEnglishFormat = $objDateFrom->format('Y-m-d');
 
-    $objDateTo = DateTime::createFromFormat('Y-m-d', $getDateTo);
-    if ($objDateTo === false) {
-        // check if date_from  has system format
-        $objDateTo = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $getDateTo);
-    }
     $dateTo = $objDateTo->format($gSettingsManager->getString('system_date'));
     $endDateEnglishFormat = $objDateTo->format('Y-m-d');
 

--- a/src/Infrastructure/Utils/DateTimeUtils.php
+++ b/src/Infrastructure/Utils/DateTimeUtils.php
@@ -1,0 +1,128 @@
+<?php
+namespace Admidio\Infrastructure\Utils;
+
+use DateTime;
+use InvalidArgumentException;
+
+/**
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+final class DateTimeUtils
+{
+    /**
+     * Parse a date using the internal ISO date format or the configured Admidio
+     * date format.
+     *
+     * If the date cannot be parsed and a fallback date is supplied, the
+     * fallback date is returned. Without a fallback, null is returned.
+     *
+     * @param string      $date         Date that should be parsed
+     * @param string|null $fallbackDate Optional fallback date in ISO format (Y-m-d)
+     * @return DateTime|null
+     */
+    public static function parseDate(string $date, ?string $fallbackDate = null): ?DateTime 
+    {
+        global $gSettingsManager;
+
+        $dateObject = self::createDateFromFormat('Y-m-d', $date);
+
+        if ($dateObject === null) {
+            $dateObject = self::createDateFromFormat(
+                $gSettingsManager->getString('system_date'),
+                $date
+            );
+        }
+
+        if ($dateObject !== null) {
+            return $dateObject;
+        }
+
+        if ($fallbackDate === null) {
+            return null;
+        }
+
+        $fallbackDateObject = self::createDateFromFormat('Y-m-d', $fallbackDate);
+
+        if ($fallbackDateObject === null) {
+            throw new InvalidArgumentException('Invalid fallback date "' . $fallbackDate . '".');
+        }
+
+        return $fallbackDateObject;
+    }
+
+    /**
+     * Parse a date and time using the internal Admidio formats or the configured
+     * system date and time formats.
+     *
+     * The following formats are supported:
+     * - Y-m-d H:i:s
+     * - Y-m-d H:i
+     * - Y-m-d\TH:i
+     * - configured system_date + system_time
+     *
+     * If the value cannot be parsed and a fallback value is supplied, the fallback
+     * must use the internal format Y-m-d H:i:s or Y-m-d H:i.
+     *
+     * @param string      $dateTime         Date and time that should be parsed
+     * @param string|null $fallbackDateTime Optional fallback date and time
+     * @return DateTime|null
+     */
+    public static function parseDateTime(string $dateTime, ?string $fallbackDateTime = null): ?DateTime 
+    {
+        global $gSettingsManager;
+
+        $formats = array(
+            'Y-m-d H:i:s',
+            'Y-m-d H:i',
+            'Y-m-d\TH:i',
+            $gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time')
+        );
+
+        foreach ($formats as $format) {
+            $dateTimeObject = self::createDateFromFormat($format, $dateTime);
+            if ($dateTimeObject !== null) {
+                return $dateTimeObject;
+            }
+        }
+
+        if ($fallbackDateTime === null) {
+            return null;
+        }
+
+        foreach (array('Y-m-d H:i:s', 'Y-m-d H:i') as $format) {
+            $fallbackDateTimeObject = self::createDateFromFormat($format, $fallbackDateTime);
+            if ($fallbackDateTimeObject !== null) {
+                return $fallbackDateTimeObject;
+            }
+        }
+
+        throw new InvalidArgumentException('Invalid fallback date and time "' . $fallbackDateTime . '".');
+    }
+
+    /**
+     * Create a date from a specific format and reject parsing warnings/errors.
+     *
+     * @param string $format Date format
+     * @param string $date   Date value
+     * @return DateTime|null
+     */
+    private static function createDateFromFormat(string $format, string $date): ?DateTime 
+    {
+        $dateObject = DateTime::createFromFormat($format, $date);
+
+        if ($dateObject === false) {
+            return null;
+        }
+
+        $errors = DateTime::getLastErrors();
+
+        if ($errors !== false
+            && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) {
+            return null;
+        }
+
+        return $dateObject;
+    }
+}

--- a/src/ProfileFields/ValueObjects/ProfileFields.php
+++ b/src/ProfileFields/ValueObjects/ProfileFields.php
@@ -5,6 +5,7 @@ use Admidio\Infrastructure\Image;
 use Admidio\Infrastructure\Language;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\ProfileFields\Entity\ProfileField;
 use Admidio\Infrastructure\Entity\Entity;
 use Admidio\Infrastructure\Database;
@@ -741,11 +742,10 @@ class ProfileFields
                     }
                     break;
                 case 'DATE':
-                    // Date must be valid and formatted
-                    $date = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $fieldValue);
-                    if ($date === false) {
-                        $date = DateTime::createFromFormat('Y-m-d', $fieldValue);
-                        if ($date === false && !$this->noValueCheck) {
+                    $date = DateTimeUtils::parseDate($fieldValue);
+
+                    if ($date === null) {
+                        if (!$this->noValueCheck) {
                             throw new Exception('SYS_DATE_INVALID', array($this->mProfileFields[$fieldNameIntern]->getValue('usf_name'), $gSettingsManager->getString('system_date')));
                         }
                     } else {

--- a/src/Roles/ValueObject/ConditionParser.php
+++ b/src/Roles/ValueObject/ConditionParser.php
@@ -4,6 +4,7 @@ namespace Admidio\Roles\ValueObject;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 use DateInterval;
 use DateTime;
 
@@ -115,8 +116,9 @@ class ConditionParser
 
         // validate date and return it in database format
         if ($date !== '') {
-            $dateObject = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $date);
-            if ($dateObject !== false) {
+            $dateObject = DateTimeUtils::parseDate($date);
+
+            if ($dateObject !== null) {
                 return $db->escapeString($dateObject->format('Y-m-d'));
             }
         }

--- a/src/UI/Presenter/FormPresenter.php
+++ b/src/UI/Presenter/FormPresenter.php
@@ -10,12 +10,13 @@ use DateTime;
 use PDO;
 use Ramsey\Uuid\Uuid;
 use Securimage;
-use Admidio\Infrastructure\Utils\SecurityUtils;
 use SimpleXMLElement;
 use Smarty\Smarty;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\Infrastructure\Utils\SecurityUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 
 /**
  * @brief Creates an Admidio specific form
@@ -754,13 +755,12 @@ class FormPresenter
 
         // if datetime then add a time field behind the date field
         if ($optionsAll['type'] === 'datetime') {
-            $datetime = DateTime::createFromFormat($gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time'), $value);
+            $datetime = DateTimeUtils::parseDateTime($value);
 
-            // now add a date and a time field to the form
             $attributes['dateValue'] = null;
             $attributes['timeValue'] = null;
 
-            if ($datetime) {
+            if ($datetime !== null) {
                 $attributes['dateValue'] = $datetime->format('Y-m-d');
                 $attributes['timeValue'] = $datetime->format('H:i');
             }
@@ -780,9 +780,11 @@ class FormPresenter
             $optionsTime['type'] = 'time';
             $this->elements[$id . '_time'] = $optionsTime;
         } elseif ($optionsAll['type'] === 'date') {
-            $datetime = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $value);
-            if (!empty($value) && is_object($datetime))
+            $datetime = DateTimeUtils::parseDate($value);
+
+            if ($value !== '' && $datetime !== null) {
                 $value = $datetime->format('Y-m-d');
+            }
             $attributes['pattern'] = '\d{4}-\d{2}-\d{2}';
         } elseif ($optionsAll['type'] === 'time') {
             $datetime = DateTime::createFromFormat('Y-m-d' . $gSettingsManager->getString('system_time'), DATE_NOW . $value);
@@ -2199,17 +2201,10 @@ class FormPresenter
                             $this->validateCaptcha($fieldValues[$element['id']]);
                             break;
                         case 'date':
-                            // check if date is a valid Admidio date format
-                            $objAdmidioDate = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $fieldValues[$element['id']]);
-
-                            if (!$objAdmidioDate) {
-                                // check if date has english format
-                                $objEnglishDate = DateTime::createFromFormat('Y-m-d', $fieldValues[$element['id']]);
-
-                                if (!$objEnglishDate) {
-                                    throw new Exception('The date "' . $element['label'] . '" has an invalid date format!');
-                                }
+                            if (DateTimeUtils::parseDate($fieldValues[$element['id']]) === null) {
+                                throw new Exception('The date "' . $element['label'] . '" has an invalid date format!');
                             }
+                            break;
                         case 'editor':
                             // check html string vor invalid tags and scripts
                             $config = HTMLPurifier_Config::createDefault();

--- a/src/Users/Entity/User.php
+++ b/src/Users/Entity/User.php
@@ -14,6 +14,7 @@ use Admidio\Session\Entity\Session;
 use Admidio\Infrastructure\Utils\PasswordUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\Changelog\Entity\LogChanges;
 use RobThree\Auth\TwoFactorAuth;
 use RobThree\Auth\Providers\Qr\QRServerProvider;
@@ -2260,9 +2261,9 @@ class User extends Entity
 
         // format of date will be local but database hase stored Y-m-d format must be changed for compare
         if ($this->mProfileFieldsData->getProperty($columnName, 'usf_type') === 'DATE') {
-            $date = \DateTime::createFromFormat($gSettingsManager->getString('system_date'), $newValue);
+            $date = DateTimeUtils::parseDate($newValue);
 
-            if ($date !== false) {
+            if ($date !== null) {
                 $newValue = $date->format('Y-m-d');
             }
         } elseif (

--- a/system/bootstrap/function.php
+++ b/system/bootstrap/function.php
@@ -9,6 +9,7 @@
  ***********************************************************************************************
  */
 
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
 use Admidio\Users\Entity\User;
@@ -375,16 +376,8 @@ function admFuncVariableIsValid(array $array, string $variableName, string $data
             break;
 
         case 'date':
-            // check if date is a valid Admidio date format
-            $objAdmidioDate = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $value);
-
-            if (!$objAdmidioDate) {
-                // check if date has english format
-                $objEnglishDate = DateTime::createFromFormat('Y-m-d', $value);
-
-                if (!$objEnglishDate) {
-                    throw new Exception('The date parameter "' . $variableName . '" has an invalid date format!');
-                }
+            if (DateTimeUtils::parseDate($value) === null) {
+                throw new Exception('The date parameter "' . $variableName . '" has an invalid date format!');
             }
             break;
 

--- a/system/classes/HtmlForm.php
+++ b/system/classes/HtmlForm.php
@@ -4,6 +4,7 @@ use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\PhpIniUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 
 /**
  * @brief Creates an Admidio specific form with special elements
@@ -706,8 +707,11 @@ class HtmlForm
 
         // if datetime then add a time field behind the date field
         if ($optionsAll['type'] === 'datetime') {
-            $datetime = DateTime::createFromFormat($gSettingsManager->getString('system_date') . ' ' . $gSettingsManager->getString('system_time'), $value);
-
+            $datetime = DateTimeUtils::parseDateTime($value);
+            if ($value !== '' && $datetime !== null) {
+                $value = $datetime->format('Y-m-d\TH:i');
+            }
+            
             // now add a date and a time field to the form
             $attributes['dateValue'] = null;
             $attributes['timeValue'] = null;
@@ -725,9 +729,10 @@ class HtmlForm
             $attributes['timeValueAttributes'] = array();
             $attributes['timeValueAttributes']['class'] = 'form-control datetime-time-control';
         } elseif ($optionsAll['type'] === 'date') {
-            $datetime = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $value);
-            if (!empty($value) && is_object($datetime))
+            $datetime = DateTimeUtils::parseDate($value);
+            if ($value !== '' && $datetime !== null) {
                 $value = $datetime->format('Y-m-d');
+            }
             $attributes['pattern'] = '\d{4}-\d{2}-\d{2}';
         } elseif ($optionsAll['type'] === 'time') {
             $datetime = DateTime::createFromFormat('Y-m-d' . $gSettingsManager->getString('system_time'), DATE_NOW . $value);

--- a/system/classes/ModuleEvents.php
+++ b/system/classes/ModuleEvents.php
@@ -4,6 +4,7 @@ use Admidio\Categories\Entity\Category;
 use Admidio\Events\Entity\Event;
 use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Exception;
+use Admidio\Infrastructure\Utils\DateTimeUtils;
 
 /**
  * @brief This class reads event recordset from database
@@ -476,14 +477,9 @@ class ModuleEvents extends Modules
         }
 
         // Create date object and format date_from in English format and system format and push to date range array
-        $objDateFrom = DateTime::createFromFormat('Y-m-d', $dateRangeStart);
+        $objDateFrom = DateTimeUtils::parseDate($dateRangeStart);
 
-        if ($objDateFrom === false) {
-            // check if date_from has system format
-            $objDateFrom = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $dateRangeStart);
-        }
-
-        if ($objDateFrom === false) {
+        if ($objDateFrom === null) {
             return false;
         }
 
@@ -491,14 +487,9 @@ class ModuleEvents extends Modules
         $this->setParameter('dateStartFormatAdmidio', $objDateFrom->format($gSettingsManager->getString('system_date')));
 
         // Create date object and format date_to in English format and system format and push to date range array
-        $objDateTo = DateTime::createFromFormat('Y-m-d', $dateRangeEnd);
+        $objDateTo = DateTimeUtils::parseDate($dateRangeEnd);
 
-        if ($objDateTo === false) {
-            // check if date_from  has system format
-            $objDateTo = DateTime::createFromFormat($gSettingsManager->getString('system_date'), $dateRangeEnd);
-        }
-
-        if ($objDateTo === false) {
+        if ($objDateTo === null) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

Date and datetime strings reach Admidio in two shapes: the ISO format used internally and
in URLs, and the date or datetime format configured for the organization. The parsing of
those values was duplicated across forms, profile fields, role conditions, event and
changelog date filters, each with slightly different fallback and validation behaviour.

`DateTimeUtils` gains `parseDate()` and `parseDateTime()`, which accept either shape,
return `null` for a value that is not a valid calendar date, and take an optional fallback.
The duplicated parsing is replaced by calls to them.

## What this changes

- one place that understands both ISO and the configured Admidio formats
- consistent validation: an invalid calendar date is now rejected everywhere, instead of
  being silently accepted by some of the callers
- fixes an invalid fallback in the change history date filter
- removes the duplicated parsing from form handling and validation, profile fields, role
  conditions, and the event and change history date filters

## Files

`src/Infrastructure/Utils/DateTimeUtils.php` gets the new methods; the callers are
`src/UI/Presenter/FormPresenter.php`, `src/ProfileFields/ValueObjects/ProfileFields.php`,
`src/Roles/ValueObject/ConditionParser.php`, `src/Users/Entity/User.php`,
`system/bootstrap/function.php`, `system/classes/HtmlForm.php`,
`system/classes/ModuleEvents.php`, `modules/groups-roles/lists_show.php` and
`modules/changelog/`.

## Note

A follow-up pull request with improvements to the change history builds on this one — the
change history module is among the callers converted here.
