### PR TITLE
update.txt: Fix parser to read whole lines and split at =

### DIFF
--- a/src/Infrastructure/Cli/CoreTasks.php
+++ b/src/Infrastructure/Cli/CoreTasks.php
@@ -2592,10 +2592,12 @@ final class CoreTasks
 
         $format = CliApplication::optionString($options, 'format', 'text');
         if ($format === 'text') {
+            // a version that the update server doesn't provide is displayed as "n/a"
             CliApplication::writeOutput(
-                'Stable version: ' . $data['stableVersion'] . PHP_EOL
-                . 'Beta version:   ' . $data['betaVersion']
-                . ($data['betaRelease'] !== '' ? '-Beta.' . $data['betaRelease'] : '') . PHP_EOL
+                'Stable version: ' . ($data['stableVersion'] !== '' ? $data['stableVersion'] : 'n/a') . PHP_EOL
+                . 'Beta version:   ' . ($data['betaVersion'] !== ''
+                    ? $data['betaVersion'] . ($data['betaRelease'] !== '' ? '-Beta.' . $data['betaRelease'] : '')
+                    : 'n/a') . PHP_EOL
                 . 'Update state:   ' . $data['versionUpdate'] . PHP_EOL,
                 $options
             );

--- a/src/Infrastructure/Cli/CoreTasks.php
+++ b/src/Infrastructure/Cli/CoreTasks.php
@@ -2589,6 +2589,17 @@ final class CoreTasks
 
         /** @var array<string,mixed> $data */
         $data = $service->getUpdateInformation();
+        $versionUpdate = (int) $data['versionUpdate'];
+
+        /*
+         * 99 does not describe a version but a failed request. The command could not determine
+         * anything, so it must not report a result.
+         */
+        if ($versionUpdate === 99) {
+            throw new RuntimeException(
+                'The Admidio update information could not be read from ' . ADMIDIO_HOMEPAGE . 'update.txt.'
+            );
+        }
 
         $format = CliApplication::optionString($options, 'format', 'text');
         if ($format === 'text') {
@@ -2605,9 +2616,10 @@ final class CoreTasks
             CliApplication::writeValue($data, $options, $format);
         }
 
-        return (int)$data['versionUpdate'] === 99
-            ? CliApplication::EXIT_UPDATE_AVAILABLE
-            : CliApplication::EXIT_SUCCESS;
+        // 0 = up to date, 1 = new stable version, 2 = new beta version, 3 = both
+        return $versionUpdate === 0
+            ? CliApplication::EXIT_SUCCESS
+            : CliApplication::EXIT_UPDATE_AVAILABLE;
     }
 
     public static function systemInfo(array $arguments, array $options): int

--- a/src/Preferences/Service/PreferencesService.php
+++ b/src/Preferences/Service/PreferencesService.php
@@ -6,6 +6,7 @@ use Admidio\Changelog\Service\ChangelogService;
 use Admidio\Infrastructure\Exception;
 use Admidio\Infrastructure\Htaccess;
 use Admidio\Infrastructure\Utils\FileSystemUtils;
+use Admidio\Infrastructure\Utils\SecurityUtils;
 use Admidio\Infrastructure\Utils\StringUtils;
 use Admidio\Infrastructure\Entity\Text;
 use Admidio\Infrastructure\Email;
@@ -294,9 +295,14 @@ class PreferencesService
         $betaRelease = $updateInformation['betaRelease'];
         $versionUpdate = $updateInformation['versionUpdate'];
 
