### PR TITLE
Installation: Create CLI installer via "./admidio install:run" 

### DIFF
--- a/admidio
+++ b/admidio
@@ -42,15 +42,20 @@ function admCliBootstrapOption(array $arguments, string $name): string
 }
 
 /**
- * Determine the command before the full CLI bootstrap is available.
+ * Read the name of the command out of the arguments.
  *
- * This is only used for commands that must be able to run without a database connection.
+ * The command decides which bootstrap can be used, so it has to be known before the registry
+ * exists. Only the first token that is neither an option nor the value of an option is taken; a
+ * misspelled command is reported later by CliApplication, which knows every command. The tokens
+ * are read exactly like CliApplication::findCommand() reads them, short flags included, so both
+ * arrive at the same command.
  *
  * @param array<int,string> $arguments
  */
 function admCliBootstrapCommand(array $arguments): string
 {
     $globalFlags = array('quiet', 'no-interaction', 'yes', 'help');
+    $globalShortFlags = array('h', 'q', 'y');
     $globalValueOptions = array('host', 'organization', 'as', 'format', 'output');
 
     for ($index = 1, $count = count($arguments); $index < $count; ++$index) {
@@ -58,6 +63,15 @@ function admCliBootstrapCommand(array $arguments): string
 
         if ($token === '--') {
             return $arguments[$index + 1] ?? '';
+        }
+
+        // Short flags may precede the command just like their long forms.
+        if (!str_starts_with($token, '--') && str_starts_with($token, '-') && strlen($token) > 1) {
+            if (in_array(substr($token, 1), $globalShortFlags, true)) {
+                continue;
+            }
+
+            return '';
         }
 
         if (!str_starts_with($token, '--')) {
@@ -86,10 +100,54 @@ function admCliBootstrapCommand(array $arguments): string
 
 $cliHost = admCliBootstrapOption($argv, 'host');
 $cliOrganization = admCliBootstrapOption($argv, 'organization');
-$cliSkipDatabase = admCliBootstrapCommand($argv) === 'maintenance:mode';
+$cliCommand = admCliBootstrapCommand($argv);
+
+/*
+ * Maintenance mode has to be inspectable and revocable while the database is unavailable, so its
+ * command reads the configuration file but opens no database connection.
+ */
+$cliSkipDatabase = $cliCommand === 'maintenance:mode';
+
+/*
+ * An installation has no configuration file and no database yet, so its commands need a bootstrap
+ * that creates neither. Everything the constants are derived from is read from the command line
+ * there, and the commands check that their options match what was bootstrapped.
+ */
+$installationCommands = array('install:check', 'install:run');
+
+/*
+ * The commands that only describe the command line have to work on an Admidio that is not installed
+ * yet, otherwise install:run could not even be looked up before it is used.
+ */
+$documentationCommands = array('', 'help', 'list', 'completion', 'cli:selfcheck');
+
+$installationBootstrap = in_array($cliCommand, $installationCommands, true)
+    || (in_array($cliCommand, $documentationCommands, true) && !is_file(__DIR__ . '/adm_my_files/config.php'));
 
 try {
-    require __DIR__ . '/system/bootstrap/cli.php';
+    if (in_array($cliCommand, $installationCommands, true)) {
+        /*
+         * Ask for the values that the command line does not contain. This happens here and not in
+         * the command, because the table prefix and the time zone are needed to build the table
+         * names and the timestamps of the installation, which Admidio does while it is bootstrapping.
+         */
+        if (!in_array('--help', $argv, true) && !in_array('-h', $argv, true)) {
+            require __DIR__ . '/vendor/autoload.php';
+            $argv = Admidio\Infrastructure\Cli\CliInstallationInput::complete($argv, __DIR__);
+        }
+
+        $cliRootUrl = admCliBootstrapOption($argv, 'root-url');
+        $cliLanguage = admCliBootstrapOption($argv, 'language');
+        $cliTablePrefix = admCliBootstrapOption($argv, 'table-prefix');
+        $cliDbType = admCliBootstrapOption($argv, 'db-type');
+        $cliTimezone = admCliBootstrapOption($argv, 'timezone');
+    }
+
+    if ($installationBootstrap) {
+        require __DIR__ . '/system/bootstrap/cli-installation.php';
+    } else {
+        require __DIR__ . '/system/bootstrap/cli.php';
+    }
 
     $application = new Admidio\Infrastructure\Cli\CliApplication();
     exit($application->run($argv));

--- a/install/install_steps/connect_database.php
+++ b/install/install_steps/connect_database.php
@@ -9,10 +9,11 @@
  ***********************************************************************************************
  */
 
-use Admidio\Infrastructure\Database;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\PasswordUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
+use Admidio\InstallationUpdate\Service\Installation;
+use Admidio\InstallationUpdate\ValueObject\InstallationConfig;
 use Admidio\UI\Presenter\FormPresenter;
 use Admidio\UI\Presenter\InstallationPresenter;
 
@@ -120,85 +121,36 @@ if ($mode === 'html') {
         throw new Exception('SYS_INVALID_PAGE_VIEW');
     }
 
-    // PHP-Check Regex-Patterns
-    $sqlIdentifiersRegex = '/^[a-zA-Z0-9_$@-]+$/';
-
     // Store database access data filtered in session variables
     $_SESSION['db_type']      = $formValues['adm_db_type'];
     $_SESSION['db_host']      = $formValues['adm_db_host'];
-    $_SESSION['db_port']      = $formValues['adm_db_port'];
+    $_SESSION['db_port']      = InstallationConfig::normalizePort($formValues['adm_db_port']);
     $_SESSION['db_name']      = $formValues['adm_db_name'];
     $_SESSION['db_username']  = $formValues['adm_db_username'];
     $_SESSION['db_password']  = $formValues['adm_db_password'];
     $_SESSION['table_prefix'] = $formValues['adm_table_prefix'];
 
-    // Check DB-type
-    if (!in_array($_SESSION['db_type'], array(Database::DB_TYPE_MARIADB, Database::DB_TYPE_MYSQL, Database::DB_TYPE_PGSQL), true)) {
-        throw new Exception('INS_DATABASE_TYPE_INVALID');
-    }
+    // check the entered values with the same rules that a headless installation uses
+    Installation::validateDatabaseInput(
+        $_SESSION['db_type'],
+        $_SESSION['db_host'],
+        $_SESSION['db_port'],
+        $_SESSION['db_name'],
+        $_SESSION['db_username'],
+        $_SESSION['table_prefix']
+    );
 
-    // Check host
-    // TODO: unix_server is currently not supported
-    if (filter_var($_SESSION['db_host'], FILTER_VALIDATE_DOMAIN) === false && filter_var($_SESSION['db_host'], FILTER_VALIDATE_IP) === false) {
-        throw new Exception('INS_HOST_INVALID');
-    }
-
-    // Check port
-    if ($_SESSION['db_port'] === '' || $_SESSION['db_port'] === null) {
-        $_SESSION['db_port'] = null;
-    } elseif (is_numeric($_SESSION['db_port']) && (int) $_SESSION['db_port'] > 0 && (int) $_SESSION['db_port'] <= 65535) {
-        $_SESSION['db_port'] = (int) $_SESSION['db_port'];
-    } else {
-        throw new Exception('INS_DATABASE_PORT_INVALID');
-    }
-
-    // Check database
-    if (strlen($_SESSION['db_name']) > 64 || preg_match($sqlIdentifiersRegex, $_SESSION['db_name']) !== 1) {
-        throw new Exception('SYS_FIELD_INVALID_INPUT', array('SYS_DATABASE'));
-    }
-
-    // Check user
-    if (strlen($_SESSION['db_username']) > 64 || preg_match($sqlIdentifiersRegex, $_SESSION['db_username']) !== 1) {
-        throw new Exception('SYS_FIELD_INVALID_INPUT', array('SYS_USERNAME'));
-    }
-
-    // Check password
+    // a weak database password is not an error of the installation, but it should be logged
     $zxcvbnScore = PasswordUtils::passwordStrength($_SESSION['db_password']);
     if ($zxcvbnScore <= 2) {
         $gLogger->warning('Database password is weak! (zxcvbn lib)', array('score' => $zxcvbnScore));
     }
 
-    // Check prefix
-    if (strlen($_SESSION['table_prefix']) > 10 || preg_match($sqlIdentifiersRegex, $_SESSION['table_prefix']) !== 1) {
-        throw new Exception('SYS_FIELD_INVALID_INPUT', array('INS_TABLE_PREFIX'));
-    }
-
     // for security reasons only check database connection if no config file exists
     if (!is_file($configPath)) {
-        // check database connections
-        try {
-            $gDebug = true;
-            $db = new Database($_SESSION['db_type'], $_SESSION['db_host'], $_SESSION['db_port'], $_SESSION['db_name'], $_SESSION['db_username'], $_SESSION['db_password']);
-            $db->checkWriteAccess();
-            $gDebug = false;
-        } catch (Exception $e) {
-            throw new Exception('SYS_DATABASE_NO_LOGIN', array($e->getMessage()));
-        }
-
-        // check database version
-        $message = \Admidio\InstallationUpdate\Service\Installation::checkDatabaseVersion($db);
-        if ($message !== '') {
-            throw new Exception($message);
-        }
-
-        // now check if a valid installation exists.
-        $sql = 'SELECT org_id FROM ' . $_SESSION['table_prefix'] . '_organizations';
-        $pdoStatement = $db->queryPrepared($sql, array(), false);
-
-        if ($pdoStatement !== false && $pdoStatement->rowCount() > 0) {
-            // valid installation exists -> exit installation
-            throw new Exception('INS_INSTALLATION_EXISTS');
-        }
+        $gDebug = true;
+        Installation::connectDatabase(InstallationConfig::fromInstallerSession($_SESSION, ADMIDIO_URL));
+        $gDebug = false;
     }
 
     echo json_encode(array(

--- a/install/install_steps/create_administrator.php
+++ b/install/install_steps/create_administrator.php
@@ -10,9 +10,8 @@
  */
 
 use Admidio\Infrastructure\Exception;
-use Admidio\Infrastructure\Utils\PasswordUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
-use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\InstallationUpdate\Service\Installation;
 use Admidio\UI\Presenter\FormPresenter;
 use Admidio\UI\Presenter\InstallationPresenter;
 
@@ -111,27 +110,14 @@ if ($mode === 'html') {
     $_SESSION['user_password']         = $formValues['adm_user_password'];
     $_SESSION['user_password_confirm'] = $formValues['adm_user_password_confirm'];
 
-    // username should only have valid chars
-    if (!StringUtils::strValidCharacters($_SESSION['user_login'], 'noSpecialChar')) {
-        throw new Exception('SYS_FIELD_INVALID_CHAR', array('SYS_USERNAME'));
-    }
-
-    // Password min length is 8 chars
-    if (strlen($_SESSION['user_password']) < PASSWORD_MIN_LENGTH) {
-        throw new Exception('SYS_PASSWORD_LENGTH');
-    }
-
-    // check if password is strong enough
-    $userData = array(
-        $_SESSION['user_last_name'],
+    // check the entered values with the same rules that a headless installation uses
+    Installation::validateAdministratorInput(
+        $_SESSION['user_login'],
         $_SESSION['user_first_name'],
+        $_SESSION['user_last_name'],
         $_SESSION['user_email'],
-        $_SESSION['user_login']
+        $_SESSION['user_password']
     );
-    // Admin Password should have a minimum strength of 1
-    if (PasswordUtils::passwordStrength($_SESSION['user_password'], $userData) < 1) {
-        throw new Exception('SYS_PASSWORD_NOT_STRONG_ENOUGH');
-    }
 
     // password must be the same with password confirm
     if ($_SESSION['user_password'] !== $_SESSION['user_password_confirm']) {

--- a/install/install_steps/create_config.php
+++ b/install/install_steps/create_config.php
@@ -10,7 +10,8 @@
  */
 
 use Admidio\Infrastructure\Utils\SecurityUtils;
-use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\InstallationUpdate\Service\Installation;
+use Admidio\InstallationUpdate\ValueObject\InstallationConfig;
 use Admidio\UI\Presenter\FormPresenter;
 use Admidio\UI\Presenter\InstallationPresenter;
 
@@ -24,44 +25,23 @@ if (is_file($configPath)) {
     // => EXIT
 }
 
-// read configuration file structure
-$filename          = 'config.php';
-$configFileHandle  = fopen($filename, 'rb');
-$configFileContent = fread($configFileHandle, filesize($filename));
-fclose($configFileHandle);
-
-$port = 'null';
-if ($_SESSION['db_port']) {
-    $port = $_SESSION['db_port'];
-}
-
-// replace placeholders in configuration file structure with data of installation wizard
-$replaces = array(
-    '%DB_TYPE%'    => $_SESSION['db_type'],
-    '%DB_HOST%'      => $_SESSION['db_host'],
-    '\'%DB_PORT%\''  => $port, // String -> Int
-    '%DB_NAME%'      => $_SESSION['db_name'],
-    '%DB_USERNAME%'  => $_SESSION['db_username'],
-    '%DB_PASSWORD%'  => $_SESSION['db_password'],
-    '%TABLE_PREFIX%' => $_SESSION['table_prefix'],
-    '%ROOT_PATH%'    => $g_root_path,
-    '%TIMEZONE%'     => $_SESSION['orga_timezone']
-);
-$configFileContent = StringUtils::strMultiReplace($configFileContent, $replaces);
-
-$_SESSION['config_file_content'] = $configFileContent;
+// create the content of the configuration file out of the data of the installation wizard
+$installationConfig = InstallationConfig::fromInstallerSession($_SESSION, $g_root_path);
+$_SESSION['config_file_content'] = Installation::generateConfigFileContent($installationConfig);
 
 $page = new InstallationPresenter('adm_installation_create_config', $gL10n->get('INS_INSTALLATION_VERSION', array(ADMIDIO_VERSION_TEXT)));
 $page->addTemplateFile('installation.tpl');
 
 // now save new configuration file in Admidio folder if user has write access to this folder
-$configFileHandle = @fopen($configPath, 'ab');
+$configFileWritten = true;
 
-if ($configFileHandle) {
-    // save config file in Admidio folder
-    fwrite($configFileHandle, $configFileContent);
-    fclose($configFileHandle);
+try {
+    Installation::writeConfigFile($installationConfig, $configPath);
+} catch (RuntimeException $exception) {
+    $configFileWritten = false;
+}
 
+if ($configFileWritten) {
     // start installation
     $page->assignSmartyVariable('subHeadline', $gL10n->get('INS_INSTALL_ADMIDIO'));
     $page->assignSmartyVariable('text', $gL10n->get('INS_DATA_FULLY_ENTERED'));

--- a/install/install_steps/create_organization.php
+++ b/install/install_steps/create_organization.php
@@ -11,7 +11,7 @@
 
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Utils\SecurityUtils;
-use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\InstallationUpdate\Service\Installation;
 use Admidio\UI\Presenter\FormPresenter;
 use Admidio\UI\Presenter\InstallationPresenter;
 
@@ -101,14 +101,13 @@ if ($mode === 'html') {
     $_SESSION['orga_email']     = $formValues['adm_organization_email'];
     $_SESSION['orga_timezone']  = $formValues['adm_organization_timezone'];
 
-    if (!in_array($_SESSION['orga_timezone'], \DateTimeZone::listIdentifiers(), true)) {
-        throw new Exception('SYS_FIELD_INVALID_INPUT', array('ORG_TIMEZONE'));
-    }
-
-    // allow only letters, numbers and special characters like .-_+@
-    if (!StringUtils::strValidCharacters($_SESSION['orga_shortname'], 'noSpecialChar')) {
-        throw new Exception('SYS_FIELD_INVALID_CHAR', array('SYS_NAME_ABBREVIATION'));
-    }
+    // check the entered values with the same rules that a headless installation uses
+    Installation::validateOrganizationInput(
+        $_SESSION['orga_shortname'],
+        $_SESSION['orga_longname'],
+        $_SESSION['orga_email'],
+        $_SESSION['orga_timezone']
+    );
 
     echo json_encode(array(
         'status' => 'success',

--- a/install/install_steps/start_installation.php
+++ b/install/install_steps/start_installation.php
@@ -9,17 +9,10 @@
  ***********************************************************************************************
  */
 
-use Admidio\Components\Entity\ComponentUpdate;
 use Admidio\Infrastructure\Exception;
-use Admidio\Infrastructure\Entity\Entity;
-use Admidio\Infrastructure\Plugins\PluginManager;
-use Admidio\Infrastructure\Utils\PasswordUtils;
-use Admidio\Infrastructure\Utils\PhpIniUtils;
 use Admidio\Infrastructure\Utils\SecurityUtils;
-use Admidio\Organizations\Entity\Organization;
-use Admidio\ProfileFields\ValueObjects\ProfileFields;
-use Admidio\Users\Entity\User;
-use Ramsey\Uuid\Uuid;
+use Admidio\InstallationUpdate\Service\Installation;
+use Admidio\InstallationUpdate\ValueObject\InstallationConfig;
 
 if (basename($_SERVER['SCRIPT_FILENAME']) === 'start_installation.php') {
     exit('This page may not be called directly!');
@@ -35,7 +28,7 @@ if (!is_file($configPath)) {
 if (isset($_SESSION['table_prefix'])
     && ($_SESSION['db_type'] !== DB_TYPE
         || $_SESSION['db_host'] !== DB_HOST
-        || $_SESSION['db_port'] !== DB_PORT
+        || $_SESSION['db_port'] !== InstallationConfig::normalizePort(DB_PORT)
         || $_SESSION['db_name'] !== DB_NAME
         || $_SESSION['db_username'] !== DB_USERNAME
         || $_SESSION['db_password'] !== DB_PASSWORD
@@ -43,275 +36,12 @@ if (isset($_SESSION['table_prefix'])
     throw new Exception('INS_DATA_DO_NOT_MATCH', array('config.php'));
 }
 
-// set execution time to 5 minutes because we have a lot to do
-PhpIniUtils::startNewExecutionTimeLimit(300);
-
-// read data from sql script db.sql and execute all statements to the current database
-\Admidio\InstallationUpdate\Service\Installation::querySqlFile($db, 'db.sql');
-
-// create default data
-
-// add system component to database
-$component = new ComponentUpdate($db);
-$component->setValue('com_type', 'SYSTEM');
-$component->setValue('com_name', 'Admidio Core');
-$component->setValue('com_name_intern', 'CORE');
-$component->setValue('com_version', ADMIDIO_VERSION);
-$component->setValue('com_beta', ADMIDIO_VERSION_BETA);
-$component->setValue('com_update_step', $component->getMaxUpdateStep());
-$component->save();
-
-// create a hidden system user for internal use
-// all recordsets created by installation will get the create id of the system user
-$gCurrentUser = new Entity($db, TBL_USERS, 'usr');
-$gCurrentUser->setValue('usr_login_name', $gL10n->get('SYS_SYSTEM'));
-$gCurrentUser->setValue('usr_valid', '0');
-$gCurrentUser->setValue('usr_timestamp_create', DATETIME_NOW);
-$gCurrentUser->save(false); // no registered user -> UserIdCreate couldn't be filled
-$gCurrentUserId = $gCurrentUser->getValue('usr_id');
-
-// create all modules components
-$sql = 'INSERT INTO ' . TBL_COMPONENTS . '
-               (com_type, com_name, com_name_intern, com_version, com_beta)
-        VALUES (\'MODULE\', \'SYS_ANNOUNCEMENTS\',   \'ANNOUNCEMENTS\',  \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_CATEGORIES\',      \'CATEGORIES\',     \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_CATEGORY_REPORT\', \'CATEGORY-REPORT\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_CHANGE_HISTORY\',  \'CHANGELOG\',      \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_EVENTS\',          \'EVENTS\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_DOCUMENTS_FILES\', \'DOCUMENTS-FILES\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_INVENTORY\',        \'INVENTORY\',     \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_FORUM\',           \'FORUM\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_WEBLINKS\',        \'LINKS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_GROUPS_ROLES\',    \'GROUPS-ROLES\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_CONTACTS\',        \'CONTACTS\',       \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_MESSAGES\',        \'MESSAGES\',       \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_MENU\',            \'MENU\',           \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_ORGANIZATION\',    \'ORGANIZATIONS\',  \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_PHOTOS\',          \'PHOTOS\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_SETTINGS\',        \'PREFERENCES\',    \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_PROFILE\',         \'PROFILE\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_REGISTRATION\',    \'REGISTRATION\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_ROOM_MANAGEMENT\', \'ROOMS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
-             , (\'MODULE\', \'SYS_PLUGIN_MANAGER\',  \'PLUGINS\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')';
-$db->query($sql); // TODO add more params
-
-// create organization independent categories
-$sql = 'INSERT INTO ' . TBL_CATEGORIES . '
-               (cat_org_id, cat_uuid, cat_type, cat_name_intern, cat_name, cat_default, cat_system, cat_sequence, cat_usr_id_create, cat_timestamp_create)
-        VALUES (NULL, \'' . Uuid::uuid4() . '\', \'USF\', \'BASIC_DATA\', \'SYS_BASIC_DATA\', false, true, 1, ?, ?) -- $gCurrentUserId, DATETIME_NOW';
-$db->queryPrepared($sql, array($gCurrentUserId, DATETIME_NOW));
-$categoryIdMasterData = $db->lastInsertId();
-
-$sql = 'INSERT INTO ' . TBL_CATEGORIES . '
-               (cat_org_id, cat_uuid, cat_type, cat_name_intern, cat_name, cat_default, cat_system, cat_sequence, cat_usr_id_create, cat_timestamp_create)
-        VALUES (NULL, \'' . Uuid::uuid4() . '\', \'USF\', \'SOCIAL_NETWORKS\', \'SYS_SOCIAL_NETWORKS\', false, false, 2, ?, ?) -- $gCurrentUserId, DATETIME_NOW';
-$db->queryPrepared($sql, array($gCurrentUserId, DATETIME_NOW));
-$categoryIdSocialNetworks = $db->lastInsertId();
-
-$sql = 'INSERT INTO ' . TBL_CATEGORIES . '
-               (cat_org_id, cat_uuid, cat_type, cat_name_intern, cat_name, cat_default, cat_system, cat_sequence, cat_usr_id_create, cat_timestamp_create)
-        VALUES (NULL, \'' . Uuid::uuid4() . '\', \'USF\', \'ADDIDIONAL_DATA\', \'INS_ADDIDIONAL_DATA\', false, false, 3, ?, ?) -- $gCurrentUserId, DATETIME_NOW';
-$db->queryPrepared($sql, array($gCurrentUserId, DATETIME_NOW));
-$categoryIdAddidionalData = $db->lastInsertId();
-
-// create roles rights
-$sql = 'INSERT INTO ' . TBL_ROLES_RIGHTS . '
-               (ror_name_intern, ror_table)
-        VALUES (\'folder_view\',   \'' . TBL_FOLDERS . '\')
-             , (\'folder_upload\', \'' . TBL_FOLDERS . '\')
-             , (\'category_view\', \'' . TBL_CATEGORIES . '\')
-             , (\'event_participation\', \'' . TBL_CATEGORIES . '\')
-             , (\'menu_view\',     \'' . TBL_MENU . '\')
-             , (\'sso_saml_access\', \'' . TBL_SAML_CLIENTS . '\')
-             , (\'sso_oidc_access\', \'' . TBL_OIDC_CLIENTS . '\')
-             ';
-$db->queryPrepared($sql);
-
-// add edit categories right with reference to parent right
-$sql = 'INSERT INTO ' . TBL_ROLES_RIGHTS . '
-               (ror_name_intern, ror_table, ror_ror_id_parent)
-        VALUES (\'category_edit\', \'' . TBL_CATEGORIES . '\', (SELECT rr.ror_id FROM ' . TBL_ROLES_RIGHTS . ' rr WHERE rr.ror_name_intern = \'category_view\'))';
-$db->queryPrepared($sql);
-
-// create profile fields of category basic data
-$sql = 'INSERT INTO ' . TBL_USER_FIELDS . '
-               (usf_cat_id, usf_uuid, usf_type, usf_name_intern, usf_name, usf_description, usf_system, usf_disabled, usf_required_input, usf_registration, usf_sequence, usf_usr_id_create, usf_timestamp_create)
-        VALUES (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'LAST_NAME\',  \'SYS_LASTNAME\',  NULL, true, true, 1, true, 1,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'FIRST_NAME\', \'SYS_FIRSTNAME\', NULL, true, true, 1, true, 2,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'STREET\',     \'SYS_STREET\',    NULL, false, false, 0, false, 3,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'POSTCODE\',   \'SYS_POSTCODE\',  NULL, false, false, 0, false, 4,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'CITY\',       \'SYS_CITY\',      NULL, false, false, 0, false, 5,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'COUNTRY\',    \'SYS_COUNTRY\',   NULL, false, false, 0, false, 6,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'PHONE\',        \'PHONE\',      \'SYS_PHONE\',     NULL, false, false, 0, false, 7,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'PHONE\',        \'MOBILE\',     \'SYS_MOBILE\',    NULL, false, false, 0, false, 8,  ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'DATE\',         \'BIRTHDAY\',   \'SYS_BIRTHDAY\',  NULL, false, false, 0, false, 10, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'RADIO_BUTTON\', \'GENDER\',     \'SYS_GENDER\',    NULL, false, false, 0, false, 11, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'EMAIL\',        \'EMAIL\',      \'SYS_EMAIL\',     NULL, true, false, 2, true, 12, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'URL\',          \'WEBSITE\',    \'SYS_WEBSITE\',   NULL, false, false, 0, false, 13, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdAddidionalData . ', \'' . Uuid::uuid4() . '\', \'CHECKBOX\', \'DATA_PROTECTION_PERMISSION\', \'SYS_DATA_PROTECTION_PERMISSION\', \'' . $gL10n->get('SYS_DATA_PROTECTION_PERMISSION_DESC') . '\', false, false, 2, false, 14, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')';
-$db->query($sql); // TODO add more params
-
-// add gender options to database
-$sql = 'INSERT INTO ' . TBL_USER_FIELD_OPTIONS . '
-               (ufo_usf_id, ufo_value, ufo_sequence)
-        VALUES ((SELECT usf_id FROM ' . TBL_USER_FIELDS . ' WHERE usf_cat_id = ' . $categoryIdMasterData . ' AND usf_name_intern = \'GENDER\'), \'gender-male|SYS_MALE\', 1)
-             , ((SELECT usf_id FROM ' . TBL_USER_FIELDS . ' WHERE usf_cat_id = ' . $categoryIdMasterData . ' AND usf_name_intern = \'GENDER\'), \'gender-female|SYS_FEMALE\', 2)
-             , ((SELECT usf_id FROM ' . TBL_USER_FIELDS . ' WHERE usf_cat_id = ' . $categoryIdMasterData . ' AND usf_name_intern = \'GENDER\'), \'gender-trans|SYS_DIVERSE\', 3)';
-$db->query($sql);
-
-// create profile fields of category social networks
-$sql = 'INSERT INTO ' . TBL_USER_FIELDS . '
-               (usf_cat_id, usf_uuid, usf_type, usf_name_intern, usf_name, usf_description, usf_icon, usf_url, usf_system, usf_sequence, usf_usr_id_create, usf_timestamp_create)
-        VALUES (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'BLUESKY\',   \'SYS_BLUESKY\',   \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'bluesky\',   \'https://bsky.app/profile/#user_content#\',     false, 1, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'FACEBOOK\',  \'SYS_FACEBOOK\',  \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'facebook\',  \'https://www.facebook.com/#user_content#\',     false, 2, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'INSTAGRAM\', \'SYS_INSTAGRAM\', \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'instagram\', \'https://www.instagram.com/#user_content#\',    false, 3, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'LINKEDIN\',  \'SYS_LINKEDIN\',  \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'linkedin\',  \'https://www.linkedin.com/in/#user_content#\',  false, 4, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'MASTODON\',  \'SYS_MASTODON\',  \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'mastodon\',  \'https://mastodon.social/#user_content#\',      false, 5, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'XING\',      \'SYS_XING\',      \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', null,          \'https://www.xing.com/profile/#user_content#\', false, 6, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')';
-$db->query($sql); // TODO add more params
-
-// create user relation types
-$sql = 'INSERT INTO ' . TBL_USER_RELATION_TYPES . '
-               (urt_id, urt_uuid, urt_name, urt_name_male, urt_name_female, urt_id_inverse, urt_usr_id_create, urt_timestamp_create)
-        VALUES (1, \'' . Uuid::uuid4() . '\', \'SYS_PARENT\',      \'SYS_FATHER\',           \'SYS_MOTHER\',          null, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (2, \'' . Uuid::uuid4() . '\', \'SYS_CHILD\',       \'SYS_SON\',              \'SYS_DAUGHTER\',           1, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (3, \'' . Uuid::uuid4() . '\', \'SYS_SIBLING\',     \'SYS_BROTHER\',          \'SYS_SISTER\',             3, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (4, \'' . Uuid::uuid4() . '\', \'SYS_SPOUSE\',      \'SYS_HUSBAND\',          \'SYS_WIFE\',               4, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (5, \'' . Uuid::uuid4() . '\', \'SYS_COHABITANT\',  \'SYS_COHABITANT_MALE\',  \'SYS_COHABITANT_FEMALE\',  5, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (6, \'' . Uuid::uuid4() . '\', \'SYS_COMPANION\',   \'SYS_BOYFRIEND\',        \'SYS_GIRLFRIEND\',         6, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (7, \'' . Uuid::uuid4() . '\', \'SYS_SUPERIOR\',    \'SYS_SUPERIOR_MALE\',    \'SYS_SUPERIOR_FEMALE\', null, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')
-             , (8, \'' . Uuid::uuid4() . '\', \'SYS_SUBORDINATE\', \'SYS_SUBORDINATE_MALE\', \'SYS_SUBORDINATE_FEMALE\', 7, ' . $gCurrentUserId . ', \'' . DATETIME_NOW . '\')';
-$db->query($sql); // TODO add more params
-
-$sql = 'UPDATE ' . TBL_USER_RELATION_TYPES . '
-           SET urt_id_inverse = 2
-         WHERE urt_id = 1';
-$db->queryPrepared($sql);
-
-$sql = 'UPDATE ' . TBL_USER_RELATION_TYPES . '
-           SET urt_id_inverse = 8
-         WHERE urt_id = 7';
-$db->queryPrepared($sql);
-
-// create new organization
-$gCurrentOrganization = new Organization($db, $_SESSION['orga_shortname']);
-$gCurrentOrganization->setValue('org_longname', $_SESSION['orga_longname']);
-$gCurrentOrganization->setValue('org_shortname', $_SESSION['orga_shortname']);
-$gCurrentOrganization->setValue('org_homepage', ADMIDIO_URL);
-$gCurrentOrganization->setValue('org_email_administrator', $_SESSION['orga_email']);
-$gCurrentOrganization->save();
-$gCurrentOrgId = $gCurrentOrganization->getValue('org_id');
-
-$gProfileFields = new ProfileFields($db, $gCurrentOrgId);
-
-// create administrator and assign roles
-$administrator = new User($db, $gProfileFields);
-$administrator->setValue('usr_login_name', $_SESSION['user_login']);
-$administrator->setPassword($_SESSION['user_password']);
-$administrator->setValue('usr_usr_id_create', $gCurrentUserId);
-$administrator->setValue('usr_timestamp_create', DATETIME_NOW);
-$administrator->save(false); // no registered user -> UserIdCreate couldn't be filled
-$adminUsrId = $administrator->getValue('usr_id');
-
-// write all preferences from preferences.php in table adm_preferences
-require_once(ADMIDIO_PATH . FOLDER_INSTALLATION . '/db_scripts/preferences.php');
-
-// set some specific preferences whose values came from user input of the installation wizard
-$defaultOrgPreferences['system_language'] = $language;
-
-// calculate the best cost value for your server performance
-$benchmarkResults = PasswordUtils::costBenchmark($gPasswordHashAlgorithm);
-if (is_int($benchmarkResults['options']['cost'])) {
-    $defaultOrgPreferences['system_hashing_cost'] = $benchmarkResults['options']['cost'];
-}
-
-// create all necessary data for this organization
-$gSettingsManager =& $gCurrentOrganization->getSettingsManager();
-$gSettingsManager->setMulti($defaultOrgPreferences, false);
-
-// the preferences of the organization exist now, so the value can be changed
-\Admidio\InstallationUpdate\Service\Installation::disableSoundexSearchIfPgSql($db);
-
-$gCurrentOrganization->createBasicData($adminUsrId);
-
-// create default room for room module in database
-$sql = 'INSERT INTO ' . TBL_ROOMS . '
-               (room_uuid, room_name, room_description, room_capacity, room_usr_id_create, room_timestamp_create)
-        VALUES (\'' . Uuid::uuid4() . '\', ?, ?, 15, ?, ?) -- $gL10n->get(\'INS_CONFERENCE_ROOM\'), $gL10n->get(\'INS_DESCRIPTION_CONFERENCE_ROOM\'), $gCurrentUserId, DATETIME_NOW';
-$params = array(
-    $gL10n->get('INS_CONFERENCE_ROOM'),
-    $gL10n->get('INS_DESCRIPTION_CONFERENCE_ROOM'),
-    $gCurrentUserId,
-    DATETIME_NOW
-);
-$db->queryPrepared($sql, $params);
-
-// first create a user object "current user" with administrator rights
-// because administrator is allowed to edit firstname and lastname
-$gCurrentUser = new User($db, $gProfileFields, $adminUsrId);
-$gCurrentUser->saveChangesWithoutRights();
-$gCurrentUser->setValue('LAST_NAME', $_SESSION['user_last_name']);
-$gCurrentUser->setValue('FIRST_NAME', $_SESSION['user_first_name']);
-$gCurrentUser->setValue('EMAIL', $_SESSION['user_email']);
-$gCurrentUser->save(false);
-
-// now create a full user object for system user
-$systemUser = new User($db, $gProfileFields, $gCurrentUserId);
-$systemUser->saveChangesWithoutRights();
-$systemUser->setValue('LAST_NAME', $gL10n->get('SYS_SYSTEM'));
-$systemUser->save(false); // no registered user -> UserIdCreate couldn't be filled
-
-// now set current user to system user
-$gCurrentUser->readDataById($gCurrentUserId);
-
-// Menu entries for the standard installation
-$sql = 'INSERT INTO ' . TBL_MENU . '
-               (men_com_id, men_men_id_parent, men_uuid, men_node, men_order, men_standard, men_name_intern, men_url, men_icon, men_name, men_description)
-        VALUES (NULL, NULL, \'' . Uuid::uuid4() . '\', true, 1, true, \'modules\', NULL, \'\', \'SYS_MODULES\', \'\')
-             , (NULL, NULL, \'' . Uuid::uuid4() . '\', true, 2, true, \'administration\', NULL, \'\', \'SYS_ADMINISTRATION\', \'\')
-             , (NULL, NULL, \'' . Uuid::uuid4() . '\', true, 3, true, \'extensions\', NULL, \'\', \'SYS_EXTENSIONS\', \'\')
-             , (NULL, 1, \'' . Uuid::uuid4() . '\', false, 1, true, \'overview\', \''.FOLDER_MODULES.'/overview.php\', \'bi-house-door-fill\', \'SYS_OVERVIEW\', \'\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'ANNOUNCEMENTS\'), 1, \'' . Uuid::uuid4() . '\', false, 2, true, \'announcements\', \''.FOLDER_MODULES.'/announcements.php\', \'newspaper\', \'SYS_ANNOUNCEMENTS\', \'SYS_ANNOUNCEMENTS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'EVENTS\'), 1, \'' . Uuid::uuid4() . '\', false, 3, true, \'events\', \''.FOLDER_MODULES.'/events/events.php\', \'calendar-week-fill\', \'SYS_EVENTS\', \'SYS_EVENTS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MESSAGES\'), 1, \'' . Uuid::uuid4() . '\', false, 4, true, \'messages\', \''.FOLDER_MODULES.'/messages/messages.php\', \'envelope-fill\', \'SYS_MESSAGES\', \'SYS_MESSAGES_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'GROUPS-ROLES\'), 1, \'' . Uuid::uuid4() . '\', false, 5, true, \'groups-roles\', \''.FOLDER_MODULES.'/groups-roles/groups_roles.php\', \'people-fill\', \'SYS_GROUPS_ROLES\', \'SYS_GROUPS_ROLES_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'CONTACTS\'), 1, \'' . Uuid::uuid4() . '\', false, 6, true, \'contacts\', \''.FOLDER_MODULES.'/contacts/contacts.php\', \'person-vcard-fill\', \'SYS_CONTACTS\', \'SYS_CONTACTS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'DOCUMENTS-FILES\'), 1, \'' . Uuid::uuid4() . '\', false, 7, true, \'documents-files\', \''.FOLDER_MODULES.'/documents-files.php\', \'file-earmark-arrow-down-fill\', \'SYS_DOCUMENTS_FILES\', \'SYS_DOCUMENTS_FILES_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'INVENTORY\'), 1, \'' . Uuid::uuid4() . '\', false, 8, true, \'inventory\', \''.FOLDER_MODULES.'/inventory.php\', \'box-seam-fill\', \'SYS_INVENTORY\', \'SYS_INVENTORY_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PHOTOS\'), 1, \'' . Uuid::uuid4() . '\', false, 9, true, \'photo\', \''.FOLDER_MODULES.'/photos/photos.php\', \'image-fill\', \'SYS_PHOTOS\', \'SYS_PHOTOS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'CATEGORY-REPORT\'), 1, \'' . Uuid::uuid4() . '\', false, 10, true, \'category-report\', \''.FOLDER_MODULES.'/category-report/category_report.php\', \'list-stars\', \'SYS_CATEGORY_REPORT\', \'SYS_CATEGORY_REPORT_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'LINKS\'), 1, \'' . Uuid::uuid4() . '\', false, 11, true, \'weblinks\', \''.FOLDER_MODULES.'/links/links.php\', \'link-45deg\', \'SYS_WEBLINKS\', \'SYS_WEBLINKS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'FORUM\'), 1, \'' . Uuid::uuid4() . '\', false, 12, true, \'forum\', \''.FOLDER_MODULES.'/forum.php\', \'chat-dots-fill\', \'SYS_FORUM\', \'SYS_FORUM_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PREFERENCES\'), 2, \'' . Uuid::uuid4() . '\', false, 1, true, \'orgprop\', \''.FOLDER_MODULES.'/preferences.php\', \'gear-fill\', \'SYS_SETTINGS\', \'ORG_ORGANIZATION_PROPERTIES_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'REGISTRATION\'), 2, \'' . Uuid::uuid4() . '\', false, 2, true, \'registration\', \''.FOLDER_MODULES.'/registration.php\', \'card-checklist\', \'SYS_REGISTRATIONS\', \'SYS_MANAGE_NEW_REGISTRATIONS_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MENU\'), 2, \'' . Uuid::uuid4() . '\', false, 3, true, \'menu\', \''.FOLDER_MODULES.'/menu.php\', \'menu-button-wide-fill\', \'SYS_MENU\', \'SYS_MENU_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'ORGANIZATIONS\'), 2, \'' . Uuid::uuid4() . '\', false, 4, true, \'organization\', \''.FOLDER_MODULES.'/organizations.php\', \'diagram-3-fill\', \'SYS_ORGANIZATION\', \'SYS_ORGANIZATION_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PLUGINS\'), 2, \'' . Uuid::uuid4() . '\', false, 5, true, \'plugins\', \''.FOLDER_MODULES.'/plugins.php\', \'puzzle\', \'SYS_PLUGIN_MANAGER\', \'SYS_PLUGIN_MANAGER_DESC\')
-             , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'CHANGELOG\'), 2, \'' . Uuid::uuid4() . '\', false, 6, true, \'changelog\', \''.FOLDER_MODULES.'/changelog/changelog.php\', \'clock-history\', \'SYS_CHANGE_HISTORY\', \'SYS_CHANGE_HISTORY_DESC\')';
-$db->query($sql);
-
-// install all overview plugins
-$pluginManager = new PluginManager();
-$plugins = $pluginManager->getAvailablePlugins();
-
-foreach ($plugins as $plugin) {
-    // check, if the plugin has an interface, if not, scip it
-    if (!isset($plugin['interface']) || $plugin['interface'] == null) {
-        continue;
-    }
-    // check if the plugin is an overview plugin, if so, install it
-    $instance = $plugin['interface']::getInstance();
-    if ($instance->isAdmidioPlugin()) {
-        // Install the overview plugin
-        $instance->doInstall();
-    }
-}
+// create the database and all its data with the values that were collected by the wizard
+Installation::install($db, InstallationConfig::fromInstallerSession($_SESSION, ADMIDIO_URL));
 
 // delete session data
 session_unset();
 session_destroy();
-
-$gLogger->info('INSTALLATION: Installation successfully complete');
 
 echo json_encode(array(
     'status' => 'success',

--- a/install/installation.php
+++ b/install/installation.php
@@ -6,6 +6,7 @@ use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Session\Entity\Session;
 use Admidio\UI\Presenter\InstallationPresenter;
 use Admidio\Infrastructure\Entity\Entity;
+use Admidio\InstallationUpdate\ValueObject\InstallationConfig;
 
 /**
  ***********************************************************************************************
@@ -36,7 +37,8 @@ try {
      */
     function getAdmidioUrl(bool $checkForwardedHost = true): string
     {
-        $ssl = !empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'on') === 0;
+        $ssl = (!empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'on') === 0)
+            || (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0);
         $sp = strtolower($_SERVER['SERVER_PROTOCOL']);
         $protocol = substr($sp, 0, strpos($sp, '/')) . ($ssl ? 's' : '');
         $port = (int)$_SERVER['SERVER_PORT'];
@@ -105,7 +107,16 @@ try {
 
     $gL10n = new Language($language);
 
-    $language = $gL10n->getLanguage();
+    /*
+     * The wizard skips the language step if a configuration file already exists, therefore the
+     * language of the browser is used until the user selects one. It is stored in the session
+     * because the installation writes it as the language of the new organization.
+     */
+    if ($gL10n->getLanguage() === '') {
+        $gL10n->setLanguage(Language::determineBrowserLanguage('en'));
+    }
+
+    $_SESSION['language'] = $gL10n->getLanguage();
 
     /* Disable logging changes to the database. This will not be reverted,
      *  i.e. during installation / setup no logs are written. The next user
@@ -159,7 +170,7 @@ try {
             // save database parameters of config.php in session variables
             $_SESSION['db_type'] = DB_TYPE;
             $_SESSION['db_host'] = DB_HOST;
-            $_SESSION['db_port'] = DB_PORT;
+            $_SESSION['db_port'] = InstallationConfig::normalizePort(DB_PORT);
             $_SESSION['db_name'] = DB_NAME;
             $_SESSION['db_username'] = DB_USERNAME;
             $_SESSION['db_password'] = DB_PASSWORD;

--- a/languages/en.xml
+++ b/languages/en.xml
@@ -47,6 +47,7 @@
   <string name="INS_ORGA_SHORTNAME_EXISTS">Organization #VAR1_BOLD# already exists. Please select another name.</string>
   <string name="INS_PHONE_LIST">Phone list</string>
   <string name="INS_PLEASE_CHOOSE_LANGUAGE">Please choose a language</string>
+  <string name="INS_ROOT_URL_INVALID">The URL of the Admidio installation is not valid. Enter the complete URL of the installation, for example https://www.example.org/admidio</string>
   <string name="INS_SET_ORGANIZATION">Define organization</string>
   <string name="INS_SET_UP_ORGANIZATION">Setting up organization</string>
   <string name="INS_SETUP_WAS_SUCCESSFUL">Set up successful</string>

--- a/src/Infrastructure/Cli/CliInstallationInput.php
+++ b/src/Infrastructure/Cli/CliInstallationInput.php
@@ -1,0 +1,338 @@
+<?php
+namespace Admidio\Infrastructure\Cli;
+
+use Admidio\Infrastructure\Utils\PasswordUtils;
+use Admidio\Infrastructure\Utils\StringUtils;
+use DateTimeZone;
+use RuntimeException;
+
+/**
+ ***********************************************************************************************
+ * Interactive questionnaire of install:check and install:run.
+ *
+ * The commands take every value of a new installation as an option, which is what a script needs
+ * but a lot to type by hand. If a value is missing, this class asks for it, in the order of the
+ * web installation wizard, and returns the completed command line.
+ *
+ * It runs before Admidio is bootstrapped, because the table prefix and the time zone are needed to
+ * build the table names and the timestamps of the installation. Therefore it only uses plain PHP
+ * and the two utility classes that need no Admidio constants. The authoritative validation is the
+ * one of Admidio\InstallationUpdate\Service\Installation, which the command runs afterwards; the
+ * checks here exist so that a typo is reported at the question instead of at the end of the
+ * questionnaire.
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ ***********************************************************************************************
+ */
+final class CliInstallationInput
+{
+    /**
+     * Ask for every value of the installation that the command line doesn't contain.
+     *
+     * @param array<int,string> $argv Arguments of the process.
+     * @param string $rootPath Path of the Admidio installation.
+     * @return array<int,string> Returns the arguments with an option for every answer.
+     */
+    public static function complete(array $argv, string $rootPath): array
+    {
+        // --no-interaction is the promise of a caller that it answers no questions
+        if (self::flag($argv, 'no-interaction')) {
+            return $argv;
+        }
+
+        /*
+         * An existing configuration file defines the database, the URL and the time zone of this
+         * installation, so only the values of the organization are missing.
+         */
+        $configFileExists = is_file($rootPath . '/adm_my_files/config.php');
+        $answers = array();
+
+        self::write(PHP_EOL . 'Installation of Admidio. Press Ctrl+C to abort.' . PHP_EOL);
+
+        self::ask($argv, $answers, 'language', 'Language of the organization', 'en', function (string $value) use ($rootPath): ?string {
+            return array_key_exists($value, self::supportedLanguages($rootPath))
+                ? null
+                : 'Unknown language. Available: ' . implode(', ', array_keys(self::supportedLanguages($rootPath)));
+        });
+
+        if (!$configFileExists) {
+            self::write(PHP_EOL . 'Address of the installation' . PHP_EOL);
+            self::ask($argv, $answers, 'root-url', 'URL of this Admidio installation', '', function (string $value): ?string {
+                return filter_var($value, FILTER_VALIDATE_URL) !== false
+                    && in_array(parse_url($value, PHP_URL_SCHEME), array('http', 'https'), true)
+                    ? null
+                    : 'Enter the complete URL, for example https://www.example.org/admidio';
+            });
+
+            self::write(PHP_EOL . 'Access to the database' . PHP_EOL);
+            self::ask($argv, $answers, 'db-type', 'Database system (mariadb, mysql, pgsql)', 'mariadb', function (string $value): ?string {
+                return in_array($value, array('mariadb', 'mysql', 'pgsql'), true)
+                    ? null
+                    : 'Admidio only supports mariadb, mysql and pgsql.';
+            });
+            self::ask($argv, $answers, 'db-host', 'Host of the database server', 'localhost', function (string $value): ?string {
+                return filter_var($value, FILTER_VALIDATE_DOMAIN) !== false || filter_var($value, FILTER_VALIDATE_IP) !== false
+                    ? null
+                    : 'Enter a host name or an IP address.';
+            });
+            self::ask($argv, $answers, 'db-port', 'Port of the database server, empty for the default port', '', function (string $value): ?string {
+                if ($value === '') {
+                    return null;
+                }
+                return is_numeric($value) && (int) $value >= 1 && (int) $value <= 65535 ? null : 'Enter a port between 1 and 65535.';
+            });
+            self::ask($argv, $answers, 'db-name', 'Name of the database', '', self::identifierValidator('database name', 64));
+            self::ask($argv, $answers, 'db-user', 'User of the database', '', self::identifierValidator('user name', 64));
+            self::askSecret($argv, $answers, 'db-password', 'Password of the database user', false);
+            self::ask($argv, $answers, 'table-prefix', 'Prefix of the Admidio tables', 'adm', self::identifierValidator('table prefix', 10));
+        }
+
+        self::write(PHP_EOL . 'Organization' . PHP_EOL);
+        self::ask($argv, $answers, 'organization-shortname', 'Short name of the organization', '', function (string $value): ?string {
+            return StringUtils::strValidCharacters($value, 'noSpecialChar')
+                ? null
+                : 'Allowed are letters, numbers and the special characters .-_+@';
+        });
+        self::ask($argv, $answers, 'organization-name', 'Name of the organization', '', self::notEmptyValidator());
+        self::ask($argv, $answers, 'organization-email', 'Email address of the organization', '', self::emailValidator());
+
+        if (!$configFileExists) {
+            self::ask($argv, $answers, 'timezone', 'Time zone of the organization', date_default_timezone_get(), function (string $value): ?string {
+                return in_array($value, DateTimeZone::listIdentifiers(), true)
+                    ? null
+                    : 'Unknown time zone. Use a name of https://www.php.net/manual/en/timezones.php';
+            });
+        }
+
+        self::write(PHP_EOL . 'Administrator' . PHP_EOL);
+        self::ask($argv, $answers, 'admin-last-name', 'Last name of the administrator', '', self::notEmptyValidator());
+        self::ask($argv, $answers, 'admin-first-name', 'First name of the administrator', '', self::notEmptyValidator());
+        self::ask($argv, $answers, 'admin-email', 'Email address of the administrator', '', self::emailValidator());
+        self::ask($argv, $answers, 'admin-login', 'Login name of the administrator', '', function (string $value): ?string {
+            return StringUtils::strValidCharacters($value, 'noSpecialChar')
+                ? null
+                : 'Allowed are letters, numbers and the special characters .-_+@';
+        });
+        // the password may not consist of the data of the administrator, so zxcvbn needs to know it
+        self::askSecret($argv, $answers, 'admin-password', 'Password of the administrator', true, array(
+            self::value($argv, $answers, 'admin-last-name'),
+            self::value($argv, $answers, 'admin-first-name'),
+            self::value($argv, $answers, 'admin-email'),
+            self::value($argv, $answers, 'admin-login')
+        ));
+
+        self::write(PHP_EOL);
+
+        foreach ($answers as $name => $value) {
+            /*
+             * The answers are appended to the arguments of this process, they never become part of
+             * the command line of the operating system, so a password stays invisible to others.
+             */
+            $argv[] = '--' . $name . '=' . $value;
+        }
+
+        return $argv;
+    }
+
+    /**
+     * Ask for one value, until the answer is valid.
+     *
+     * @param array<int,string> $argv
+     * @param array<string,string> $answers
+     * @param callable|null $validator Returns an error text for an invalid answer, null if it is valid.
+     */
+    private static function ask(array $argv, array &$answers, string $option, string $question, string $default, ?callable $validator = null): void
+    {
+        if (self::option($argv, $option) !== null) {
+            return;
+        }
+
+        while (true) {
+            $answer = self::read($question . ($default === '' ? '' : ' [' . $default . ']') . ': ');
+
+            if ($answer === '') {
+                $answer = $default;
+            }
+
+            $error = $validator === null ? null : $validator($answer);
+            if ($error === null) {
+                $answers[$option] = $answer;
+                return;
+            }
+
+            self::write($error . PHP_EOL);
+        }
+    }
+
+    /**
+     * Ask for a password without showing it. A password of the installation is repeated, a password
+     * that only has to match an existing database is not.
+     *
+     * @param array<int,string> $argv
+     * @param array<string,string> $answers
+     * @param array<int,string> $userData Values that a password may not consist of.
+     */
+    private static function askSecret(array $argv, array &$answers, string $option, string $question, bool $repeat, array $userData = array()): void
+    {
+        if (self::option($argv, $option) !== null || self::flag($argv, $option . '-stdin')) {
+            return;
+        }
+
+        while (true) {
+            $answer = self::read($question . ': ', true);
+
+            if (!$repeat) {
+                $answers[$option] = $answer;
+                return;
+            }
+
+            if (strlen($answer) < 8) {
+                self::write('The password must have at least 8 characters.' . PHP_EOL);
+                continue;
+            }
+            if (PasswordUtils::passwordStrength($answer, $userData) < 1) {
+                self::write('The password is not secure enough.' . PHP_EOL);
+                continue;
+            }
+            if ($answer !== self::read('Repeat the password: ', true)) {
+                self::write('The passwords are not equal.' . PHP_EOL);
+                continue;
+            }
+
+            $answers[$option] = $answer;
+            return;
+        }
+    }
+
+    /**
+     * @return callable
+     */
+    private static function identifierValidator(string $label, int $maxLength): callable
+    {
+        return function (string $value) use ($label, $maxLength): ?string {
+            if ($value === '' || strlen($value) > $maxLength) {
+                return 'Enter a ' . $label . ' of 1 to ' . $maxLength . ' characters.';
+            }
+
+            return preg_match('/^[a-zA-Z0-9_$@-]+$/', $value) === 1
+                ? null
+                : 'Allowed are letters, numbers and the special characters _$@-';
+        };
+    }
+
+    /**
+     * @return callable
+     */
+    private static function notEmptyValidator(): callable
+    {
+        return function (string $value): ?string {
+            return trim($value) === '' ? 'The value must not be empty.' : null;
+        };
+    }
+
+    /**
+     * @return callable
+     */
+    private static function emailValidator(): callable
+    {
+        return function (string $value): ?string {
+            return filter_var($value, FILTER_VALIDATE_EMAIL) !== false ? null : 'Enter a valid email address.';
+        };
+    }
+
+    /**
+     * Read one line from the input of the process. A password is not echoed, which is only possible
+     * through stty and therefore not on Windows.
+     */
+    private static function read(string $question, bool $secret = false): string
+    {
+        self::write($question);
+
+        $restore = null;
+        if ($secret && PHP_OS_FAMILY !== 'Windows' && function_exists('shell_exec')) {
+            $settings = @shell_exec('stty -g 2>/dev/null');
+            if (is_string($settings) && trim($settings) !== '') {
+                $restore = trim($settings);
+                @shell_exec('stty -echo 2>/dev/null');
+            }
+        }
+
+        try {
+            $answer = fgets(STDIN);
+        } finally {
+            if ($restore !== null) {
+                @shell_exec('stty ' . escapeshellarg($restore) . ' 2>/dev/null');
+                // the newline of the user was swallowed together with the echo
+                self::write(PHP_EOL);
+            }
+        }
+
+        if ($answer === false) {
+            throw new RuntimeException(
+                'The installation needs more values, but there is no more input. Give the missing values '
+                . 'as options, or use --no-interaction to get the name of the first missing option.'
+            );
+        }
+
+        return trim($answer);
+    }
+
+    private static function write(string $text): void
+    {
+        fwrite(STDERR, $text);
+    }
+
+    /**
+     * Read the value of an option out of the arguments, in the two notations that the command line
+     * of Admidio accepts.
+     *
+     * @param array<int,string> $argv
+     * @return string|null Returns null if the option was not used.
+     */
+    private static function option(array $argv, string $name): ?string
+    {
+        $prefix = '--' . $name . '=';
+
+        for ($index = 1, $count = count($argv); $index < $count; ++$index) {
+            if (str_starts_with($argv[$index], $prefix)) {
+                return substr($argv[$index], strlen($prefix));
+            }
+            if ($argv[$index] === '--' . $name && isset($argv[$index + 1])) {
+                return $argv[$index + 1];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Value of an option, no matter whether it was given on the command line or answered here.
+     *
+     * @param array<int,string> $argv
+     * @param array<string,string> $answers
+     */
+    private static function value(array $argv, array $answers, string $name): string
+    {
+        return $answers[$name] ?? self::option($argv, $name) ?? '';
+    }
+
+    /**
+     * @param array<int,string> $argv
+     */
+    private static function flag(array $argv, string $name): bool
+    {
+        return in_array('--' . $name, $argv, true);
+    }
+
+    /**
+     * @return array<string,array<string,string>> Returns the languages that Admidio supports.
+     */
+    private static function supportedLanguages(string $rootPath): array
+    {
+        require $rootPath . '/languages/languages.php';
+
+        return $gSupportedLanguages;
+    }
+}

--- a/src/Infrastructure/Cli/CoreTasks.php
+++ b/src/Infrastructure/Cli/CoreTasks.php
@@ -25,6 +25,8 @@ use Admidio\Infrastructure\Utils\MaintenanceMode;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
 use Admidio\Infrastructure\Utils\SystemInfoUtils;
+use Admidio\InstallationUpdate\Service\Installation;
+use Admidio\InstallationUpdate\ValueObject\InstallationConfig;
 use Admidio\Inventory\Entity\Item;
 use Admidio\Inventory\Entity\ItemBorrowData;
 use Admidio\Inventory\Entity\ItemField;
@@ -411,12 +413,67 @@ final class CoreTasks
 
     private static function registerSystemTasks(): void
     {
-        $installReason = 'current master implements installation as the procedural web flow under install/install_steps/; '
-            . 'src/InstallationUpdate/Service/Installation.php has no complete headless installation operation.';
-        self::task('install:check', 'unavailable', 'Validate prerequisites for a new installation.',
-            'install:check', null, false, array(), array(), array(), $installReason);
-        self::task('install:run', 'unavailable', 'Install a new Admidio database and organization.',
-            'install:run', null, false, array(), array(), array(), $installReason);
+        /*
+         * The database of a new installation is described by adm_my_files/config.php. If that file
+         * already exists, its values are used and the --db-* options may only repeat them. If it
+         * doesn't exist, the options describe the database and install:run writes the file.
+         *
+         * Every value that is not given as an option is asked for, in the order of the web
+         * installation wizard, unless --no-interaction forbids questions.
+         */
+        $installOptions = array(
+            self::opt('db-type', 'Database system. Required without an existing configuration file.', 'TYPE', false, false, false, array('mariadb', 'mysql', 'pgsql')),
+            self::opt('db-host', 'Host name or IP address of the database server.', 'HOST'),
+            self::opt('db-port', 'Port of the database server. Empty for the default port of the database system.', 'PORT'),
+            self::opt('db-name', 'Name of the database.', 'NAME'),
+            self::opt('db-user', 'User of the database.', 'USER'),
+            self::opt('db-password', 'Password of the database user. Prefer --db-password-stdin.', 'PASSWORD'),
+            self::opt('db-password-stdin', 'Read the password of the database user from STDIN.', '', false, false, true),
+            self::opt('table-prefix', 'Prefix of the Admidio tables, "adm" by default.', 'PREFIX'),
+            self::opt('root-url', 'URL of this Admidio installation. Required without an existing configuration file.', 'URL'),
+            self::opt('language', 'Language of the new organization, "en" by default.', 'LANGUAGE'),
+            self::opt('timezone', 'Time zone of the new organization.', 'TIMEZONE'),
+            self::opt('organization-shortname', 'Short name of the organization.', 'NAME', true),
+            self::opt('organization-name', 'Name of the organization.', 'NAME', true),
+            self::opt('organization-email', 'Email address of the organization administrator.', 'EMAIL', true),
+            self::opt('admin-login', 'Login name of the administrator.', 'LOGIN', true),
+            self::opt('admin-first-name', 'First name of the administrator.', 'NAME', true),
+            self::opt('admin-last-name', 'Last name of the administrator.', 'NAME', true),
+            self::opt('admin-email', 'Email address of the administrator.', 'EMAIL', true),
+            self::opt('admin-password', 'Password of the administrator. Prefer --admin-password-stdin.', 'PASSWORD'),
+            self::opt('admin-password-stdin', 'Read the password of the administrator from STDIN. It is the second line if the database password is read from STDIN too.', '', false, false, true),
+            self::opt('format', 'Output format.', 'FORMAT', false, false, false, array('text', 'json'))
+        );
+        $installUsage = '--db-type=TYPE --db-host=HOST --db-name=NAME --db-user=USER --root-url=URL'
+            . ' --organization-shortname=NAME --organization-name=NAME --organization-email=EMAIL'
+            . ' --admin-login=LOGIN --admin-first-name=NAME --admin-last-name=NAME --admin-email=EMAIL [options]';
+        $installExample = 'admidio %COMMAND% --db-type=mariadb --db-host=localhost --db-name=admidio --db-user=admidio'
+            . ' --db-password-stdin --root-url=https://www.example.org/admidio --timezone=Europe/Berlin'
+            . ' --organization-shortname=EXAMPLE --organization-name="Example Organization" --organization-email=info@example.org'
+            . ' --admin-login=admin --admin-first-name=Anna --admin-last-name=Admin --admin-email=anna@example.org --admin-password-stdin';
+
+        self::task(
+            'install:check',
+            'installCheck',
+            'Check all values and prerequisites of a new installation without changing anything. Missing values are asked for.',
+            'install:check ' . $installUsage,
+            null,
+            false,
+            array(),
+            $installOptions,
+            array(str_replace('%COMMAND%', 'install:check', $installExample))
+        );
+        self::task(
+            'install:run',
+            'installRun',
+            'Install a new Admidio database with its first organization and administrator. Missing values are asked for, --no-interaction requires all of them as options.',
+            'install:run ' . $installUsage . ' [--yes]',
+            null,
+            false,
+            array(),
+            array_merge($installOptions, array(self::opt('yes', 'Confirm the installation.', '', false, false, true))),
+            array(str_replace('%COMMAND%', 'install:run', $installExample) . ' --yes')
+        );
 
         self::task(
             'update:check',
@@ -2289,6 +2346,236 @@ final class CoreTasks
         }
 
         return $state === 'ok' ? CliApplication::EXIT_SUCCESS : CliApplication::EXIT_STATE_NOT_OK;
+    }
+
+    /**
+     * Path of the configuration file that describes the database of this Admidio installation.
+     */
+    private static function installationConfigPath(): string
+    {
+        return ADMIDIO_PATH . FOLDER_DATA . '/config.php';
+    }
+
+    /**
+     * Build the input of a new installation out of the options of install:check and install:run.
+     *
+     * Admidio derives its table names, its time zone and its URL from the configuration file while
+     * it is bootstrapping, therefore long before this command runs. The corresponding options were
+     * already read by the CLI bootstrap, and the values of the bootstrap are the defaults here. A
+     * difference between both means that the option cannot take effect, so it is reported instead
+     * of silently installing something else.
+     *
+     * @param array<string,mixed> $options
+     * @throws Exception
+     */
+    private static function installationConfig(array $options): InstallationConfig
+    {
+        global $gL10n;
+
+        $configFileExists = is_file(self::installationConfigPath());
+
+        $config = InstallationConfig::fromArray(array(
+            'dbType' => CliApplication::optionString($options, 'db-type', $configFileExists ? DB_TYPE : ''),
+            'dbHost' => CliApplication::optionString($options, 'db-host', $configFileExists ? (string) DB_HOST : ''),
+            'dbPort' => CliApplication::optionString($options, 'db-port', $configFileExists && DB_PORT !== null ? (string) DB_PORT : ''),
+            'dbName' => CliApplication::optionString($options, 'db-name', $configFileExists ? (string) DB_NAME : ''),
+            'dbUsername' => CliApplication::optionString($options, 'db-user', $configFileExists ? (string) DB_USERNAME : ''),
+            'dbPassword' => self::installationSecret($options, 'db-password', $configFileExists ? (string) DB_PASSWORD : ''),
+            'tablePrefix' => CliApplication::optionString($options, 'table-prefix', TABLE_PREFIX),
+            'rootUrl' => CliApplication::optionString($options, 'root-url', $configFileExists ? ADMIDIO_URL : ''),
+            'language' => CliApplication::optionString($options, 'language', $gL10n->getLanguage()),
+            'timezone' => CliApplication::optionString($options, 'timezone', date_default_timezone_get()),
+            'organizationShortName' => CliApplication::optionString($options, 'organization-shortname'),
+            'organizationName' => CliApplication::optionString($options, 'organization-name'),
+            'organizationEmail' => CliApplication::optionString($options, 'organization-email'),
+            'adminLogin' => CliApplication::optionString($options, 'admin-login'),
+            'adminFirstName' => CliApplication::optionString($options, 'admin-first-name'),
+            'adminLastName' => CliApplication::optionString($options, 'admin-last-name'),
+            'adminEmail' => CliApplication::optionString($options, 'admin-email'),
+            'adminPassword' => self::installationSecret($options, 'admin-password', '')
+        ));
+
+        if ($configFileExists) {
+            /*
+             * The site reads its database out of the configuration file, so an installation into a
+             * different database would leave a site that cannot reach its own data.
+             */
+            self::assertConfigFileValue('db-type', $config->dbType, DB_TYPE);
+            self::assertConfigFileValue('db-host', $config->dbHost, (string) DB_HOST);
+            self::assertConfigFileValue('db-port', (string) $config->dbPort, (string) InstallationConfig::normalizePort(DB_PORT));
+            self::assertConfigFileValue('db-name', $config->dbName, (string) DB_NAME);
+            self::assertConfigFileValue('db-user', $config->dbUsername, (string) DB_USERNAME);
+            self::assertConfigFileValue('db-password', $config->dbPassword, (string) DB_PASSWORD, false);
+            self::assertConfigFileValue('table-prefix', $config->tablePrefix, TABLE_PREFIX);
+            self::assertConfigFileValue('timezone', $config->timezone, date_default_timezone_get());
+            self::assertConfigFileValue('root-url', $config->rootUrl, rtrim(ADMIDIO_URL, '/'));
+
+            return $config;
+        }
+
+        if (CliApplication::optionString($options, 'root-url') === '') {
+            throw new InvalidArgumentException(
+                'Missing required option --root-url. Without ' . FOLDER_DATA
+                . '/config.php the URL of the new installation is not known.'
+            );
+        }
+
+        self::assertBootstrapValue('db-type', $config->dbType, DB_TYPE);
+        self::assertBootstrapValue('table-prefix', $config->tablePrefix, TABLE_PREFIX);
+        self::assertBootstrapValue('timezone', $config->timezone, date_default_timezone_get());
+        self::assertBootstrapValue('root-url', $config->rootUrl, rtrim(ADMIDIO_URL, '/'));
+
+        return $config;
+    }
+
+    /**
+     * Read a password of the installation, either from its option or from a line of STDIN.
+     *
+     * @param array<string,mixed> $options
+     */
+    private static function installationSecret(array $options, string $name, string $default): string
+    {
+        $secret = CliApplication::readSecret($options, $name, $name . '-stdin');
+
+        return $secret === '' ? $default : $secret;
+    }
+
+    /**
+     * Check an option of the installation against the value that the configuration file defines.
+     *
+     * @param bool $showValues Set to false for a secret, whose values may not be printed.
+     * @throws InvalidArgumentException
+     */
+    private static function assertConfigFileValue(
+        string $option,
+        string $value,
+        string $configFileValue,
+        bool $showValues = true
+    ): void {
+        if ($value === $configFileValue) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            '--' . $option . ($showValues ? ' is "' . $value . '" but ' : ' does not match ')
+            . FOLDER_DATA . '/config.php' . ($showValues ? ' defines "' . $configFileValue . '"' : '')
+            . '. An existing configuration file defines the database of this installation, so either '
+            . 'remove the option or the configuration file.'
+        );
+    }
+
+    /**
+     * Check an option of the installation against the value that Admidio was started with.
+     *
+     * The constants that are derived from these options exist before a command is dispatched, so the
+     * CLI bootstrap reads them itself. It only understands the forms "--option value" and
+     * "--option=value" outside of the "--" terminator.
+     *
+     * @throws RuntimeException
+     */
+    private static function assertBootstrapValue(string $option, string $value, string $bootstrapValue): void
+    {
+        if ($value === $bootstrapValue) {
+            return;
+        }
+
+        throw new RuntimeException(
+            '--' . $option . ' was not readable before Admidio started, which is why "' . $bootstrapValue
+            . '" was used instead of "' . $value . '". Write the option as --' . $option . '=VALUE.'
+        );
+    }
+
+    /**
+     * Report the values of an installation that a command has established.
+     *
+     * @param array<string,mixed> $options
+     * @param array<string,mixed> $result
+     */
+    private static function writeInstallationValues(InstallationConfig $config, array $result, array $options): void
+    {
+        CliApplication::writeValue(
+            array_merge(
+                array(
+                    'config_file' => self::installationConfigPath(),
+                    'database_type' => $config->dbType,
+                    'database_host' => $config->dbHost,
+                    'database_name' => $config->dbName,
+                    'table_prefix' => $config->tablePrefix,
+                    'root_url' => $config->rootUrl,
+                    'organization' => $config->organizationShortName,
+                    'administrator' => $config->adminLogin
+                ),
+                $result
+            ),
+            $options,
+            CliApplication::optionString($options, 'format', 'record')
+        );
+    }
+
+    public static function installCheck(array $arguments, array $options): int
+    {
+        $config = self::installationConfig($options);
+        $configFileExists = is_file(self::installationConfigPath());
+
+        Installation::validateConfiguration($config);
+
+        /*
+         * The command may not change anything, so the folders that the installation needs are only
+         * checked for the permission that would let install:run create them.
+         */
+        if (!is_dir(ADMIDIO_PATH . FOLDER_DATA) || !is_writable(ADMIDIO_PATH . FOLDER_DATA)) {
+            throw new RuntimeException(FOLDER_DATA . ' has to exist and it has to be writable.');
+        }
+
+        $db = Installation::connectDatabase($config);
+
+        self::writeInstallationValues(
+            $config,
+            array(
+                'config_file_state' => $configFileExists ? 'exists' : 'will be created',
+                'database_version' => $db->getName() . ' ' . $db->getVersion(),
+                'installable' => true
+            ),
+            $options
+        );
+
+        return CliApplication::EXIT_SUCCESS;
+    }
+
+    public static function installRun(array $arguments, array $options): int
+    {
+        $config = self::installationConfig($options);
+        $configFileExists = is_file(self::installationConfigPath());
+
+        Installation::validateConfiguration($config);
+        Installation::checkFolderPermissions();
+
+        // everything is checked before the first change, so a rejected installation leaves no traces
+        $db = Installation::connectDatabase($config);
+
+        CliApplication::confirm(
+            'Install Admidio for the organization "' . $config->organizationShortName . '" into the database "'
+            . $config->dbName . '" of ' . $config->dbHost . '?',
+            $options
+        );
+
+        if (!$configFileExists) {
+            Installation::writeConfigFile($config, self::installationConfigPath());
+        }
+
+        $result = Installation::install($db, $config);
+
+        self::writeInstallationValues(
+            $config,
+            array(
+                'organization_id' => $result['organizationId'],
+                'administrator_id' => $result['administratorId'],
+                'installed' => true
+            ),
+            $options
+        );
+
+        return CliApplication::EXIT_SUCCESS;
     }
 
     public static function updateCheck(array $arguments, array $options): int

--- a/src/InstallationUpdate/Service/Installation.php
+++ b/src/InstallationUpdate/Service/Installation.php
@@ -1,14 +1,33 @@
 <?php
 namespace Admidio\InstallationUpdate\Service;
 
+use Admidio\Components\Entity\ComponentUpdate;
+use Admidio\Infrastructure\Entity\Entity;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Database;
+use Admidio\Infrastructure\Plugins\PluginManager;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
+use Admidio\Infrastructure\Utils\PasswordUtils;
+use Admidio\Infrastructure\Utils\PhpIniUtils;
+use Admidio\Infrastructure\Utils\StringUtils;
+use Admidio\InstallationUpdate\ValueObject\InstallationConfig;
+use Admidio\Organizations\Entity\Organization;
+use Admidio\ProfileFields\ValueObjects\ProfileFields;
+use Admidio\Users\Entity\User;
+use DateTimeZone;
+use Ramsey\Uuid\Uuid;
 use RuntimeException;
 use UnexpectedValueException;
 
 /**
  * @brief Class to implement useful method for installation and update process.
+ *
+ * Beside the helper methods for the update the class implements the complete installation of a new
+ * Admidio database. install() creates the schema, the default data, the first organization and its
+ * administrator from an InstallationConfig, and generateConfigFileContent() and writeConfigFile()
+ * create the configuration file. None of these methods reads a request, a session or a form, so the
+ * web installation wizard and the command line share the same installation.
+ *
  * @copyright The Admidio Team
  * @see https://www.admidio.org/
  * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
@@ -82,7 +101,7 @@ class Installation
      */
     public static function disableSoundexSearchIfPgSql(Database $db)
     {
-        if (DB_TYPE === Database::PDO_ENGINE_PGSQL) {
+        if ($db->getEngine() === Database::PDO_ENGINE_PGSQL) {
             // soundex is not a default function in PostgresSQL
             $sql = 'UPDATE ' . TBL_PREFERENCES . '
                    SET prf_value = false
@@ -114,6 +133,780 @@ class Installation
 
         foreach ($sqlStatements as $sqlStatement) {
             $db->queryPrepared($sqlStatement);
+        }
+    }
+
+    /**
+     * Check the values that are necessary to connect to the database of the new installation. This is
+     * the validation of the database step of the installation wizard.
+     * @param string $dbType Database system, one of the Database::DB_TYPE_* values.
+     * @param string $dbHost Host name or IP address of the database server.
+     * @param int|null $dbPort Port of the database server or **null** for the default port.
+     * @param string $dbName Name of the database.
+     * @param string $dbUsername User of the database.
+     * @param string $tablePrefix Prefix of all Admidio tables.
+     * @return void
+     * @throws Exception
+     */
+    public static function validateDatabaseInput(
+        string $dbType,
+        string $dbHost,
+        ?int $dbPort,
+        string $dbName,
+        string $dbUsername,
+        string $tablePrefix
+    ): void {
+        $sqlIdentifiersRegex = '/^[a-zA-Z0-9_$@-]+$/';
+
+        if (!in_array($dbType, array(Database::DB_TYPE_MARIADB, Database::DB_TYPE_MYSQL, Database::DB_TYPE_PGSQL), true)) {
+            throw new Exception('INS_DATABASE_TYPE_INVALID');
+        }
+
+        // TODO: unix_server is currently not supported
+        if (filter_var($dbHost, FILTER_VALIDATE_DOMAIN) === false && filter_var($dbHost, FILTER_VALIDATE_IP) === false) {
+            throw new Exception('INS_HOST_INVALID');
+        }
+
+        if ($dbPort !== null && ($dbPort < 1 || $dbPort > 65535)) {
+            throw new Exception('INS_DATABASE_PORT_INVALID');
+        }
+
+        if (strlen($dbName) > 64 || preg_match($sqlIdentifiersRegex, $dbName) !== 1) {
+            throw new Exception('SYS_FIELD_INVALID_INPUT', array('SYS_DATABASE'));
+        }
+
+        if (strlen($dbUsername) > 64 || preg_match($sqlIdentifiersRegex, $dbUsername) !== 1) {
+            throw new Exception('SYS_FIELD_INVALID_INPUT', array('SYS_USERNAME'));
+        }
+
+        if (strlen($tablePrefix) > 10 || preg_match($sqlIdentifiersRegex, $tablePrefix) !== 1) {
+            throw new Exception('SYS_FIELD_INVALID_INPUT', array('INS_TABLE_PREFIX'));
+        }
+    }
+
+    /**
+     * Check the values of the organization that will be created. This is the validation of the
+     * organization step of the installation wizard.
+     * @param string $shortName Short name of the organization.
+     * @param string $longName Long name of the organization.
+     * @param string $email Email address of the organization administrator.
+     * @param string $timezone PHP time zone of the organization.
+     * @return void
+     * @throws Exception
+     */
+    public static function validateOrganizationInput(
+        string $shortName,
+        string $longName,
+        string $email,
+        string $timezone
+    ): void {
+        // allow only letters, numbers and special characters like .-_+@
+        if (!StringUtils::strValidCharacters($shortName, 'noSpecialChar')) {
+            throw new Exception('SYS_FIELD_INVALID_CHAR', array('SYS_NAME_ABBREVIATION'));
+        }
+
+        if ($longName === '') {
+            throw new Exception('SYS_FIELD_EMPTY', array('SYS_NAME'));
+        }
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            throw new Exception('SYS_EMAIL_INVALID', array('SYS_EMAIL_ADMINISTRATOR'));
+        }
+
+        if (!in_array($timezone, DateTimeZone::listIdentifiers(), true)) {
+            throw new Exception('SYS_FIELD_INVALID_INPUT', array('ORG_TIMEZONE'));
+        }
+    }
+
+    /**
+     * Check the values of the administrator that will be created. This is the validation of the
+     * administrator step of the installation wizard.
+     * @param string $login Login name of the administrator.
+     * @param string $firstName First name of the administrator.
+     * @param string $lastName Last name of the administrator.
+     * @param string $email Email address of the administrator.
+     * @param string $password Password of the administrator.
+     * @return void
+     * @throws Exception
+     */
+    public static function validateAdministratorInput(
+        string $login,
+        string $firstName,
+        string $lastName,
+        string $email,
+        string $password
+    ): void {
+        // username should only have valid chars
+        if (!StringUtils::strValidCharacters($login, 'noSpecialChar')) {
+            throw new Exception('SYS_FIELD_INVALID_CHAR', array('SYS_USERNAME'));
+        }
+
+        if ($firstName === '') {
+            throw new Exception('SYS_FIELD_EMPTY', array('SYS_FIRSTNAME'));
+        }
+
+        if ($lastName === '') {
+            throw new Exception('SYS_FIELD_EMPTY', array('SYS_LASTNAME'));
+        }
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            throw new Exception('SYS_EMAIL_INVALID', array('SYS_EMAIL'));
+        }
+
+        // Password min length is 8 chars
+        if (strlen($password) < PASSWORD_MIN_LENGTH) {
+            throw new Exception('SYS_PASSWORD_LENGTH');
+        }
+
+        // Admin Password should have a minimum strength of 1
+        if (PasswordUtils::passwordStrength($password, array($lastName, $firstName, $email, $login)) < 1) {
+            throw new Exception('SYS_PASSWORD_NOT_STRONG_ENOUGH');
+        }
+    }
+
+    /**
+     * Check all values of an installation. The web wizard validates the input of each step with the
+     * methods above, a headless installation receives all values at once and validates them here.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @return void
+     * @throws Exception
+     */
+    public static function validateConfiguration(InstallationConfig $config): void
+    {
+        global $gL10n;
+
+        self::validateDatabaseInput(
+            $config->dbType,
+            $config->dbHost,
+            $config->dbPort,
+            $config->dbName,
+            $config->dbUsername,
+            $config->tablePrefix
+        );
+
+        if ($config->rootUrl === '' || filter_var($config->rootUrl, FILTER_VALIDATE_URL) === false
+            || !in_array(parse_url($config->rootUrl, PHP_URL_SCHEME), array('http', 'https'), true)) {
+            throw new Exception('INS_ROOT_URL_INVALID');
+        }
+
+        if ($config->language === '') {
+            throw new Exception('INS_LANGUAGE_NOT_CHOSEN');
+        }
+
+        if (!array_key_exists($config->language, $gL10n->getAvailableLanguages())) {
+            throw new Exception('SYS_FIELD_INVALID_INPUT', array('SYS_LANGUAGE'));
+        }
+
+        self::validateOrganizationInput(
+            $config->organizationShortName,
+            $config->organizationName,
+            $config->organizationEmail,
+            $config->timezone
+        );
+        self::validateAdministratorInput(
+            $config->adminLogin,
+            $config->adminFirstName,
+            $config->adminLastName,
+            $config->adminEmail,
+            $config->adminPassword
+        );
+    }
+
+    /**
+     * Connect to the database of the new installation and check that Admidio can be installed there.
+     * The connection needs write access, the database must fulfill the minimum version and it may
+     * not contain an Admidio installation already.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @return Database Returns the connection to the database of the new installation.
+     * @throws Exception
+     */
+    public static function connectDatabase(InstallationConfig $config): Database
+    {
+        try {
+            $db = new Database(
+                $config->dbType,
+                $config->dbHost,
+                $config->dbPort,
+                $config->dbName,
+                $config->dbUsername,
+                $config->dbPassword
+            );
+            $db->checkWriteAccess();
+        } catch (Exception $e) {
+            throw new Exception('SYS_DATABASE_NO_LOGIN', array($e->getMessage()));
+        }
+
+        $message = self::checkDatabaseVersion($db);
+        if ($message !== '') {
+            throw new Exception($message);
+        }
+
+        self::checkInstallationNotExists($db, $config->tablePrefix);
+
+        return $db;
+    }
+
+    /**
+     * Check that the database doesn't contain an Admidio installation already. A second installation
+     * would overwrite the data of the existing one.
+     * @param Database $db Connection to the database of the new installation.
+     * @param string $tablePrefix Prefix of all Admidio tables.
+     * @return void
+     * @throws Exception
+     */
+    public static function checkInstallationNotExists(Database $db, string $tablePrefix): void
+    {
+        $sql = 'SELECT org_id FROM ' . $tablePrefix . '_organizations';
+        $pdoStatement = $db->queryPrepared($sql, array(), false);
+
+        // an error of the statement means that the table doesn't exist and therefore no installation exists
+        if ($pdoStatement !== false && $pdoStatement->rowCount() > 0) {
+            throw new Exception('INS_INSTALLATION_EXISTS');
+        }
+    }
+
+    /**
+     * Create the content of the configuration file config.php out of the template install/config.php
+     * and the values of the installation.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @return string Returns the content of the configuration file.
+     * @throws Exception
+     */
+    public static function generateConfigFileContent(InstallationConfig $config): string
+    {
+        $templatePath = ADMIDIO_PATH . FOLDER_INSTALLATION . '/config.php';
+
+        try {
+            $configFileContent = FileSystemUtils::readFile($templatePath);
+        } catch (RuntimeException | UnexpectedValueException $e) {
+            throw new Exception('INS_ERROR_OPEN_FILE', array($templatePath));
+        }
+
+        /*
+         * The values are written into single quoted PHP strings, so a backslash or an apostrophe of
+         * a password would otherwise create a configuration file that cannot be parsed.
+         */
+        $escape = static function (string $value): string {
+            return str_replace(array('\\', '\''), array('\\\\', '\\\''), $value);
+        };
+
+        // replace placeholders in configuration file structure with data of the installation
+        $replaces = array(
+            '%DB_TYPE%' => $escape($config->dbType),
+            '%DB_HOST%' => $escape($config->dbHost),
+            '\'%DB_PORT%\'' => $config->dbPort === null ? 'null' : (string) $config->dbPort, // String -> Int
+            '%DB_NAME%' => $escape($config->dbName),
+            '%DB_USERNAME%' => $escape($config->dbUsername),
+            '%DB_PASSWORD%' => $escape($config->dbPassword),
+            '%TABLE_PREFIX%' => $escape($config->tablePrefix),
+            '%ROOT_PATH%' => $escape($config->rootUrl),
+            '%TIMEZONE%' => $escape($config->timezone)
+        );
+
+        return StringUtils::strMultiReplace($configFileContent, $replaces);
+    }
+
+    /**
+     * Write the configuration file of the new installation. The file is created in a temporary file
+     * and moved to its destination afterwards, so an aborted write cannot leave a half written
+     * configuration file behind, which the next request would load.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @param string|null $configPath Path of the configuration file. Default is adm_my_files/config.php.
+     * @return string Returns the path of the written configuration file.
+     * @throws Exception
+     * @throws RuntimeException Throws if the file could not be written.
+     */
+    public static function writeConfigFile(InstallationConfig $config, ?string $configPath = null): string
+    {
+        $configPath ??= ADMIDIO_PATH . FOLDER_DATA . '/config.php';
+        $configFileContent = self::generateConfigFileContent($config);
+        $configFolder = dirname($configPath);
+
+        /*
+         * tempnam() would fall back to the temp folder of the system, where the file with the
+         * database password does not belong and from where it could not be moved on every system.
+         */
+        if (!is_writable($configFolder)) {
+            throw new RuntimeException('The folder ' . $configFolder . ' is not writable.');
+        }
+
+        $temporaryFile = @tempnam($configFolder, 'config');
+        if ($temporaryFile === false) {
+            throw new RuntimeException('The configuration file ' . $configPath . ' could not be written.');
+        }
+
+        try {
+            // tempnam() creates the file for the current user only, but the web server has to read it
+            @chmod($temporaryFile, 0666 & ~umask());
+
+            if (@file_put_contents($temporaryFile, $configFileContent) === false
+                || !@rename($temporaryFile, $configPath)) {
+                throw new RuntimeException('The configuration file ' . $configPath . ' could not be written.');
+            }
+        } finally {
+            if (is_file($temporaryFile)) {
+                @unlink($temporaryFile);
+            }
+        }
+
+        return $configPath;
+    }
+
+    /**
+     * Install a new Admidio database. The method creates the database schema, all default data, the
+     * first organization with its preferences and basic data, the administrator of that organization
+     * and installs the plugins that are delivered with Admidio.
+     *
+     * The database must be empty, use connectDatabase() to create a connection that was checked for
+     * that. The configuration file must already match the given values, because the table prefix,
+     * the time zone and the URL of the installation are read from the Admidio constants.
+     *
+     * @param Database $db Connection to the database of the new installation.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @return array<string,int> Returns the id of the created organization and of its administrator.
+     * @throws Exception
+     */
+    public static function install(Database $db, InstallationConfig $config): array
+    {
+        global $gDb, $gL10n, $gLogger, $gCurrentUser, $gCurrentUserId, $gCurrentOrganization, $gCurrentOrgId;
+        global $gProfileFields, $gSettingsManager;
+
+        self::validateConfiguration($config);
+
+        /*
+         * db.sql and the table constants are built from TABLE_PREFIX, which Admidio derives from the
+         * configuration file while it is bootstrapping. The installation can therefore only create
+         * the tables of the prefix that the process was started with.
+         */
+        if ($config->tablePrefix !== TABLE_PREFIX) {
+            throw new Exception('INS_DATA_DO_NOT_MATCH', array('config.php'));
+        }
+
+        // the entities of the installation are created with the database of the new installation
+        $gDb = $db;
+
+        /*
+         * The installation is not a change of an existing installation, so it doesn't belong into the
+         * changelog. Beside that the tables of the changelog don't exist before db.sql was executed.
+         */
+        Entity::setLoggingEnabled(false);
+
+        $gL10n->setLanguage($config->language);
+
+        // set execution time to 5 minutes because we have a lot to do
+        PhpIniUtils::startNewExecutionTimeLimit(300);
+
+        // read data from sql script db.sql and execute all statements to the current database
+        self::querySqlFile($db, 'db.sql');
+
+        // create default data
+        self::installComponents($db);
+        $gCurrentUserId = self::createSystemUser($db);
+        self::createDefaultProfileFields($db, $gCurrentUserId);
+        self::createRolesRights($db);
+        self::createUserRelationTypes($db, $gCurrentUserId);
+
+        // create new organization with its administrator
+        $gCurrentOrganization = self::createOrganization($db, $config);
+        $gCurrentOrgId = (int) $gCurrentOrganization->getValue('org_id');
+        $gProfileFields = new ProfileFields($db, $gCurrentOrgId);
+        $administratorId = self::createAdministrator($db, $config, $gCurrentUserId);
+
+        /*
+         * No reference assignment: within a function that would only rebind the local alias of the
+         * global variable, so $gSettingsManager would stay empty for everything that reads it while
+         * the installation is running.
+         */
+        $gSettingsManager = $gCurrentOrganization->getSettingsManager();
+        $gSettingsManager->setMulti(self::defaultOrganizationPreferences($config), false);
+        self::disableSoundexSearchIfPgSql($db);
+        $gCurrentOrganization->createBasicData($administratorId);
+
+        self::createDefaultRoom($db, $gCurrentUserId);
+        self::completeUserData($db, $config, $administratorId, $gCurrentUserId);
+        self::createDefaultMenu($db);
+        self::installPlugins();
+
+        $gLogger->info('INSTALLATION: Installation successfully complete');
+
+        return array(
+            'organizationId' => $gCurrentOrgId,
+            'administratorId' => $administratorId
+        );
+    }
+
+    /**
+     * Add the system component and all module components to the database.
+     * @param Database $db Connection to the database of the new installation.
+     * @return void
+     * @throws Exception
+     */
+    private static function installComponents(Database $db): void
+    {
+        // add system component to database
+        $component = new ComponentUpdate($db);
+        $component->setValue('com_type', 'SYSTEM');
+        $component->setValue('com_name', 'Admidio Core');
+        $component->setValue('com_name_intern', 'CORE');
+        $component->setValue('com_version', ADMIDIO_VERSION);
+        $component->setValue('com_beta', ADMIDIO_VERSION_BETA);
+        $component->setValue('com_update_step', $component->getMaxUpdateStep());
+        $component->save();
+
+        // create all modules components
+        $sql = 'INSERT INTO ' . TBL_COMPONENTS . '
+                       (com_type, com_name, com_name_intern, com_version, com_beta)
+                VALUES (\'MODULE\', \'SYS_ANNOUNCEMENTS\',   \'ANNOUNCEMENTS\',  \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_CATEGORIES\',      \'CATEGORIES\',     \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_CATEGORY_REPORT\', \'CATEGORY-REPORT\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_CHANGE_HISTORY\',  \'CHANGELOG\',      \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_EVENTS\',          \'EVENTS\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_DOCUMENTS_FILES\', \'DOCUMENTS-FILES\',\''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_INVENTORY\',        \'INVENTORY\',     \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_FORUM\',           \'FORUM\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_WEBLINKS\',        \'LINKS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_GROUPS_ROLES\',    \'GROUPS-ROLES\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_CONTACTS\',        \'CONTACTS\',       \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_MESSAGES\',        \'MESSAGES\',       \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_MENU\',            \'MENU\',           \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_ORGANIZATION\',    \'ORGANIZATIONS\',  \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_PHOTOS\',          \'PHOTOS\',         \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_SETTINGS\',        \'PREFERENCES\',    \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_PROFILE\',         \'PROFILE\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_REGISTRATION\',    \'REGISTRATION\',   \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_ROOM_MANAGEMENT\', \'ROOMS\',          \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')
+                     , (\'MODULE\', \'SYS_PLUGIN_MANAGER\',  \'PLUGINS\',        \''.ADMIDIO_VERSION.'\', '.ADMIDIO_VERSION_BETA.')';
+        $db->query($sql); // TODO add more params
+    }
+
+    /**
+     * Create a hidden system user for internal use. All records that are created by the installation
+     * get this user as their creating user.
+     * @param Database $db Connection to the database of the new installation.
+     * @return int Returns the id of the system user.
+     * @throws Exception
+     */
+    private static function createSystemUser(Database $db): int
+    {
+        global $gL10n, $gCurrentUser;
+
+        $gCurrentUser = new Entity($db, TBL_USERS, 'usr');
+        $gCurrentUser->setValue('usr_login_name', $gL10n->get('SYS_SYSTEM'));
+        $gCurrentUser->setValue('usr_valid', '0');
+        $gCurrentUser->setValue('usr_timestamp_create', DATETIME_NOW);
+        $gCurrentUser->save(false); // no registered user -> UserIdCreate couldn't be filled
+
+        return (int) $gCurrentUser->getValue('usr_id');
+    }
+
+    /**
+     * Create the categories and profile fields that every Admidio installation has.
+     * @param Database $db Connection to the database of the new installation.
+     * @param int $systemUserId Id of the system user that creates the records.
+     * @return void
+     * @throws Exception
+     */
+    private static function createDefaultProfileFields(Database $db, int $systemUserId): void
+    {
+        global $gL10n;
+
+        // create organization independent categories
+        $sql = 'INSERT INTO ' . TBL_CATEGORIES . '
+                       (cat_org_id, cat_uuid, cat_type, cat_name_intern, cat_name, cat_default, cat_system, cat_sequence, cat_usr_id_create, cat_timestamp_create)
+                VALUES (NULL, \'' . Uuid::uuid4() . '\', \'USF\', \'BASIC_DATA\', \'SYS_BASIC_DATA\', false, true, 1, ?, ?) -- $systemUserId, DATETIME_NOW';
+        $db->queryPrepared($sql, array($systemUserId, DATETIME_NOW));
+        $categoryIdMasterData = $db->lastInsertId();
+
+        $sql = 'INSERT INTO ' . TBL_CATEGORIES . '
+                       (cat_org_id, cat_uuid, cat_type, cat_name_intern, cat_name, cat_default, cat_system, cat_sequence, cat_usr_id_create, cat_timestamp_create)
+                VALUES (NULL, \'' . Uuid::uuid4() . '\', \'USF\', \'SOCIAL_NETWORKS\', \'SYS_SOCIAL_NETWORKS\', false, false, 2, ?, ?) -- $systemUserId, DATETIME_NOW';
+        $db->queryPrepared($sql, array($systemUserId, DATETIME_NOW));
+        $categoryIdSocialNetworks = $db->lastInsertId();
+
+        $sql = 'INSERT INTO ' . TBL_CATEGORIES . '
+                       (cat_org_id, cat_uuid, cat_type, cat_name_intern, cat_name, cat_default, cat_system, cat_sequence, cat_usr_id_create, cat_timestamp_create)
+                VALUES (NULL, \'' . Uuid::uuid4() . '\', \'USF\', \'ADDIDIONAL_DATA\', \'INS_ADDIDIONAL_DATA\', false, false, 3, ?, ?) -- $systemUserId, DATETIME_NOW';
+        $db->queryPrepared($sql, array($systemUserId, DATETIME_NOW));
+        $categoryIdAddidionalData = $db->lastInsertId();
+
+        // create profile fields of category basic data
+        $sql = 'INSERT INTO ' . TBL_USER_FIELDS . '
+                       (usf_cat_id, usf_uuid, usf_type, usf_name_intern, usf_name, usf_description, usf_system, usf_disabled, usf_required_input, usf_registration, usf_sequence, usf_usr_id_create, usf_timestamp_create)
+                VALUES (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'LAST_NAME\',  \'SYS_LASTNAME\',  NULL, true, true, 1, true, 1,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'FIRST_NAME\', \'SYS_FIRSTNAME\', NULL, true, true, 1, true, 2,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'STREET\',     \'SYS_STREET\',    NULL, false, false, 0, false, 3,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'POSTCODE\',   \'SYS_POSTCODE\',  NULL, false, false, 0, false, 4,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'CITY\',       \'SYS_CITY\',      NULL, false, false, 0, false, 5,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'TEXT\',         \'COUNTRY\',    \'SYS_COUNTRY\',   NULL, false, false, 0, false, 6,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'PHONE\',        \'PHONE\',      \'SYS_PHONE\',     NULL, false, false, 0, false, 7,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'PHONE\',        \'MOBILE\',     \'SYS_MOBILE\',    NULL, false, false, 0, false, 8,  ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'DATE\',         \'BIRTHDAY\',   \'SYS_BIRTHDAY\',  NULL, false, false, 0, false, 10, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'RADIO_BUTTON\', \'GENDER\',     \'SYS_GENDER\',    NULL, false, false, 0, false, 11, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'EMAIL\',        \'EMAIL\',      \'SYS_EMAIL\',     NULL, true, false, 2, true, 12, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdMasterData . ', \'' . Uuid::uuid4() . '\', \'URL\',          \'WEBSITE\',    \'SYS_WEBSITE\',   NULL, false, false, 0, false, 13, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdAddidionalData . ', \'' . Uuid::uuid4() . '\', \'CHECKBOX\', \'DATA_PROTECTION_PERMISSION\', \'SYS_DATA_PROTECTION_PERMISSION\', \'' . $gL10n->get('SYS_DATA_PROTECTION_PERMISSION_DESC') . '\', false, false, 2, false, 14, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')';
+        $db->query($sql); // TODO add more params
+
+        // add gender options to database
+        $sql = 'INSERT INTO ' . TBL_USER_FIELD_OPTIONS . '
+                       (ufo_usf_id, ufo_value, ufo_sequence)
+                VALUES ((SELECT usf_id FROM ' . TBL_USER_FIELDS . ' WHERE usf_cat_id = ' . $categoryIdMasterData . ' AND usf_name_intern = \'GENDER\'), \'gender-male|SYS_MALE\', 1)
+                     , ((SELECT usf_id FROM ' . TBL_USER_FIELDS . ' WHERE usf_cat_id = ' . $categoryIdMasterData . ' AND usf_name_intern = \'GENDER\'), \'gender-female|SYS_FEMALE\', 2)
+                     , ((SELECT usf_id FROM ' . TBL_USER_FIELDS . ' WHERE usf_cat_id = ' . $categoryIdMasterData . ' AND usf_name_intern = \'GENDER\'), \'gender-trans|SYS_DIVERSE\', 3)';
+        $db->query($sql);
+
+        // create profile fields of category social networks
+        $sql = 'INSERT INTO ' . TBL_USER_FIELDS . '
+                       (usf_cat_id, usf_uuid, usf_type, usf_name_intern, usf_name, usf_description, usf_icon, usf_url, usf_system, usf_sequence, usf_usr_id_create, usf_timestamp_create)
+                VALUES (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'BLUESKY\',   \'SYS_BLUESKY\',   \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'bluesky\',   \'https://bsky.app/profile/#user_content#\',     false, 1, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'FACEBOOK\',  \'SYS_FACEBOOK\',  \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'facebook\',  \'https://www.facebook.com/#user_content#\',     false, 2, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'INSTAGRAM\', \'SYS_INSTAGRAM\', \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'instagram\', \'https://www.instagram.com/#user_content#\',    false, 3, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'LINKEDIN\',  \'SYS_LINKEDIN\',  \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'linkedin\',  \'https://www.linkedin.com/in/#user_content#\',  false, 4, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'MASTODON\',  \'SYS_MASTODON\',  \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', \'mastodon\',  \'https://mastodon.social/#user_content#\',      false, 5, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (' . $categoryIdSocialNetworks . ', \'' . Uuid::uuid4() . '\', \'TEXT\', \'XING\',      \'SYS_XING\',      \'' . $gL10n->get('SYS_SOCIAL_NETWORK_FIELD_URL_DESC') . '\', null,          \'https://www.xing.com/profile/#user_content#\', false, 6, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')';
+        $db->query($sql); // TODO add more params
+    }
+
+    /**
+     * Create the roles rights that Admidio assigns to roles.
+     * @param Database $db Connection to the database of the new installation.
+     * @return void
+     * @throws Exception
+     */
+    private static function createRolesRights(Database $db): void
+    {
+        $sql = 'INSERT INTO ' . TBL_ROLES_RIGHTS . '
+                       (ror_name_intern, ror_table)
+                VALUES (\'folder_view\',   \'' . TBL_FOLDERS . '\')
+                     , (\'folder_upload\', \'' . TBL_FOLDERS . '\')
+                     , (\'category_view\', \'' . TBL_CATEGORIES . '\')
+                     , (\'event_participation\', \'' . TBL_CATEGORIES . '\')
+                     , (\'menu_view\',     \'' . TBL_MENU . '\')
+                     , (\'sso_saml_access\', \'' . TBL_SAML_CLIENTS . '\')
+                     , (\'sso_oidc_access\', \'' . TBL_OIDC_CLIENTS . '\')
+                     ';
+        $db->queryPrepared($sql);
+
+        // add edit categories right with reference to parent right
+        $sql = 'INSERT INTO ' . TBL_ROLES_RIGHTS . '
+                       (ror_name_intern, ror_table, ror_ror_id_parent)
+                VALUES (\'category_edit\', \'' . TBL_CATEGORIES . '\', (SELECT rr.ror_id FROM ' . TBL_ROLES_RIGHTS . ' rr WHERE rr.ror_name_intern = \'category_view\'))';
+        $db->queryPrepared($sql);
+    }
+
+    /**
+     * Create the user relation types that Admidio delivers.
+     * @param Database $db Connection to the database of the new installation.
+     * @param int $systemUserId Id of the system user that creates the records.
+     * @return void
+     * @throws Exception
+     */
+    private static function createUserRelationTypes(Database $db, int $systemUserId): void
+    {
+        $sql = 'INSERT INTO ' . TBL_USER_RELATION_TYPES . '
+                       (urt_id, urt_uuid, urt_name, urt_name_male, urt_name_female, urt_id_inverse, urt_usr_id_create, urt_timestamp_create)
+                VALUES (1, \'' . Uuid::uuid4() . '\', \'SYS_PARENT\',      \'SYS_FATHER\',           \'SYS_MOTHER\',          null, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (2, \'' . Uuid::uuid4() . '\', \'SYS_CHILD\',       \'SYS_SON\',              \'SYS_DAUGHTER\',           1, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (3, \'' . Uuid::uuid4() . '\', \'SYS_SIBLING\',     \'SYS_BROTHER\',          \'SYS_SISTER\',             3, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (4, \'' . Uuid::uuid4() . '\', \'SYS_SPOUSE\',      \'SYS_HUSBAND\',          \'SYS_WIFE\',               4, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (5, \'' . Uuid::uuid4() . '\', \'SYS_COHABITANT\',  \'SYS_COHABITANT_MALE\',  \'SYS_COHABITANT_FEMALE\',  5, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (6, \'' . Uuid::uuid4() . '\', \'SYS_COMPANION\',   \'SYS_BOYFRIEND\',        \'SYS_GIRLFRIEND\',         6, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (7, \'' . Uuid::uuid4() . '\', \'SYS_SUPERIOR\',    \'SYS_SUPERIOR_MALE\',    \'SYS_SUPERIOR_FEMALE\', null, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')
+                     , (8, \'' . Uuid::uuid4() . '\', \'SYS_SUBORDINATE\', \'SYS_SUBORDINATE_MALE\', \'SYS_SUBORDINATE_FEMALE\', 7, ' . $systemUserId . ', \'' . DATETIME_NOW . '\')';
+        $db->query($sql); // TODO add more params
+
+        $sql = 'UPDATE ' . TBL_USER_RELATION_TYPES . '
+                   SET urt_id_inverse = 2
+                 WHERE urt_id = 1';
+        $db->queryPrepared($sql);
+
+        $sql = 'UPDATE ' . TBL_USER_RELATION_TYPES . '
+                   SET urt_id_inverse = 8
+                 WHERE urt_id = 7';
+        $db->queryPrepared($sql);
+    }
+
+    /**
+     * Create the first organization of the installation.
+     * @param Database $db Connection to the database of the new installation.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @return Organization Returns the created organization.
+     * @throws Exception
+     */
+    private static function createOrganization(Database $db, InstallationConfig $config): Organization
+    {
+        $organization = new Organization($db, $config->organizationShortName);
+        $organization->setValue('org_longname', $config->organizationName);
+        $organization->setValue('org_shortname', $config->organizationShortName);
+        $organization->setValue('org_homepage', $config->rootUrl);
+        $organization->setValue('org_email_administrator', $config->organizationEmail);
+        $organization->save();
+
+        return $organization;
+    }
+
+    /**
+     * Create the administrator of the new organization. Only the login data is set here, the profile
+     * fields of the user are filled after the basic data of the organization was created.
+     * @param Database $db Connection to the database of the new installation.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @param int $systemUserId Id of the system user that creates the records.
+     * @return int Returns the id of the administrator.
+     * @throws Exception
+     */
+    private static function createAdministrator(Database $db, InstallationConfig $config, int $systemUserId): int
+    {
+        global $gProfileFields;
+
+        $administrator = new User($db, $gProfileFields);
+        $administrator->setValue('usr_login_name', $config->adminLogin);
+        $administrator->setPassword($config->adminPassword);
+        $administrator->setValue('usr_usr_id_create', $systemUserId);
+        $administrator->setValue('usr_timestamp_create', DATETIME_NOW);
+        $administrator->save(false); // no registered user -> UserIdCreate couldn't be filled
+
+        return (int) $administrator->getValue('usr_id');
+    }
+
+    /**
+     * Read the default preferences of an organization and set the values that come from the input of
+     * the installation.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @return array<string,mixed> Returns the preferences of the new organization.
+     * @throws Exception
+     */
+    private static function defaultOrganizationPreferences(InstallationConfig $config): array
+    {
+        global $gPasswordHashAlgorithm;
+
+        // read all preferences from preferences.php
+        require(ADMIDIO_PATH . FOLDER_INSTALLATION . '/db_scripts/preferences.php');
+
+        // set some specific preferences whose values came from the input of the installation
+        $defaultOrgPreferences['system_language'] = $config->language;
+
+        // calculate the best cost value for your server performance
+        $benchmarkResults = PasswordUtils::costBenchmark($gPasswordHashAlgorithm);
+        if (is_int($benchmarkResults['options']['cost'])) {
+            $defaultOrgPreferences['system_hashing_cost'] = $benchmarkResults['options']['cost'];
+        }
+
+        return $defaultOrgPreferences;
+    }
+
+    /**
+     * Create the default room of the room module.
+     * @param Database $db Connection to the database of the new installation.
+     * @param int $systemUserId Id of the system user that creates the records.
+     * @return void
+     * @throws Exception
+     */
+    private static function createDefaultRoom(Database $db, int $systemUserId): void
+    {
+        global $gL10n;
+
+        $sql = 'INSERT INTO ' . TBL_ROOMS . '
+                       (room_uuid, room_name, room_description, room_capacity, room_usr_id_create, room_timestamp_create)
+                VALUES (\'' . Uuid::uuid4() . '\', ?, ?, 15, ?, ?) -- $gL10n->get(\'INS_CONFERENCE_ROOM\'), $gL10n->get(\'INS_DESCRIPTION_CONFERENCE_ROOM\'), $systemUserId, DATETIME_NOW';
+        $params = array(
+            $gL10n->get('INS_CONFERENCE_ROOM'),
+            $gL10n->get('INS_DESCRIPTION_CONFERENCE_ROOM'),
+            $systemUserId,
+            DATETIME_NOW
+        );
+        $db->queryPrepared($sql, $params);
+    }
+
+    /**
+     * Fill the profile fields of the administrator and of the system user. This is only possible
+     * after the basic data of the organization exists, because the profile fields are checked
+     * against the rights of the current user.
+     * @param Database $db Connection to the database of the new installation.
+     * @param InstallationConfig $config Input values of the new installation.
+     * @param int $administratorId Id of the administrator of the new organization.
+     * @param int $systemUserId Id of the system user that creates the records.
+     * @return void
+     * @throws Exception
+     */
+    private static function completeUserData(Database $db, InstallationConfig $config, int $administratorId, int $systemUserId): void
+    {
+        global $gL10n, $gProfileFields, $gCurrentUser;
+
+        // first create a user object "current user" with administrator rights
+        // because administrator is allowed to edit firstname and lastname
+        $gCurrentUser = new User($db, $gProfileFields, $administratorId);
+        $gCurrentUser->saveChangesWithoutRights();
+        $gCurrentUser->setValue('LAST_NAME', $config->adminLastName);
+        $gCurrentUser->setValue('FIRST_NAME', $config->adminFirstName);
+        $gCurrentUser->setValue('EMAIL', $config->adminEmail);
+        $gCurrentUser->save(false);
+
+        // now create a full user object for system user
+        $systemUser = new User($db, $gProfileFields, $systemUserId);
+        $systemUser->saveChangesWithoutRights();
+        $systemUser->setValue('LAST_NAME', $gL10n->get('SYS_SYSTEM'));
+        $systemUser->save(false); // no registered user -> UserIdCreate couldn't be filled
+
+        // now set current user to system user
+        $gCurrentUser->readDataById($systemUserId);
+    }
+
+    /**
+     * Create the menu entries of a standard installation.
+     * @param Database $db Connection to the database of the new installation.
+     * @return void
+     * @throws Exception
+     */
+    private static function createDefaultMenu(Database $db): void
+    {
+        $sql = 'INSERT INTO ' . TBL_MENU . '
+                       (men_com_id, men_men_id_parent, men_uuid, men_node, men_order, men_standard, men_name_intern, men_url, men_icon, men_name, men_description)
+                VALUES (NULL, NULL, \'' . Uuid::uuid4() . '\', true, 1, true, \'modules\', NULL, \'\', \'SYS_MODULES\', \'\')
+                     , (NULL, NULL, \'' . Uuid::uuid4() . '\', true, 2, true, \'administration\', NULL, \'\', \'SYS_ADMINISTRATION\', \'\')
+                     , (NULL, NULL, \'' . Uuid::uuid4() . '\', true, 3, true, \'extensions\', NULL, \'\', \'SYS_EXTENSIONS\', \'\')
+                     , (NULL, 1, \'' . Uuid::uuid4() . '\', false, 1, true, \'overview\', \''.FOLDER_MODULES.'/overview.php\', \'bi-house-door-fill\', \'SYS_OVERVIEW\', \'\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'ANNOUNCEMENTS\'), 1, \'' . Uuid::uuid4() . '\', false, 2, true, \'announcements\', \''.FOLDER_MODULES.'/announcements.php\', \'newspaper\', \'SYS_ANNOUNCEMENTS\', \'SYS_ANNOUNCEMENTS_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'EVENTS\'), 1, \'' . Uuid::uuid4() . '\', false, 3, true, \'events\', \''.FOLDER_MODULES.'/events/events.php\', \'calendar-week-fill\', \'SYS_EVENTS\', \'SYS_EVENTS_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MESSAGES\'), 1, \'' . Uuid::uuid4() . '\', false, 4, true, \'messages\', \''.FOLDER_MODULES.'/messages/messages.php\', \'envelope-fill\', \'SYS_MESSAGES\', \'SYS_MESSAGES_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'GROUPS-ROLES\'), 1, \'' . Uuid::uuid4() . '\', false, 5, true, \'groups-roles\', \''.FOLDER_MODULES.'/groups-roles/groups_roles.php\', \'people-fill\', \'SYS_GROUPS_ROLES\', \'SYS_GROUPS_ROLES_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'CONTACTS\'), 1, \'' . Uuid::uuid4() . '\', false, 6, true, \'contacts\', \''.FOLDER_MODULES.'/contacts/contacts.php\', \'person-vcard-fill\', \'SYS_CONTACTS\', \'SYS_CONTACTS_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'DOCUMENTS-FILES\'), 1, \'' . Uuid::uuid4() . '\', false, 7, true, \'documents-files\', \''.FOLDER_MODULES.'/documents-files.php\', \'file-earmark-arrow-down-fill\', \'SYS_DOCUMENTS_FILES\', \'SYS_DOCUMENTS_FILES_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'INVENTORY\'), 1, \'' . Uuid::uuid4() . '\', false, 8, true, \'inventory\', \''.FOLDER_MODULES.'/inventory.php\', \'box-seam-fill\', \'SYS_INVENTORY\', \'SYS_INVENTORY_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PHOTOS\'), 1, \'' . Uuid::uuid4() . '\', false, 9, true, \'photo\', \''.FOLDER_MODULES.'/photos/photos.php\', \'image-fill\', \'SYS_PHOTOS\', \'SYS_PHOTOS_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'CATEGORY-REPORT\'), 1, \'' . Uuid::uuid4() . '\', false, 10, true, \'category-report\', \''.FOLDER_MODULES.'/category-report/category_report.php\', \'list-stars\', \'SYS_CATEGORY_REPORT\', \'SYS_CATEGORY_REPORT_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'LINKS\'), 1, \'' . Uuid::uuid4() . '\', false, 11, true, \'weblinks\', \''.FOLDER_MODULES.'/links/links.php\', \'link-45deg\', \'SYS_WEBLINKS\', \'SYS_WEBLINKS_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'FORUM\'), 1, \'' . Uuid::uuid4() . '\', false, 12, true, \'forum\', \''.FOLDER_MODULES.'/forum.php\', \'chat-dots-fill\', \'SYS_FORUM\', \'SYS_FORUM_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PREFERENCES\'), 2, \'' . Uuid::uuid4() . '\', false, 1, true, \'orgprop\', \''.FOLDER_MODULES.'/preferences.php\', \'gear-fill\', \'SYS_SETTINGS\', \'ORG_ORGANIZATION_PROPERTIES_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'REGISTRATION\'), 2, \'' . Uuid::uuid4() . '\', false, 2, true, \'registration\', \''.FOLDER_MODULES.'/registration.php\', \'card-checklist\', \'SYS_REGISTRATIONS\', \'SYS_MANAGE_NEW_REGISTRATIONS_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'MENU\'), 2, \'' . Uuid::uuid4() . '\', false, 3, true, \'menu\', \''.FOLDER_MODULES.'/menu.php\', \'menu-button-wide-fill\', \'SYS_MENU\', \'SYS_MENU_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'ORGANIZATIONS\'), 2, \'' . Uuid::uuid4() . '\', false, 4, true, \'organization\', \''.FOLDER_MODULES.'/organizations.php\', \'diagram-3-fill\', \'SYS_ORGANIZATION\', \'SYS_ORGANIZATION_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'PLUGINS\'), 2, \'' . Uuid::uuid4() . '\', false, 5, true, \'plugins\', \''.FOLDER_MODULES.'/plugins.php\', \'puzzle\', \'SYS_PLUGIN_MANAGER\', \'SYS_PLUGIN_MANAGER_DESC\')
+                     , ((SELECT com_id FROM '.TBL_COMPONENTS.' WHERE com_name_intern = \'CHANGELOG\'), 2, \'' . Uuid::uuid4() . '\', false, 6, true, \'changelog\', \''.FOLDER_MODULES.'/changelog/changelog.php\', \'clock-history\', \'SYS_CHANGE_HISTORY\', \'SYS_CHANGE_HISTORY_DESC\')
+                     ';
+        $db->query($sql);
+    }
+
+    /**
+     * Install all overview plugins that are delivered with Admidio.
+     * @return void
+     * @throws Exception
+     */
+    private static function installPlugins(): void
+    {
+        $pluginManager = new PluginManager();
+        $plugins = $pluginManager->getAvailablePlugins();
+
+        foreach ($plugins as $plugin) {
+            // check, if the plugin has an interface, if not, scip it
+            if (!isset($plugin['interface']) || $plugin['interface'] == null) {
+                continue;
+            }
+            // check if the plugin is an overview plugin, if so, install it
+            $instance = $plugin['interface']::getInstance();
+            if ($instance->isAdmidioPlugin()) {
+                // Install the overview plugin
+                $instance->doInstall();
+            }
         }
     }
 }

--- a/src/InstallationUpdate/ValueObject/InstallationConfig.php
+++ b/src/InstallationUpdate/ValueObject/InstallationConfig.php
@@ -1,0 +1,149 @@
+<?php
+namespace Admidio\InstallationUpdate\ValueObject;
+
+use Admidio\Infrastructure\Exception;
+
+/**
+ * @brief All input values that are needed to install a new Admidio database.
+ *
+ * The object holds what an installation needs and nothing about the way it was collected. The web
+ * wizard fills it from the session of its steps, the command line from its options. Therefore the
+ * installation itself does not depend on FormPresenter, $_POST or $_SESSION and can also be
+ * executed headless.
+ *
+ * The values are not checked here. Admidio\InstallationUpdate\Service\Installation validates them,
+ * either as a whole through validateConfiguration() or per wizard step through
+ * validateDatabaseInput(), validateOrganizationInput() and validateAdministratorInput().
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ */
+class InstallationConfig
+{
+    /**
+     * @param string $dbType Database system, one of the Database::DB_TYPE_* values.
+     * @param string $dbHost Host name or IP address of the database server.
+     * @param int|null $dbPort Port of the database server or **null** for the default port.
+     * @param string $dbName Name of the database.
+     * @param string $dbUsername User of the database.
+     * @param string $dbPassword Password of the database user.
+     * @param string $tablePrefix Prefix of all Admidio tables, e.g. **adm**.
+     * @param string $rootUrl URL of this Admidio installation, e.g. **https://www.example.org/admidio**.
+     * @param string $language ISO code of the language of the new organization, e.g. **de**.
+     * @param string $timezone PHP time zone of the new organization, e.g. **Europe/Berlin**.
+     * @param string $organizationShortName Short name of the first organization.
+     * @param string $organizationName Long name of the first organization.
+     * @param string $organizationEmail Email address of the organization administrator.
+     * @param string $adminLogin Login name of the administrator that will be created.
+     * @param string $adminFirstName First name of the administrator.
+     * @param string $adminLastName Last name of the administrator.
+     * @param string $adminEmail Email address of the administrator.
+     * @param string $adminPassword Password of the administrator.
+     */
+    public function __construct(
+        public readonly string $dbType,
+        public readonly string $dbHost,
+        public readonly ?int $dbPort,
+        public readonly string $dbName,
+        public readonly string $dbUsername,
+        public readonly string $dbPassword,
+        public readonly string $tablePrefix,
+        public readonly string $rootUrl,
+        public readonly string $language,
+        public readonly string $timezone,
+        public readonly string $organizationShortName,
+        public readonly string $organizationName,
+        public readonly string $organizationEmail,
+        public readonly string $adminLogin,
+        public readonly string $adminFirstName,
+        public readonly string $adminLastName,
+        public readonly string $adminEmail,
+        public readonly string $adminPassword
+    ) {
+    }
+
+    /**
+     * Create the object from an array with the property names as keys. Missing values are empty,
+     * only the table prefix falls back to the Admidio default **adm**.
+     * @param array<string,mixed> $values
+     * @return self
+     * @throws Exception
+     */
+    public static function fromArray(array $values): self
+    {
+        return new self(
+            (string) ($values['dbType'] ?? ''),
+            (string) ($values['dbHost'] ?? ''),
+            self::normalizePort($values['dbPort'] ?? null),
+            (string) ($values['dbName'] ?? ''),
+            (string) ($values['dbUsername'] ?? ''),
+            (string) ($values['dbPassword'] ?? ''),
+            (string) ($values['tablePrefix'] ?? 'adm'),
+            rtrim((string) ($values['rootUrl'] ?? ''), '/'),
+            (string) ($values['language'] ?? ''),
+            (string) ($values['timezone'] ?? ''),
+            (string) ($values['organizationShortName'] ?? ''),
+            (string) ($values['organizationName'] ?? ''),
+            (string) ($values['organizationEmail'] ?? ''),
+            (string) ($values['adminLogin'] ?? ''),
+            (string) ($values['adminFirstName'] ?? ''),
+            (string) ($values['adminLastName'] ?? ''),
+            (string) ($values['adminEmail'] ?? ''),
+            (string) ($values['adminPassword'] ?? '')
+        );
+    }
+
+    /**
+     * Create the object from the session of the web installation wizard. Every wizard step stores
+     * its values under its own session keys, this method maps them to the installation input.
+     * @param array<string,mixed> $session Normally $_SESSION of the installation wizard.
+     * @param string $rootUrl URL of this Admidio installation.
+     * @return self
+     * @throws Exception
+     */
+    public static function fromInstallerSession(array $session, string $rootUrl): self
+    {
+        return self::fromArray(array(
+            'dbType' => $session['db_type'] ?? '',
+            'dbHost' => $session['db_host'] ?? '',
+            'dbPort' => $session['db_port'] ?? null,
+            'dbName' => $session['db_name'] ?? '',
+            'dbUsername' => $session['db_username'] ?? '',
+            'dbPassword' => $session['db_password'] ?? '',
+            'tablePrefix' => $session['table_prefix'] ?? 'adm',
+            'rootUrl' => $rootUrl,
+            'language' => $session['language'] ?? '',
+            'timezone' => $session['orga_timezone'] ?? '',
+            'organizationShortName' => $session['orga_shortname'] ?? '',
+            'organizationName' => $session['orga_longname'] ?? '',
+            'organizationEmail' => $session['orga_email'] ?? '',
+            'adminLogin' => $session['user_login'] ?? '',
+            'adminFirstName' => $session['user_first_name'] ?? '',
+            'adminLastName' => $session['user_last_name'] ?? '',
+            'adminEmail' => $session['user_email'] ?? '',
+            'adminPassword' => $session['user_password'] ?? ''
+        ));
+    }
+
+    /**
+     * An empty port means the default port of the database system. Every other value must be a
+     * number, so that a typo cannot end up in config.php as the port of the database server.
+     * @param mixed $port
+     * @return int|null Returns the port as a number or **null** for the default port.
+     * @throws Exception
+     */
+    public static function normalizePort(mixed $port): ?int
+    {
+        if ($port === null || $port === '') {
+            return null;
+        }
+
+        if (!is_numeric($port)) {
+            throw new Exception('INS_DATABASE_PORT_INVALID');
+        }
+
+        // A configured port 0 is the notation of some config.php files for "use the default port".
+        return (int) $port === 0 ? null : (int) $port;
+    }
+}

--- a/system/bootstrap/cli-installation.php
+++ b/system/bootstrap/cli-installation.php
@@ -1,0 +1,83 @@
+<?php
+
+use Admidio\Infrastructure\Entity\Entity;
+use Admidio\Infrastructure\Language;
+
+/**
+ ***********************************************************************************************
+ * Bootstrap for the Admidio command-line commands that install a new Admidio database.
+ *
+ * install:check and install:run run before there is an installation: normally there is no
+ * adm_my_files/config.php, and there is never a database schema, an organization, a settings
+ * manager or an acting user. This bootstrap therefore only initializes the constants, the
+ * autoloader, the logging and the language, and it never connects to a database.
+ *
+ * Admidio derives the table names, the time zone and its URL from the configuration file while it
+ * is bootstrapping, long before a command is dispatched. If no configuration file exists, those
+ * values are taken from the command line instead, and the install commands verify that what they
+ * received matches what was bootstrapped here.
+ *
+ * The following variables are read if the calling script has set them: $cliHost, $cliRootUrl,
+ * $cliLanguage, $cliTablePrefix, $cliDbType and $cliTimezone.
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ ***********************************************************************************************
+ */
+
+if (PHP_SAPI !== 'cli') {
+    exit('This script may only be called from the command line!');
+}
+
+$rootPath = dirname(__DIR__, 2);
+$configFile = $rootPath . '/adm_my_files/config.php';
+
+require_once $rootPath . '/system/bootstrap/cli-request.php';
+
+admCliRequestVariables($rootPath, admCliRequestHost(isset($cliHost) ? $cliHost : ''));
+
+if (is_file($configFile)) {
+    // an existing configuration file wins, the new installation has to use the database it defines
+    require_once $configFile;
+} else {
+    if (isset($cliTablePrefix) && $cliTablePrefix !== '') {
+        $g_tbl_praefix = $cliTablePrefix;
+    }
+    if (isset($cliDbType) && $cliDbType !== '') {
+        $gDbType = $cliDbType;
+    }
+    if (isset($cliTimezone) && $cliTimezone !== '') {
+        $gTimezone = $cliTimezone;
+    }
+    if (isset($cliRootUrl) && $cliRootUrl !== '') {
+        $g_root_path = rtrim($cliRootUrl, '/');
+    }
+}
+
+if (!isset($g_root_path) || $g_root_path === '') {
+    $g_root_path = 'http://localhost';
+}
+
+// An HTTP redirect has no meaning in a CLI process.
+$gForceHTTPS = false;
+
+/*
+ * ADMIDIO_URL and the other URL constants have to describe the installation that is created, not
+ * the machine that the command runs on.
+ */
+admCliRequestVariablesFromUrl($rootPath, $g_root_path);
+
+require_once $rootPath . '/system/bootstrap/bootstrap.php';
+
+$gL10n = new Language(isset($cliLanguage) && $cliLanguage !== '' ? $cliLanguage : Language::REFERENCE_LANGUAGE);
+
+/*
+ * Everything that the installation creates belongs to the new installation and not into its
+ * changelog. Beside that the tables of the changelog only exist after the schema was created.
+ */
+Entity::setLoggingEnabled(false);
+
+$gValidLogin = false;
+$gCurrentUserId = 0;
+$gCurrentUserUUID = '';

--- a/system/bootstrap/cli-request.php
+++ b/system/bootstrap/cli-request.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ ***********************************************************************************************
+ * Request environment of Admidio command-line scripts.
+ *
+ * Admidio derives its URL constants from $_SERVER, and a config.php may select its database
+ * settings by the host of the request. A CLI process has neither, so the bootstrap of the command
+ * line fills both with deterministic values through the functions of this file.
+ *
+ * @copyright The Admidio Team
+ * @see https://www.admidio.org/
+ * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License v2.0 only
+ ***********************************************************************************************
+ */
+
+if (PHP_SAPI !== 'cli') {
+    exit('This script may only be called from the command line!');
+}
+
+/**
+ * Determine the host that config.php is read with.
+ *
+ * The value ends up in HTTP_HOST, SERVER_NAME and REQUEST_URI and is therefore read by config.php
+ * and by the URL constants derived in constants.php. Accept only a host name with an optional port
+ * so a caller cannot smuggle a path, a scheme or a header break into those values.
+ *
+ * @param string $cliHost Host of the --host option, empty if the option was not used.
+ * @return string Returns the host name with an optional port.
+ * @throws RuntimeException Throws if the given host is not a host name.
+ */
+function admCliRequestHost(string $cliHost = ''): string
+{
+    $host = $cliHost;
+
+    if ($host === '') {
+        $host = (string)getenv('ADMIDIO_HOST');
+    }
+    if ($host === '') {
+        return 'localhost';
+    }
+
+    if (!preg_match('/^(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*(?::\d{1,5})?$/', $host)
+        && !preg_match('/^\[[0-9A-Fa-f:.]+](?::\d{1,5})?$/', $host)) {
+        throw new RuntimeException(
+            'The host "' . $host . '" is not a valid host name. --host and ADMIDIO_HOST expect '
+            . 'a host name with an optional port, for example "example.org" or "example.org:8080".'
+        );
+    }
+
+    return $host;
+}
+
+/**
+ * Fill the request variables that Admidio reads while it is bootstrapping.
+ *
+ * @param string $rootPath Path of the Admidio installation.
+ * @param string $host Host of the Admidio installation.
+ * @param int $port Port of the Admidio installation.
+ * @param string $urlPath Path of the Admidio installation within the URL, e.g. **subfolder**.
+ * @return void
+ */
+function admCliRequestVariables(string $rootPath, string $host, int $port = 80, string $urlPath = ''): void
+{
+    $_SERVER['HTTP_HOST'] = $host;
+    $_SERVER['SERVER_NAME'] = $host;
+    $_SERVER['SERVER_PORT'] = $port;
+    $_SERVER['DOCUMENT_ROOT'] = $rootPath;
+    $_SERVER['SCRIPT_FILENAME'] = $rootPath . '/admidio';
+    $_SERVER['SCRIPT_NAME'] = $urlPath . '/admidio';
+    $_SERVER['REQUEST_URI'] = $urlPath . '/admidio';
+}
+
+/**
+ * Fill the request variables out of the URL of this Admidio installation, which is normally
+ * defined as $g_root_path in config.php.
+ *
+ * @param string $rootPath Path of the Admidio installation.
+ * @param string $rootUrl URL of the Admidio installation.
+ * @return void
+ */
+function admCliRequestVariablesFromUrl(string $rootPath, string $rootUrl): void
+{
+    $url = parse_url($rootUrl);
+    $scheme = is_array($url) && isset($url['scheme']) ? $url['scheme'] : 'http';
+    $host = is_array($url) && isset($url['host']) ? $url['host'] : 'localhost';
+    $port = is_array($url) && isset($url['port'])
+        ? (int)$url['port']
+        : ($scheme === 'https' ? 443 : 80);
+    $urlPath = is_array($url) && isset($url['path']) ? rtrim($url['path'], '/') : '';
+
+    admCliRequestVariables($rootPath, $host, $port, $urlPath);
+}

--- a/system/bootstrap/cli.php
+++ b/system/bootstrap/cli.php
@@ -33,35 +33,13 @@ if (!is_file($configFile)) {
     throw new RuntimeException('Admidio configuration file adm_my_files/config.php was not found.');
 }
 
+require_once $rootPath . '/system/bootstrap/cli-request.php';
+
 /*
  * Some Admidio config.php files select environment-specific database settings through HTTP_HOST.
  * A CLI process has no request host, so provide a deterministic value before loading config.php.
  */
-$configHost = isset($cliHost) && $cliHost !== '' ? $cliHost : getenv('ADMIDIO_HOST');
-if ($configHost === false || $configHost === '') {
-    $configHost = 'localhost';
-}
-
-/*
- * The value ends up in HTTP_HOST, SERVER_NAME and REQUEST_URI and is therefore read by config.php
- * and by the URL constants derived in constants.php. Accept only a host name with an optional port
- * so a caller cannot smuggle a path, a scheme or a header break into those values.
- */
-if (!preg_match('/^(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*(?::\d{1,5})?$/', $configHost)
-    && !preg_match('/^\[[0-9A-Fa-f:.]+](?::\d{1,5})?$/', $configHost)) {
-    throw new RuntimeException(
-        'The host "' . $configHost . '" is not a valid host name. --host and ADMIDIO_HOST expect '
-        . 'a host name with an optional port, for example "example.org" or "example.org:8080".'
-    );
-}
-
-$_SERVER['HTTP_HOST'] = $configHost;
-$_SERVER['SERVER_NAME'] = $configHost;
-$_SERVER['SERVER_PORT'] = 80;
-$_SERVER['DOCUMENT_ROOT'] = $rootPath;
-$_SERVER['SCRIPT_FILENAME'] = $rootPath . '/admidio';
-$_SERVER['SCRIPT_NAME'] = '/admidio';
-$_SERVER['REQUEST_URI'] = '/admidio';
+admCliRequestVariables($rootPath, admCliRequestHost(isset($cliHost) ? $cliHost : ''));
 
 require_once $configFile;
 
@@ -77,21 +55,7 @@ $gForceHTTPS = false;
  * only used so the existing non-database bootstrap can run in CLI mode; no HTTP request/session
  * is created.
  */
-$rootUrl = parse_url($g_root_path);
-$scheme = is_array($rootUrl) && isset($rootUrl['scheme']) ? $rootUrl['scheme'] : 'http';
-$host = is_array($rootUrl) && isset($rootUrl['host']) ? $rootUrl['host'] : 'localhost';
-$port = is_array($rootUrl) && isset($rootUrl['port'])
-    ? (int)$rootUrl['port']
-    : ($scheme === 'https' ? 443 : 80);
-$urlPath = is_array($rootUrl) && isset($rootUrl['path']) ? rtrim($rootUrl['path'], '/') : '';
-
-$_SERVER['SERVER_PORT'] = $port;
-$_SERVER['HTTP_HOST'] = $host;
-$_SERVER['SERVER_NAME'] = $host;
-$_SERVER['DOCUMENT_ROOT'] = $rootPath;
-$_SERVER['SCRIPT_FILENAME'] = $rootPath . '/admidio';
-$_SERVER['SCRIPT_NAME'] = $urlPath . '/admidio';
-$_SERVER['REQUEST_URI'] = $urlPath . '/admidio';
+admCliRequestVariablesFromUrl($rootPath, $g_root_path);
 
 /*
  * Maintenance mode must be manageable even if the database is unavailable and while the regular


### PR DESCRIPTION
The installation was procedural code inside the web wizard that read its values out of $_SESSION. Most of that code moves unchanged into Installation::install(), which creates the schema, the default data, the organization and its administrator from an InstallationConfig; validating the input and writing config.php become methods of the same service. The wizard steps keep their forms and call the service, so the installation is independent of session and request and can also run headless.

To be used in the cli(#2105) and a regression test suite (#13)

Fixes #2110