### PR TITLE
Installation: Create the forum tables on MySQL and MariaDB

### DIFF
--- a/install/db_scripts/db.sql
+++ b/install/db_scripts/db.sql
@@ -263,10 +263,10 @@ CREATE TABLE %PREFIX%_forum_topics
     fot_usr_id_create           integer unsigned,
     fot_timestamp_create        timestamp           NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (fot_id)
-    )
-    ENGINE = InnoDB
-    DEFAULT CHARSET = utf8mb4
-    ENCODING 'UTF8';
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;
 
 CREATE UNIQUE INDEX %PREFIX%_idx_fot_uuid ON %PREFIX%_forum_topics (fot_uuid);
 
@@ -284,10 +284,10 @@ CREATE TABLE %PREFIX%_forum_posts
     fop_usr_id_change           integer unsigned,
     fop_timestamp_change        timestamp           NULL        DEFAULT NULL,
     PRIMARY KEY (fop_id)
-    )
-    ENGINE = InnoDB
-    DEFAULT CHARSET = utf8mb4
-    ENCODING 'UTF8';
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;
 
 CREATE UNIQUE INDEX %PREFIX%_idx_fop_uuid ON %PREFIX%_forum_posts (fop_uuid);
 


### PR DESCRIPTION
Both definitions ended with the PostgreSQL clause ENCODING 'UTF8', which MySQL and MariaDB reject, so a fresh installation was missing adm_forum_topics and adm_forum_posts and the forum module could not be opened. PostgreSQL never showed it because the query conversion cuts the table options.

**Open question:** @Fasse whether an update step is needed for 5.x installations that were installed fresh with
the broken file and are therefore missing the two tables. install/db_scripts/update_5_0.xml
steps 620 and 640 only run for installations that come from 4.x.

Fixes #2120