-        // a version that the update server doesn't provide is displayed as "n/a"
-        $stableVersionText = ($stableVersion === '') ? 'n/a' : $stableVersion;
-        $betaVersionText = ($betaVersion === '') ? 'n/a' : $betaVersion;
+        /*
+         * A version that the update server doesn't provide is displayed as "n/a". The values are
+         * read from a file on the Admidio server and are encoded here, so that the HTML below
+         * cannot be manipulated through that file.
+         */
+        $stableVersionText = SecurityUtils::encodeHTML(($stableVersion === '') ? 'n/a' : $stableVersion);
+        $betaVersionText = SecurityUtils::encodeHTML(($betaVersion === '') ? 'n/a' : $betaVersion);
+        $betaReleaseText = SecurityUtils::encodeHTML($betaRelease);
 
         // $versionUpdate (0 = No update, 1 = New stable version, 2 = New beta version, 3 = New stable + beta version, 99 = No connection)
         if ($versionUpdate === 1) {
@@ -329,7 +335,7 @@ class PreferencesService
         if ($versionUpdate !== 99 && $betaVersion !== '') {
             $html .= '
                 <a class="icon-link" href="' . ADMIDIO_HOMEPAGE . 'intern/adm_program/modules/announcements/announcements.php?cat_uuid=e2be424d-dd72-4c01-99ad-f8f91ec8830f" title="' . $gL10n->get('SYS_ADMIDIO_DOWNLOAD_PAGE') . '" target="_blank">' .
-                '<i class="bi bi-link"></i>' . $betaVersionText . ' Beta ' . $betaRelease . '
+                '<i class="bi bi-link"></i>' . $betaVersionText . ' Beta ' . $betaReleaseText . '
                 </a>';
         } else {
             $html .= $betaVersionText;

--- a/src/Preferences/Service/PreferencesService.php
+++ b/src/Preferences/Service/PreferencesService.php
@@ -203,32 +203,45 @@ class PreferencesService
     }
 
     /**
-     * Function to determine the update version
-     * @param string $updateInfo
-     * @param string $search
-     * @return string
+     * Parse the update information of the Admidio server into its key/value pairs.
+     *
+     * The file holds one "name=value" pair per line. Keys are compared exactly, so a new key can
+     * be added to the file without colliding with the name of an existing one.
+     *
+     * @param string $updateInfo Content of the update information file.
+     * @return array<string,string> Named array with the value of every key of the file.
      */
-    function getUpdateVersion(string $updateInfo, string $search): string
+    private function parseUpdateInformation(string $updateInfo): array
     {
-        // Variablen festlegen
-        $i = 0;
-        $pointer = '';
-        $updateVersion = '';
-        $currentVersionStart = strpos($updateInfo, $search);
-        $adding = strlen($search) - 1;
-
-        // Version auslesen
-        while ($pointer !== "\n") {
-            ++$i;
-            $updateVersion .= $pointer;
-            $pointer = $updateInfo[$currentVersionStart + $adding + $i];
+        // a UTF-8 BOM would otherwise become part of the first key
+        if (str_starts_with($updateInfo, "\xEF\xBB\xBF")) {
+            $updateInfo = substr($updateInfo, 3);
         }
 
-        return trim($updateVersion, "\n\r");
+        $information = array();
+
+        foreach (preg_split('/\R/', $updateInfo) as $line) {
+            if (!str_contains($line, '=')) {
+                continue;
+            }
+
+            list($name, $value) = explode('=', $line, 2);
+            $name = trim($name);
+
+            // the first occurrence wins, so a duplicate line cannot override the published value
+            if ($name !== '' && !array_key_exists($name, $information)) {
+                $information[$name] = trim($value);
+            }
+        }
+
+        return $information;
     }
 
     /**
      * Read the available Admidio versions and determine the update state.
+     *
+     * A version that the update server does not provide is returned as an empty string. How an
+     * unknown version should be presented is up to the caller.
      *
      * @return array{stableVersion:string,betaVersion:string,betaRelease:string,versionUpdate:int}
      */
@@ -239,25 +252,17 @@ class PreferencesService
 
         if ($updateInfo === false) {
             return array(
-                'stableVersion' => 'n/a',
-                'betaVersion' => 'n/a',
+                'stableVersion' => '',
+                'betaVersion' => '',
                 'betaRelease' => '',
                 'versionUpdate' => 99
             );
         }
 
-        $stableVersion = $this->getUpdateVersion($updateInfo, 'Version=');
-        $betaVersion = $this->getUpdateVersion($updateInfo, 'Beta-Version=');
-        $betaRelease = $this->getUpdateVersion($updateInfo, 'Beta-Release=');
-
-        if ($stableVersion === '') {
-            $stableVersion = 'n/a';
-        }
-
-        if ($betaVersion === '') {
-            $betaVersion = 'n/a';
-            $betaRelease = '';
-        }
+        $information = $this->parseUpdateInformation($updateInfo);
+        $stableVersion = $information['Version'] ?? '';
+        $betaVersion = $information['Beta-Version'] ?? '';
+        $betaRelease = $information['Beta-Release'] ?? '';
 
         return array(
             'stableVersion' => $stableVersion,
@@ -289,6 +294,10 @@ class PreferencesService
         $betaRelease = $updateInformation['betaRelease'];
         $versionUpdate = $updateInformation['versionUpdate'];
 
+        // a version that the update server doesn't provide is displayed as "n/a"
+        $stableVersionText = ($stableVersion === '') ? 'n/a' : $stableVersion;
+        $betaVersionText = ($betaVersion === '') ? 'n/a' : $betaVersion;
+
         // $versionUpdate (0 = No update, 1 = New stable version, 2 = New beta version, 3 = New stable + beta version, 99 = No connection)
         if ($versionUpdate === 1) {
             $versionsText = $gL10n->get('SYS_NEW_VERSION_AVAILABLE');
@@ -312,18 +321,18 @@ class PreferencesService
         <p>' . $gL10n->get('SYS_INSTALLED') . ':&nbsp;' . ADMIDIO_VERSION_TEXT . '</p>
         <p>' . $gL10n->get('SYS_AVAILABLE') . ':&nbsp;
             <a class="icon-link" href="' . ADMIDIO_HOMEPAGE . 'download.php" title="' . $gL10n->get('SYS_ADMIDIO_DOWNLOAD_PAGE') . '" target="_blank">' .
-            '<i class="bi bi-link"></i>' . $stableVersion . '
+            '<i class="bi bi-link"></i>' . $stableVersionText . '
             </a>
             <br />
             ' . $gL10n->get('SYS_AVAILABLE_BETA') . ': &nbsp;';
 
-        if ($versionUpdate !== 99 && $betaVersion !== 'n/a') {
+        if ($versionUpdate !== 99 && $betaVersion !== '') {
             $html .= '
                 <a class="icon-link" href="' . ADMIDIO_HOMEPAGE . 'intern/adm_program/modules/announcements/announcements.php?cat_uuid=e2be424d-dd72-4c01-99ad-f8f91ec8830f" title="' . $gL10n->get('SYS_ADMIDIO_DOWNLOAD_PAGE') . '" target="_blank">' .
-                '<i class="bi bi-link"></i>' . $betaVersion . ' Beta ' . $betaRelease . '
+                '<i class="bi bi-link"></i>' . $betaVersionText . ' Beta ' . $betaRelease . '
                 </a>';
         } else {
-            $html .= $betaVersion;
+            $html .= $betaVersionText;
         }
         $html .= '
         </p>


### PR DESCRIPTION
* getUpdateVersion() located a key with strpos() and then read the string
one character at a time. It returned the wrong value for a key whose name
contained another key's name, looped until max_execution_time when the key
sat on a final line without a trailing newline, and returned a digit from
the middle of the previous line when a key was absent altogether.

* Versions the server does not publish are now empty strings; showing them
as "n/a" is left to the preferences page and the CLI output.

* Also html-encode the version before inserting it into the page